### PR TITLE
[feat] 개발용 FastAPI Launcher 및 로컬 앱 실행 경로 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ PowerShell에서 GPU 환경을 활성화합니다.
 
 Colab 실험 환경은 `config/requirements-colab.txt`를 기준으로 합니다.
 
+## 개발용 Local Service 실행
+
+Terminal 1에서 FastAPI Local Service를 loopback으로 실행합니다.
+
+```powershell
+.\.venv-gpu\Scripts\python.exe -m google_work_agent.launcher.dev --host 127.0.0.1 --port 8000
+```
+
+실행 직후 출력되는 one-time bootstrap URL을 복사합니다. Terminal 2에서 Vite를 실행한 뒤,
+출력된 fragment를 붙인 `http://127.0.0.1:5173/` URL을 브라우저로 엽니다.
+
+```powershell
+Set-Location frontend
+npm run dev
+```
+
+Vite는 `/api`와 `/health`를 기본 `http://127.0.0.1:8000`으로 proxy합니다. Service port를
+변경했다면 Terminal 2에서 `VITE_API_PROXY_TARGET`에 같은 loopback 주소를 설정합니다.
+
 ## 검증 명령
 
 ```powershell

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,24 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const apiTarget = process.env.VITE_API_PROXY_TARGET ?? "http://127.0.0.1:8000";
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: apiTarget,
+        changeOrigin: true,
+        headers: { origin: apiTarget }
+      },
+      "/health": {
+        target: apiTarget,
+        changeOrigin: true,
+        headers: { origin: apiTarget }
+      }
+    }
+  },
   test: {
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",

--- a/src/google_work_agent/adapters/llm/status.py
+++ b/src/google_work_agent/adapters/llm/status.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from google_work_agent.adapters.llm.api_provider import APIProviderConnectionService
 from google_work_agent.adapters.llm.credentials import LLMCredentialService
-from google_work_agent.adapters.runtime import AppSettings
+from google_work_agent.adapters.runtime.settings import AppSettings
 from google_work_agent.ports import (
     ApprovedModelInfo,
     AvailabilityState,

--- a/src/google_work_agent/api/app.py
+++ b/src/google_work_agent/api/app.py
@@ -96,6 +96,7 @@ class ApiContainer:
     delete_llm_api_key_service: Any | None = None
     test_llm_connection_service: Any | None = None
     resolve_recovery_service: Any | None = None
+    shutdown_callbacks: tuple[Callable[[], None], ...] = ()
 
 
 def create_app(container: ApiContainer) -> FastAPI:
@@ -110,7 +111,10 @@ def create_app(container: ApiContainer) -> FastAPI:
         try:
             yield
         finally:
-            container.local_run_coordinator.stop()
+            try:
+                container.local_run_coordinator.stop()
+            finally:
+                _run_shutdown_callbacks(container.shutdown_callbacks)
 
     docs_url = "/docs" if container.api_docs_enabled else None
     openapi_url = "/openapi.json" if container.api_docs_enabled else None
@@ -254,3 +258,15 @@ def create_app(container: ApiContainer) -> FastAPI:
             return JSONResponse(status_code=404, content={"detail": "not found"})
 
     return app
+
+
+def _run_shutdown_callbacks(callbacks: tuple[Callable[[], None], ...]) -> None:
+    first_error: Exception | None = None
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception as error:
+            if first_error is None:
+                first_error = error
+    if first_error is not None:
+        raise first_error

--- a/src/google_work_agent/application/llm.py
+++ b/src/google_work_agent/application/llm.py
@@ -16,7 +16,7 @@ from google_work_agent.adapters.llm import (
     LLMRuntimeStatusService,
     validate_output_schema,
 )
-from google_work_agent.adapters.runtime import AppSettings
+from google_work_agent.adapters.runtime.settings import AppSettings
 from google_work_agent.application.observability import (
     ObservabilityContext,
     Severity,

--- a/src/google_work_agent/launcher/__init__.py
+++ b/src/google_work_agent/launcher/__init__.py
@@ -1,0 +1,1 @@
+"""Development and packaged-service launch entrypoints."""

--- a/src/google_work_agent/launcher/dev.py
+++ b/src/google_work_agent/launcher/dev.py
@@ -1,0 +1,496 @@
+"""Loopback-only development bootstrap for the local FastAPI service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sqlite3
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from fastapi import FastAPI
+
+from google_work_agent.adapters.events.in_memory import InMemoryRunEventPublisher
+from google_work_agent.adapters.keyring import OSKeyringSecretStore
+from google_work_agent.adapters.langgraph import LangGraphWorkflowRuntime
+from google_work_agent.adapters.llm import (
+    APIProviderConnectionService,
+    ApiStructuredLLMProvider,
+    DefaultHardwareProbe,
+    DeterministicLLMRuntimeRouter,
+    LLMCredentialService,
+    LLMRuntimeStatusService,
+    LoopbackOllamaProbe,
+    OllamaHTTPClient,
+    OllamaStructuredLLMProvider,
+    SessionMemorySecretStore,
+)
+from google_work_agent.adapters.mcp import (
+    MCPArtifactConfig,
+    MCPGoogleOAuthCredentialProvider,
+    MCPGoogleWorkspaceGateway,
+    MCPRuntimeStatusProvider,
+    SubprocessMCPTransport,
+    build_manifest_payload,
+    calculate_file_sha256,
+)
+from google_work_agent.adapters.persistence import apply_migrations, connect_sqlite
+from google_work_agent.adapters.persistence.unit_of_work import sqlite_unit_of_work_factory
+from google_work_agent.adapters.runtime import BuildProfile, FileSettingsStore, SettingsService
+from google_work_agent.api import API_CONTRACT_VERSION, ApiContainer, create_app
+from google_work_agent.api.security import (
+    InMemoryBootstrapGrantStore,
+    InMemoryLocalSessionManager,
+    LocalApiAccessGuard,
+    LocalBindPolicy,
+)
+from google_work_agent.application import (
+    DisconnectGoogleService,
+    GetGoogleConnectionService,
+    StartGoogleOAuthService,
+)
+from google_work_agent.application.coordinator import LocalRunCoordinator
+from google_work_agent.application.llm import (
+    DeleteLLMApiKeyService,
+    GetLLMConnectionService,
+    LLMRuntimeService,
+    StoreLLMApiKeyService,
+    TestLLMConnectionService,
+)
+from google_work_agent.application.queries import QueryService
+from google_work_agent.application.start_run import (
+    CreateConversationService,
+    ModifyWriteActionService,
+    RejectWriteActionService,
+    ResumeRunService,
+    StartRunService,
+)
+from google_work_agent.application.write_actions import (
+    ApproveWriteActionService,
+    PrepareWriteRetryService,
+    RequestRunCancellationService,
+)
+from google_work_agent.ports import (
+    AvailabilityState,
+    LauncherProbeDecision,
+    ProbeResult,
+    ProviderResponsePayload,
+    ReadinessAggregator,
+    ReadinessCheckResult,
+    ReadinessReport,
+    ReadinessState,
+    RuntimePolicy,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+RELEASE_VERSION = "0.1.0-dev"
+MCP_MANIFEST_VERSION = "2026-08-07.p0"
+MCP_TOOL_REGISTRY_VERSION = "2026-08-06.p0"
+DEVELOPMENT_RUNTIME_PROMPT_IDS = frozenset(
+    {
+        "request_understanding.classify",
+        "request_understanding.clarify",
+        "acquisition.plan_sources",
+        "context.select_evidence",
+        "context.assess_sufficiency",
+        "analysis.analyze",
+        "planning.answer_only",
+        "planning.draft_plan",
+        "planning.revise_plan",
+        "review.inspect",
+        "review.recheck",
+        "profile.single.request_source.initial",
+        "profile.single.reason_plan.initial",
+        "profile.single.self_review.initial",
+        "profile.single.self_review.recheck",
+        "profile.three.stage1.initial",
+        "profile.three.stage2.initial",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SystemClock:
+    def now_ms(self) -> int:
+        return time.time_ns() // 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class UUIDIdGenerator:
+    def next_id(self) -> str:
+        return str(uuid.uuid4())
+
+
+@dataclass(frozen=True, slots=True)
+class DevelopmentLauncherProbeVerifier:
+    """Bind direct development readiness to this service instance."""
+
+    service_instance_id: str
+
+    def verify(self, *, service_instance_id: str) -> LauncherProbeDecision:
+        return LauncherProbeDecision(allowed=service_instance_id == self.service_instance_id)
+
+
+@dataclass(frozen=True, slots=True)
+class DevelopmentReadinessAggregator(ReadinessAggregator):
+    database_path: Path
+    transport: SubprocessMCPTransport
+
+    def evaluate(self) -> ReadinessReport:
+        checks = (self._sqlite_check(), self._mcp_check())
+        state = (
+            ReadinessState.READY
+            if all(check.state is ReadinessState.READY for check in checks)
+            else ReadinessState.NOT_READY
+        )
+        return ReadinessReport(state=state, checks=checks)
+
+    def _sqlite_check(self) -> ReadinessCheckResult:
+        try:
+            with connect_sqlite(self.database_path) as connection:
+                row = connection.execute("SELECT COUNT(*) FROM schema_migrations;").fetchone()
+            if row is None or int(row[0]) < 1:
+                return ReadinessCheckResult(
+                    name="sqlite_migrations",
+                    state=ReadinessState.NOT_READY,
+                    detail="migration receipts are unavailable",
+                )
+        except sqlite3.Error:
+            return ReadinessCheckResult(
+                name="sqlite_migrations",
+                state=ReadinessState.NOT_READY,
+                detail="sqlite is unavailable",
+            )
+        return ReadinessCheckResult(name="sqlite_migrations", state=ReadinessState.READY)
+
+    def _mcp_check(self) -> ReadinessCheckResult:
+        metadata = self.transport.runtime_metadata()
+        if metadata.process_status != "READY" or metadata.process_instance_id is None:
+            return ReadinessCheckResult(
+                name="mcp_handshake",
+                state=ReadinessState.NOT_READY,
+                detail=metadata.last_safe_error_code or metadata.process_status,
+            )
+        return ReadinessCheckResult(name="mcp_handshake", state=ReadinessState.READY)
+
+
+class _UnavailableApiProviderTransport:
+    """Explicit boundary until a real external API-provider adapter is configured."""
+
+    def probe(self, *, api_key: str, timeout_seconds: int) -> ProbeResult:
+        del api_key, timeout_seconds
+        return ProbeResult(
+            availability=AvailabilityState.NOT_CONFIGURED,
+            safe_error_code="API_PROVIDER_NOT_CONFIGURED",
+        )
+
+    def invoke_structured(
+        self,
+        *,
+        prompt_ref: object,
+        prompt_input: object,
+        output_schema: object,
+        timeout_seconds: int,
+        api_key: str,
+    ) -> ProviderResponsePayload:
+        del prompt_ref, prompt_input, output_schema, timeout_seconds, api_key
+        raise RuntimeError("External API-provider transport is not configured.")
+
+
+def build_container(
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    runtime_root: Path | None = None,
+    bootstrap_secret: str | None = None,
+) -> ApiContainer:
+    """Assemble the development service with real local adapters."""
+
+    LocalBindPolicy(host=host, port=port).validate()
+    root = (runtime_root or PROJECT_ROOT / "runtime" / "development").resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    database_path = root / "google-work-agent.sqlite3"
+    checkpoint_database_path = root / "langgraph-checkpoints.sqlite3"
+    mcp_manifest_path = _write_mcp_manifest(root)
+    workspace_manifest_path = _write_empty_workspace_manifest(root)
+    prompt_manifest_path = _write_development_prompt_manifest(root)
+    clock = SystemClock()
+    id_generator = UUIDIdGenerator()
+    service_instance_id = f"dev-{uuid.uuid4()}"
+
+    with connect_sqlite(database_path) as connection:
+        apply_migrations(connection, now_ms=clock.now_ms)
+
+    transport = SubprocessMCPTransport(
+        config=MCPArtifactConfig(
+            executable_path=str(Path(sys.executable).resolve()),
+            manifest_path=str(mcp_manifest_path),
+            expected_binary_sha256=calculate_file_sha256(Path(sys.executable).resolve()),
+            expected_manifest_sha256=calculate_file_sha256(mcp_manifest_path),
+            expected_manifest_version=MCP_MANIFEST_VERSION,
+            expected_protocol_version=MCP_MANIFEST_VERSION,
+            expected_tool_registry_version=MCP_TOOL_REGISTRY_VERSION,
+            startup_timeout_ms=5_000,
+            request_timeout_ms=10_000,
+            max_restart_count=1,
+            environment="DEVELOPMENT",
+            service_instance_id=service_instance_id,
+            working_directory=str(PROJECT_ROOT),
+            extra_environment={
+                "GWA_TEST_KEYRING_PATH": str((root / "mcp-keyring.json").resolve()),
+                "GWA_PRODUCT_FIXTURE_MANIFEST": str(workspace_manifest_path),
+            },
+        )
+    )
+    google_provider = MCPGoogleOAuthCredentialProvider(transport=transport)
+    runtime_status_provider = MCPRuntimeStatusProvider(
+        google_provider=google_provider,
+        transport=transport,
+        api_llm="NOT_CONFIGURED",
+        ollama="NOT_CONFIGURED",
+        deployment_profile=BuildProfile.LOCAL_CAPABLE.value,
+    )
+    unit_of_work_factory = sqlite_unit_of_work_factory(database_path)
+    query_service = QueryService(
+        database_path=database_path,
+        runtime_status_provider=runtime_status_provider,
+    )
+    llm_runtime = _build_llm_runtime(
+        settings_path=root / "settings" / "app-settings.json",
+        query_service=query_service,
+    )
+    workflow_runtime = LangGraphWorkflowRuntime(
+        unit_of_work_factory=unit_of_work_factory,
+        llm_runtime=llm_runtime,
+        gateway=MCPGoogleWorkspaceGateway(transport=transport),
+        now_ms=clock.now_ms,
+        id_factory=id_generator.next_id,
+        signing_secret=secrets.token_hex(32),
+        service_instance_id=service_instance_id,
+        checkpoint_database_path=checkpoint_database_path,
+        prompt_manifest_path=prompt_manifest_path,
+    )
+    event_publisher = InMemoryRunEventPublisher(service_instance_id=service_instance_id)
+    coordinator = LocalRunCoordinator(
+        query_service=query_service,
+        unit_of_work_factory=unit_of_work_factory,
+        workflow_runtime=workflow_runtime,
+        event_publisher=event_publisher,
+        now_ms=clock.now_ms,
+        api_contract_version=API_CONTRACT_VERSION,
+    )
+    session_manager = InMemoryLocalSessionManager()
+    grant_store = InMemoryBootstrapGrantStore()
+    secret = bootstrap_secret or secrets.token_urlsafe(32)
+    grant_store.provision(
+        secret=secret,
+        service_instance_id=service_instance_id,
+        now_ms=clock.now_ms(),
+    )
+
+    return ApiContainer(
+        unit_of_work_factory=unit_of_work_factory,
+        query_service=query_service,
+        create_conversation_service=CreateConversationService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        start_run_service=StartRunService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        approve_action_service=ApproveWriteActionService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        modify_action_service=ModifyWriteActionService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        reject_action_service=RejectWriteActionService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        prepare_retry_service=PrepareWriteRetryService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        cancel_run_service=RequestRunCancellationService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        resume_run_service=ResumeRunService(
+            unit_of_work_factory=unit_of_work_factory,
+            now_ms=clock.now_ms,
+        ),
+        local_run_coordinator=coordinator,
+        workflow_runtime=workflow_runtime,
+        event_publisher=event_publisher,
+        readiness_aggregator=DevelopmentReadinessAggregator(database_path, transport),
+        runtime_status_provider=runtime_status_provider,
+        api_access_guard=LocalApiAccessGuard(
+            expected_host=f"{host}:{port}",
+            expected_origin=f"http://{host}:{port}",
+            service_instance_id=service_instance_id,
+            session_manager=session_manager,
+            release_version=RELEASE_VERSION,
+            environment="DEVELOPMENT",
+            now_ms=clock.now_ms,
+        ),
+        clock=clock,
+        id_generator=id_generator,
+        release_version=RELEASE_VERSION,
+        environment="DEVELOPMENT",
+        service_instance_id=service_instance_id,
+        local_bind_host=host,
+        local_bind_port=port,
+        launcher_probe_verifier=DevelopmentLauncherProbeVerifier(service_instance_id),
+        bootstrap_grant_store=grant_store,
+        local_session_manager=session_manager,
+        start_google_oauth_service=StartGoogleOAuthService(provider=google_provider),
+        get_google_connection_service=GetGoogleConnectionService(provider=google_provider),
+        disconnect_google_service=DisconnectGoogleService(provider=google_provider),
+        get_llm_connection_service=GetLLMConnectionService(
+            runtime_status_service=llm_runtime.status_service,
+            settings_service=llm_runtime.settings_service,
+        ),
+        store_llm_api_key_service=StoreLLMApiKeyService(
+            credential_service=llm_runtime.credential_service,
+        ),
+        delete_llm_api_key_service=DeleteLLMApiKeyService(
+            credential_service=llm_runtime.credential_service,
+        ),
+        test_llm_connection_service=TestLLMConnectionService(runtime_service=llm_runtime),
+        shutdown_callbacks=(workflow_runtime.close, transport.close),
+    )
+
+
+def create_service_app() -> FastAPI:
+    """Return an argument-free application factory for Uvicorn."""
+
+    return create_app(build_container())
+
+
+def main() -> NoReturn:
+    """Run the development service on an explicit loopback address."""
+
+    parser = argparse.ArgumentParser(description="Run the Google Work Agent development service.")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    args = parser.parse_args()
+    LocalBindPolicy(host=args.host, port=args.port).validate()
+    bootstrap_secret = secrets.token_urlsafe(32)
+    container = build_container(
+        host=args.host,
+        port=args.port,
+        bootstrap_secret=bootstrap_secret,
+    )
+    print(
+        "Open the Vite development UI with this one-time bootstrap fragment:\n"
+        f"http://127.0.0.1:5173/#bootstrap_secret={bootstrap_secret}"
+        f"&service_instance_id={container.service_instance_id}",
+        flush=True,
+    )
+    import uvicorn
+
+    uvicorn.run(create_app(container), host=args.host, port=args.port)
+    raise SystemExit(0)
+
+
+def _build_llm_runtime(*, settings_path: Path, query_service: QueryService) -> LLMRuntimeService:
+    settings_service = SettingsService(
+        store=FileSettingsStore(settings_path),
+        deployment_profile=BuildProfile.LOCAL_CAPABLE,
+        approved_model_ids=frozenset(),
+        has_active_runs=lambda: bool(query_service.list_open_runs()),
+    )
+    credential_service = LLMCredentialService(
+        provider_name="unconfigured",
+        environment="DEVELOPMENT",
+        keyring_store=OSKeyringSecretStore(),
+        session_store=SessionMemorySecretStore(),
+    )
+    ollama_transport = OllamaHTTPClient()
+    status_service = LLMRuntimeStatusService(
+        build_profile=BuildProfile.LOCAL_CAPABLE.value,
+        credential_service=credential_service,
+        api_connection_service=APIProviderConnectionService(transport=None),
+        hardware_probe=DefaultHardwareProbe(),
+        ollama_probe=LoopbackOllamaProbe(transport=ollama_transport),
+        approved_models={},
+        runtime_policy=RuntimePolicy(),
+    )
+    return LLMRuntimeService(
+        settings_service=settings_service.get,
+        status_service=status_service,
+        credential_service=credential_service,
+        api_provider=ApiStructuredLLMProvider(
+            provider_name="unconfigured",
+            transport=_UnavailableApiProviderTransport(),
+            model="unconfigured",
+        ),
+        ollama_provider_factory=lambda model, settings: OllamaStructuredLLMProvider(
+            provider_name="ollama",
+            transport=ollama_transport,
+            endpoint=settings.ollama_endpoint or "http://127.0.0.1:11434",
+            model_id=model.model_id,
+        ),
+        router=DeterministicLLMRuntimeRouter(),
+        runtime_policy=RuntimePolicy(),
+    )
+
+
+def _write_mcp_manifest(runtime_root: Path) -> Path:
+    manifest_path = runtime_root / "mcp-manifest.json"
+    manifest_path.write_text(
+        json.dumps(build_manifest_payload(), sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path.resolve()
+
+
+def _write_empty_workspace_manifest(runtime_root: Path) -> Path:
+    manifest_path = runtime_root / "development-workspace.json"
+    manifest_path.write_text(
+        json.dumps({"snapshot_id": "development-empty", "resources": [], "faults": []}),
+        encoding="utf-8",
+    )
+    return manifest_path.resolve()
+
+
+def _write_development_prompt_manifest(runtime_root: Path) -> Path:
+    """Derive a DEV-only runtime selection without editing the source prompt pack."""
+
+    source_path = PROJECT_ROOT / "prompts" / "agent" / "prompt-manifest-v0.8.2.json"
+    manifest = json.loads(source_path.read_text(encoding="utf-8"))
+    slots = manifest.get("slots")
+    if not isinstance(slots, list):
+        raise ValueError("prompt manifest slots are unavailable")
+    activated: set[str] = set()
+    for slot in slots:
+        if not isinstance(slot, dict):
+            raise ValueError("prompt manifest slot is invalid")
+        slot_id = slot.get("slot_id")
+        if isinstance(slot_id, str) and slot_id in DEVELOPMENT_RUNTIME_PROMPT_IDS:
+            slot["activation_status"] = "RUNTIME_ACTIVE"
+            activated.add(slot_id)
+    missing = DEVELOPMENT_RUNTIME_PROMPT_IDS - activated
+    if missing:
+        raise ValueError(f"development prompt slots are missing: {sorted(missing)}")
+    manifest_path = runtime_root / "prompt-manifest-development.json"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path.resolve()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/launcher/test_dev_service.py
+++ b/tests/integration/launcher/test_dev_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from fastapi.testclient import TestClient
+from uvicorn import Config, Server
+
+from google_work_agent.api import create_app
+from google_work_agent.launcher.dev import DevelopmentReadinessAggregator, build_container
+
+
+def test_development_container_serves_health_and_closes_mcp_child(tmp_path: Path) -> None:
+    container = build_container(
+        runtime_root=tmp_path / "runtime",
+        bootstrap_secret="test-bootstrap",
+    )
+    container = replace(container, client_address_resolver=lambda _request: "127.0.0.1")
+
+    with TestClient(create_app(container), base_url="http://127.0.0.1:8000") as client:
+        live = client.get("/health/live")
+        ready = client.get("/health/ready")
+
+        assert live.status_code == 200
+        assert live.json()["status"] == "LIVE"
+        assert ready.status_code == 200
+        assert ready.json()["status"] == "READY"
+        assert container.runtime_status_provider.get_summary().mcp == "READY"
+
+    assert isinstance(container.readiness_aggregator, DevelopmentReadinessAggregator)
+    assert container.readiness_aggregator.transport.runtime_metadata().process_status == "STOPPED"
+    assert container.readiness_aggregator.evaluate().state.value == "NOT_READY"
+
+
+def test_development_service_serves_loopback_health_over_uvicorn(tmp_path: Path) -> None:
+    port = _allocate_loopback_port()
+    container = build_container(
+        port=port,
+        runtime_root=tmp_path / "runtime",
+        bootstrap_secret="test-bootstrap",
+    )
+    server = Server(Config(create_app(container), host="127.0.0.1", port=port, log_level="warning"))
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        live = _get_json(f"http://127.0.0.1:{port}/health/live")
+        ready = _get_json(f"http://127.0.0.1:{port}/health/ready")
+
+        assert live["status"] == "LIVE"
+        assert ready["status"] == "READY"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert isinstance(container.readiness_aggregator, DevelopmentReadinessAggregator)
+    assert container.readiness_aggregator.transport.runtime_metadata().process_status == "STOPPED"
+
+
+def _allocate_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        return int(server.getsockname()[1])
+
+
+def _get_json(url: str) -> dict[str, object]:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url, timeout=1) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise AssertionError("health response must be an object")
+                return cast(dict[str, object], payload)
+        except URLError:
+            time.sleep(0.05)
+    raise AssertionError(f"service did not become available: {url}")

--- a/tests/unit/api/test_app_factory.py
+++ b/tests/unit/api/test_app_factory.py
@@ -150,6 +150,24 @@ def test_app_lifespan_starts_and_stops_coordinator() -> None:
     assert coordinator.stopped == 1
 
 
+def test_app_lifespan_runs_all_resource_cleanup_callbacks() -> None:
+    container, _ = _build_container(_AllowGuard())
+    cleaned: list[str] = []
+
+    def close_first() -> None:
+        cleaned.append("first")
+
+    def close_second() -> None:
+        cleaned.append("second")
+
+    container = replace(container, shutdown_callbacks=(close_first, close_second))
+
+    with TestClient(create_app(container)):
+        pass
+
+    assert cleaned == ["first", "second"]
+
+
 def test_health_routes_and_runtime_respect_guard() -> None:
     container, _ = _build_container(_DenyGuard())
 


### PR DESCRIPTION
## 개요

Google Work Agent를 개발 환경에서 실제 실행할 수 있도록 FastAPI Service bootstrap과 개발용 Launcher를 추가했습니다.

기존에는 `create_app(container)` 형태의 FastAPI App Factory와 MCP Child entrypoint는 존재했지만, 실제 `ApiContainer` 의존성을 조립하고 Local Service를 실행하는 FastAPI 개발용 entrypoint가 없었습니다.

이번 작업에서 SQLite, MCP, LLM, LangGraph Runtime, LocalRunCoordinator를 조립하여 FastAPI와 React를 실제 개발 환경에서 실행할 수 있는 경로를 추가했습니다.

## 주요 변경 사항

### 1. 개발용 FastAPI Launcher 추가

개발용 FastAPI 실행 진입점을 추가했습니다.

실행 명령:

`python -m google_work_agent.launcher.dev --host 127.0.0.1 --port 8000`

개발 bootstrap의 Runtime 조립 순서는 다음과 같습니다.

SQLite 생성 → Migration 적용 → MCP Child 시작 및 Handshake → MCP OAuth / Workspace Provider → LLM / Ollama Adapter → LangGraph Runtime → LocalRunCoordinator → ApiContainer → FastAPI

기존 `create_app(container)` 계약은 그대로 유지합니다.

### 2. Runtime Lifecycle 연결

FastAPI lifespan과 개발 Launcher를 연결하여 다음 리소스의 Lifecycle을 관리하도록 구성했습니다.

- SQLite 및 Migration 초기화
- MCP Child startup handshake
- LangGraph Runtime 초기화
- LocalRunCoordinator 초기화
- FastAPI 종료 시 MCP Child 및 Runtime resource 정리

Uvicorn/TestClient 종료 시 MCP Child가 `STOPPED` 상태로 정상 정리되는 것을 검증했습니다.

### 3. Health Check 검증

실제 Uvicorn loopback 통합 테스트를 통해 다음 Endpoint를 검증했습니다.

- `GET /health/live` → HTTP 200 / `LIVE`
- `GET /health/ready` → HTTP 200 / `READY`

`/health/ready`는 SQLite Migration 상태와 MCP handshake 상태를 함께 확인합니다.

### 4. Frontend 개발 Proxy 연결

Vite 개발 서버에서 다음 요청을 FastAPI 개발 서버로 Proxy하도록 구성했습니다.

- `/api`
- `/health`

기본 FastAPI 주소는 `http://127.0.0.1:8000`입니다.

포트를 변경해야 하는 경우 `VITE_API_PROXY_TARGET` 환경변수를 통해 Proxy 대상을 변경할 수 있습니다.

Production의 same-origin 정적 배포 구조는 변경하지 않았습니다.

### 5. OAuth DEV 설정 계약 유지

기존 Google OAuth DEV 설정 구조를 유지합니다.

- 저장소 루트 `.env.local` 사용
- 환경변수 `GOOGLE_OAUTH_CLIENT_ID` 사용
- DEVELOPMENT 환경에서만 `.env.local` 로드
- Client Secret 신규 도입 없음
- OAuth Credential 소유권은 MCP Credential Provider에 유지
- Production에서는 `.env.local` 미사용

## 개발 실행 방법

### Terminal 1 - FastAPI

프로젝트 루트에서 다음 명령으로 실행합니다.

`.\.venv-gpu\Scripts\python.exe -m google_work_agent.launcher.dev --host 127.0.0.1 --port 8000`

실행 후 출력되는 one-time bootstrap URL/fragment를 사용합니다.

### Terminal 2 - Frontend

`frontend` 디렉터리에서 다음 명령으로 실행합니다.

`npm run dev`

Vite가 출력한 주소에 FastAPI Launcher에서 발급한 bootstrap fragment를 적용하여 접속합니다.

## 테스트 및 검증

다음 항목을 추가하거나 검증했습니다.

- 개발 Service Container 조립
- FastAPI App Factory
- 실제 Uvicorn loopback 실행
- `/health/live`
- `/health/ready`
- MCP startup / shutdown lifecycle
- DEV OAuth configuration regression
- Frontend Proxy 및 Production build

최종 검증 결과:

- Unit Test: 462 passed
- Integration Test: 129 passed
- 전체 Test: 608 passed
- `ruff check src tests scripts`: PASS
- `ruff format --check src tests scripts`: PASS
- `mypy src tests`: 0 errors
- `git diff --check`: PASS
- `npm run build`: PASS

## 보안 및 설정 확인

- 실제 Google OAuth Client ID는 저장소에 포함하지 않음
- Client Secret 추가 없음
- Access Token / Refresh Token 포함 없음
- `.env.local`은 Git ignore 상태 유지
- Production에서는 DEV `.env.local`을 사용하지 않음
- OAuth Credential 처리는 MCP Credential Provider 경계를 유지

## 후속 작업

이 PR 반영 후 로컬 `.env.local`에 개발용 Desktop OAuth Client ID를 설정하고 실제 Google OAuth E2E를 진행합니다.

다음 단계에서 검증할 항목:

- Google OAuth 로그인
- PKCE / state / loopback callback
- Test User 권한 동의
- Refresh Token 저장 및 재사용
- Gmail 실제 연동
- Google Calendar 실제 연동
- Google Tasks 실제 연동
- 앱 재시작 후 Google 연결 상태 복원