### PR TITLE
[feat] Google OAuth 자격증명 라이프사이클 및 로컬 세션 흐름 완성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Google Desktop OAuth Client ID — DEV only
 GOOGLE_OAUTH_CLIENT_ID=
+# Google Desktop OAuth protocol compatibility Client Secret — DEV only
+GOOGLE_OAUTH_CLIENT_SECRET=

--- a/docs/01-b-policy-definition-v2.6.md
+++ b/docs/01-b-policy-definition-v2.6.md
@@ -1,6 +1,6 @@
 # 01-B. Google Work Agent 정책 정의서
 
-> **상태:** Draft v2.5 · **기준일:** 2026-08-09
+> **상태:** Draft v2.6 · **기준일:** 2026-08-09
 
 ## 0. 사람이 먼저 볼 핵심 정책
 
@@ -239,6 +239,9 @@ Tentative는 경고로 처리하고, Declined 또는 Free Event는 Busy에서 �
 - `state` 검증 필수
 - OOB 수동 코드 복사 방식 금지
 - Refresh Token은 OS Keyring 저장
+- Desktop OAuth Client가 `client_secret`을 발급하고 실제 Token Endpoint가 이를 요구하는 경우, 해당 값은 Confidential Secret 또는 사용자 Credential이 아니라 **Protocol Compatibility Client Credential**로 취급한다.
+- Client Secret은 PKCE·`state`·ephemeral loopback을 대체하거나 완화하는 인증 보안 경계로 사용하지 않는다.
+- Client Secret 원문은 MCP Credential Provider 경계를 벗어나 React/Vite·FastAPI API payload·SQLite·Log·Trace·Diagnostic·OS Keyring으로 전달·저장하지 않는다.
 
 ### POL-OAUTH-004 팀 테스트
 
@@ -804,8 +807,9 @@ LOCAL_CAPABLE Release는 검증된 Ollama Version, Model ID, Model Hash와 Runti
 ### POL-OAUTH-008 Credential Provider 소유권
 
 - Google Authorization Code 교환, Refresh Token 저장·갱신·폐기는 MCP Credential Provider가 소유한다.
+- Desktop OAuth Client가 실제 Token Endpoint 호환을 위해 `client_secret`을 요구하는 경우, 해당 compatibility credential의 로드와 authorization-code/refresh-token grant 사용도 MCP Credential Provider가 소유한다.
 - FastAPI와 React에는 계정·Scope·연결 상태 Metadata만 반환한다.
-- Refresh Token 원문을 FastAPI Process Memory로 복사하는 구현은 금지한다.
+- Refresh Token 또는 Desktop OAuth Client Secret 원문을 FastAPI Process Memory나 React로 복사하는 구현은 금지한다.
 
 ## 26. Clarification·조회 범위·일정 관계 정책
 - 전체 Gmail Mailbox, 장기간 무제한 원문, 모든 Workspace Source 전체 조회 요청은 `BLOCKED`다. 자동으로 범위를 축소해 실행하지 않는다.

--- a/docs/09-security-auth-v2.4.md
+++ b/docs/09-security-auth-v2.4.md
@@ -1,6 +1,6 @@
 # 09. Google Work Agent · 보안 · Auth 설계서
 
-> **상태:** Draft v2.3 · **기준일:** 2026-08-09 · **대상:** P0 MVP
+> **상태:** Draft v2.4 · **기준일:** 2026-08-09 · **대상:** P0 MVP
 
 ## 1. 핵심 결정
 
@@ -9,7 +9,8 @@
 - Bootstrap: 256-bit, 1회, 60초, URL Fragment
 - Google Refresh Token: MCP Credential Provider가 OS Keyring에서 사용
 - LLM API Key: FastAPI LLM Adapter가 별도 Keyring Entry에서 사용
-- Secret은 SQLite·Checkpoint·Trace·Audit·환경 변수·CLI 인자에 저장하지 않음
+- 사용자 Credential·OAuth Token·LLM API Key 등 Confidential Secret은 SQLite·Checkpoint·Trace·Audit·환경 변수·CLI 인자에 저장하지 않음
+- 예외: DEV Desktop OAuth Client가 실제 Google Token Endpoint 호환을 위해 `client_secret`을 요구하는 경우, 해당 값은 사용자 Credential 또는 Confidential Security Boundary가 아닌 **Google OAuth Protocol Compatibility Client Credential**로 취급하며 repo-root `.env.local`에서 MCP Credential Provider만 읽을 수 있음
 - 외부 LLM 전송은 설정 동의와 Run별 범위 표시 필요
 - 외부 전송 동의 없으면 AUTO API Fallback 금지
 - 배포되는 외부 Test·Production Artifact는 Code Signing 필수
@@ -49,6 +50,10 @@ Google Source의 지시는 이 우선순위를 변경하지 못한다.
   - Calendar `calendar.events`, `calendar.calendarlist.readonly`, `calendar.events.freebusy`
 - 필수 Scope 하나라도 거절되면 연결 미완료, Agent Run·Google Tool 차단
 - 개발·Staging·Production Google Project·Client 분리
+- Desktop OAuth Client가 `client_secret`을 발급하고 실제 Token Endpoint가 이를 요구하는 경우, `client_secret`은 PKCE·`state`·loopback을 대체하는 보안 수단이 아니다.
+- DEV에서는 MCP Credential Provider만 `GOOGLE_OAUTH_CLIENT_SECRET`을 읽고 authorization-code grant와 refresh-token grant의 protocol compatibility field로 사용할 수 있다.
+- `client_secret`은 React/Vite, FastAPI API payload, SQLite, Log, Trace, Diagnostic, OS Keyring으로 전달·저장하지 않는다.
+- Production에서는 `.env.local`, 일반 환경 변수, CLI를 통한 provisioning을 금지하며 배포 Credential provisioning 계약을 별도로 따른다.
 
 ## 5. Credential Lifecycle
 
@@ -59,6 +64,7 @@ Google Source의 지시는 이 우선순위를 변경하지 못한다.
 - Google 연결 해제: Revoke 시도 + Google Keyring Entry 삭제
 - API Key 삭제: Provider Entry 삭제
 - Plain File Fallback 금지
+- Desktop OAuth `client_secret`은 Refresh Token·Access Token과 같은 사용자 Credential Lifecycle에 포함하지 않는다. DEV compatibility credential은 MCP 설정 경계에서만 사용한다.
 
 ## 6. 외부 LLM 개인정보
 
@@ -145,7 +151,7 @@ Artifact Signature·Manifest 100%
 
 ### OAuth 소유권
 
-Authorization Code 교환, Refresh Token 저장·갱신·폐기는 MCP Credential Provider만 수행한다. FastAPI는 연결 Metadata만 취급한다.
+Authorization Code 교환, Refresh Token 저장·갱신·폐기는 MCP Credential Provider만 수행한다. Desktop OAuth Client가 protocol compatibility를 위해 `client_secret`을 요구하는 경우 해당 값의 로드·사용도 MCP Credential Provider가 소유한다. FastAPI와 React는 연결 Metadata만 취급하며 Client Secret 원문을 전달받지 않는다.
 
 ## 15. 고영향 Write 보안
 - SEND·DELETE·Task 완료·참석자 변경은 정확한 Target/Arguments와 명시 승인 후 실행한다.

--- a/docs/10-infrastructure-environment-v2.6.md
+++ b/docs/10-infrastructure-environment-v2.6.md
@@ -1,6 +1,6 @@
 # 10. Google Work Agent · 인프라 · 환경 설정 설계서
 
-> **상태:** Draft v2.5 · **OS:** Windows 11 x64 · **Browser:** Chrome·Edge
+> **상태:** Draft v2.6 · **OS:** Windows 11 x64 · **Browser:** Chrome·Edge
 
 ## 1. 확정 결정
 
@@ -77,7 +77,7 @@ Single Instance Lock
 - `SEC-INF-017`: graceful shutdown
 - `SEC-INF-018`: crash recovery
 - `SEC-INF-019`: Ollama isolation
-- `SEC-INF-020`: production secret file/env/CLI prohibition
+- `SEC-INF-020`: production secret file/env/CLI prohibition. DEV Desktop OAuth의 protocol compatibility `client_secret`은 예외적으로 repo-root `.env.local`에서 MCP Credential Provider만 읽을 수 있으나, Production에서는 이 예외를 허용하지 않는다.
 
 ## 6. Directory
 
@@ -114,6 +114,20 @@ Launcher Runtime Argument
 ```
 
 Production Secret은 `.env`, JSON, Manifest, CLI에 넣지 않는다.
+
+DEV Google Desktop OAuth local config:
+```text
+<repo-root>/.env.local
+GOOGLE_OAUTH_CLIENT_ID=<developer-owned Desktop OAuth Client ID>
+GOOGLE_OAUTH_CLIENT_SECRET=<protocol compatibility credential, when required by provider>
+```
+
+- `.env.local`은 `GWA_MCP_ENVIRONMENT=DEVELOPMENT`에서만 읽는다.
+- `.env.example`에는 Key 이름과 빈 값만 추적하며 실제 Client Secret을 넣지 않는다.
+- `GOOGLE_OAUTH_CLIENT_SECRET`은 사용자 Credential 또는 Production Security Boundary가 아니며 Google Desktop OAuth Token Endpoint 호환을 위한 client credential이다.
+- MCP Credential Provider만 Client ID·Client Secret을 읽는다. React/Vite·FastAPI API payload·SQLite·Log·Trace·Diagnostic·OS Keyring으로 전달·저장하지 않는다.
+- Production은 `.env.local`을 읽지 않으며 `SEC-INF-020`을 유지한다. Production Client Credential provisioning은 서명된 배포 Artifact/Installer 경계의 별도 계약으로 관리한다.
+- Client Secret을 사용하더라도 PKCE S256·`state`·ephemeral loopback 요구사항은 그대로 유지한다.
 
 ## 8. Installer
 

--- a/frontend/src/api/contract.ts
+++ b/frontend/src/api/contract.ts
@@ -84,6 +84,8 @@ export type GoogleConnectionResponse = {
   reauth_required: boolean;
   oauth_environment: string;
   last_checked_at_ms: number;
+  safe_error_code?: string | null;
+  safe_error_description?: string | null;
   api_contract_version: string;
 };
 

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,4 +1,5 @@
 ﻿import { render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { App } from "./App";
@@ -95,16 +96,19 @@ afterEach(() => {
   window.history.replaceState(null, "", "/");
 });
 
-test("boots from fragment and clears the bootstrap secret", async () => {
+test("captures the bootstrap fragment before asynchronous startup checks", async () => {
   window.history.replaceState(null, "", "/#bootstrap_secret=secret-1&service_instance_id=svc-1");
+  let bootstrapRequested = false;
   installFetch((path) => {
     if (path === "/health/live") {
+      window.history.replaceState(null, "", "/");
       return jsonResponse({ status: "LIVE", service_instance_id: "svc-1", release_version: "test", api_contract_version: "1", occurred_at_ms: 1 });
     }
     if (path === "/health/ready") {
       return jsonResponse({ status: "READY", checks: [{ name: "sqlite", state: "READY" }], release_version: "test", api_contract_version: "1", occurred_at_ms: 2 });
     }
     if (path === "/api/v1/session/bootstrap") {
+      bootstrapRequested = true;
       return jsonResponse({ session_established: true, service_instance_id: "svc-1", api_contract_version: "1" });
     }
     if (path === "/api/v1/runtime") {
@@ -129,7 +133,68 @@ test("boots from fragment and clears the bootstrap secret", async () => {
 
   await screen.findByText(/Google/);
   expect(window.location.hash).toBe("");
+  expect(bootstrapRequested).toBe(true);
   expect(document.body.textContent).not.toContain("secret-1");
+});
+
+test("keeps the fragment until one StrictMode bootstrap request succeeds", async () => {
+  window.history.replaceState(null, "", "/#bootstrap_secret=secret-1&service_instance_id=svc-1");
+  const paths: string[] = [];
+  let bootstrapStarted = false;
+  let resolveBootstrap: (response: Response) => void = () => {
+    throw new Error("Bootstrap request did not start");
+  };
+  globalThis.fetch = vi.fn((input: string | URL) => {
+    const path = String(input);
+    paths.push(path);
+    if (path === "/health/live") {
+      return Promise.resolve(jsonFetchResponse(liveResponse()));
+    }
+    if (path === "/health/ready") {
+      return Promise.resolve(jsonFetchResponse(readyResponse()));
+    }
+    if (path === "/api/v1/session/bootstrap") {
+      bootstrapStarted = true;
+      return new Promise<Response>((resolve) => {
+        resolveBootstrap = resolve;
+      });
+    }
+    if (path === "/api/v1/runtime") {
+      return Promise.resolve(jsonFetchResponse({ summary: runtimeSummary([]), api_contract_version: "1" }));
+    }
+    if (path === "/api/v1/google/connection") {
+      return Promise.resolve(jsonFetchResponse(googleConnection()));
+    }
+    if (path === "/api/v1/identity/google-account") {
+      return Promise.resolve(jsonFetchResponse({ account: currentAccount(), api_contract_version: "1" }));
+    }
+    if (path.startsWith("/api/v1/conversations?")) {
+      return Promise.resolve(jsonFetchResponse({ items: [], next_cursor: null, api_contract_version: "1" }));
+    }
+    if (path.startsWith("/api/v1/resources/gmail")) {
+      return Promise.resolve(jsonFetchResponse({ source: "gmail", items: [], next_page_token: null, api_contract_version: "1" }));
+    }
+    return Promise.reject(new Error(`Unhandled path ${path}`));
+  }) as typeof fetch;
+
+  render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+
+  await waitFor(() => expect(bootstrapStarted).toBe(true));
+  expect(paths.filter((path) => path === "/api/v1/session/bootstrap")).toHaveLength(1);
+  expect(paths).not.toContain("/api/v1/runtime");
+  expect(window.location.hash).toContain("bootstrap_secret");
+
+  resolveBootstrap(jsonFetchResponse({ session_established: true, service_instance_id: "svc-1", api_contract_version: "1" }));
+
+  await screen.findByText(/Google/);
+  expect(window.location.hash).toBe("");
+  expect(paths.indexOf("/api/v1/session/bootstrap")).toBeLessThan(paths.indexOf("/api/v1/runtime"));
+  expect(paths.indexOf("/api/v1/session/bootstrap")).toBeLessThan(paths.indexOf("/api/v1/google/connection"));
+  expect(paths.indexOf("/api/v1/session/bootstrap")).toBeLessThan(paths.indexOf("/api/v1/identity/google-account"));
 });
 
 test("starts a run in RESOURCE_SELECTED mode", async () => {
@@ -509,7 +574,7 @@ test("confirms an interrupt and explicitly resolves a mismatch", async () => {
   );
 });
 
-test("starts Google OAuth from settings when disconnected", async () => {
+test("starts Google OAuth from the disconnected status action", async () => {
   installFetch((path, init) => {
     if (path === "/health/live") {
       return jsonResponse(liveResponse());
@@ -526,6 +591,8 @@ test("starts Google OAuth from settings when disconnected", async () => {
         connected: false,
         credential_state: "DISCONNECTED",
         account_email: null,
+        safe_error_code: "TOKEN_EXCHANGE_INVALID_REQUEST",
+        safe_error_description: "Google rejected a required token request field.",
       });
     }
     if (path === "/api/v1/settings") {
@@ -546,7 +613,7 @@ test("starts Google OAuth from settings when disconnected", async () => {
     if (path === "/api/v1/google/oauth/start" && init?.method === "POST") {
       return jsonResponse({
         flow_id: "flow-1",
-        authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?flow=1",
+        authorization_url: "http://127.0.0.1:43123/oauth/authorize?state=flow-1",
         callback_url: "http://localhost/callback",
         expires_at_ms: 1000,
         oauth_environment: "DEVELOPMENT",
@@ -562,14 +629,69 @@ test("starts Google OAuth from settings when disconnected", async () => {
 
   await screen.findByText(/Google/);
   await user.click(screen.getByRole("button", { name: "설정" }));
-  await user.click(screen.getByRole("button", { name: "Google 로그인" }));
+  expect(await screen.findByText("TOKEN_EXCHANGE_INVALID_REQUEST")).toBeInTheDocument();
+  expect(
+    screen.getByText("Google rejected a required token request field."),
+  ).toBeInTheDocument();
+  await user.click(screen.getByRole("button", { name: "Google 연결" }));
 
   expect(window.open).toHaveBeenCalledWith(
-    "https://accounts.google.com/o/oauth2/v2/auth?flow=1",
+    "http://127.0.0.1:43123/oauth/authorize?state=flow-1",
     "_blank",
     "noopener,noreferrer",
   );
   expect(await screen.findByText("Google 연결 완료를 기다리고 있습니다.")).toBeInTheDocument();
+});
+
+test("does not open an unexpected authorization URL returned by the API", async () => {
+  installFetch((path, init) => {
+    if (path === "/health/live") {
+      return jsonResponse(liveResponse());
+    }
+    if (path === "/health/ready") {
+      return jsonResponse(readyResponse());
+    }
+    if (path === "/api/v1/runtime") {
+      return jsonResponse({ summary: runtimeSummary([]), api_contract_version: "1" });
+    }
+    if (path === "/api/v1/google/connection") {
+      return jsonResponse({ ...googleConnection(), connected: false, credential_state: "DISCONNECTED", account_email: null });
+    }
+    if (path === "/api/v1/identity/google-account") {
+      return jsonResponse({ account: currentAccount(), api_contract_version: "1" });
+    }
+    if (path.startsWith("/api/v1/conversations?")) {
+      return jsonResponse({ items: [], next_cursor: null, api_contract_version: "1" });
+    }
+    if (path.startsWith("/api/v1/resources/gmail")) {
+      return jsonResponse({ source: "gmail", items: [], next_page_token: null, api_contract_version: "1" });
+    }
+    if (path === "/api/v1/google/oauth/start" && init?.method === "POST") {
+      return jsonResponse({
+        flow_id: "flow-1",
+        authorization_url: "https://invalid.example/authorization",
+        callback_url: "http://127.0.0.1/callback",
+        expires_at_ms: 1000,
+        oauth_environment: "DEVELOPMENT",
+        scopes: ["gmail.readonly"],
+        api_contract_version: "1",
+      });
+    }
+    throw new Error(`Unhandled path ${path}`);
+  });
+
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.click(await screen.findByRole("button", { name: "Google 연결" }));
+  await waitFor(() =>
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/v1/google/oauth/start",
+      expect.objectContaining({ method: "POST" }),
+    ),
+  );
+  expect(window.open).not.toHaveBeenCalled();
+  expect(screen.getByText("Google 연결을 시작하지 못했습니다.")).toBeInTheDocument();
 });
 
 test("disconnects Google and refreshes the runtime summary", async () => {
@@ -977,6 +1099,13 @@ function installFetch(handler: (path: string, init?: RequestInit) => MockRespons
 
 function jsonResponse(json: unknown, status = 200): MockResponse {
   return { status, json };
+}
+
+function jsonFetchResponse(json: unknown, status = 200): Response {
+  return new Response(JSON.stringify(json), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function liveResponse() {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -95,6 +95,7 @@ export function App(): JSX.Element {
   const [runContext, setRunContext] = useState<RunContext | null>(null);
   const [composerText, setComposerText] = useState("");
   const [busyCommand, setBusyCommand] = useState<string | null>(null);
+  const [googleConnectPending, setGoogleConnectPending] = useState(false);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingConfirmation | null>(null);
   const [confirmationText, setConfirmationText] = useState("");
   const [statusLine, setStatusLine] = useState("로컬 API에 연결되어 있습니다.");
@@ -110,6 +111,7 @@ export function App(): JSX.Element {
   });
   const subscriptionRef = useRef<(() => void) | null>(null);
   const subscriptionRunIdRef = useRef<string | null>(null);
+  const startupPromiseRef = useRef<Promise<void> | null>(null);
 
   const refreshConversations = useCallback(async (accountId: string): Promise<void> => {
     const response = await listConversations(accountId);
@@ -209,6 +211,8 @@ export function App(): JSX.Element {
   }, [currentAccount?.account_id, resourceState.nextPageToken, resourceState.parentId, resourceState.query]);
 
   const runStartup = useCallback(async (): Promise<void> => {
+    // Preserve the one-time fragment in invocation-local memory before awaits.
+    const bootstrapFragment = readBootstrapFragment(window.location.hash);
     resourceCache.clear();
     setStartup({
       phase: "checks",
@@ -219,15 +223,14 @@ export function App(): JSX.Element {
     try {
       await getLive();
       const ready = await getReady();
-      const fragment = readBootstrapFragment(window.location.hash);
       setStartup({
         phase: "session",
         status: "loading",
-        message: fragment ? "로컬 세션을 수립하고 있습니다." : "기존 세션을 확인하고 있습니다.",
+        message: bootstrapFragment ? "로컬 세션을 수립하고 있습니다." : "기존 세션을 확인하고 있습니다.",
         checks: ready.checks,
       });
-      if (fragment) {
-        await bootstrapSession(fragment);
+      if (bootstrapFragment) {
+        await bootstrapSession(bootstrapFragment);
         window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
       }
       setStartup((current) => ({ ...current, phase: "runtime", message: "런타임 상태를 읽고 있습니다." }));
@@ -275,7 +278,9 @@ export function App(): JSX.Element {
   }, [settingsOpen]);
 
   useEffect(() => {
-    void runStartup();
+    if (startupPromiseRef.current === null) {
+      startupPromiseRef.current = runStartup();
+    }
     return () => {
       subscriptionRef.current?.();
       subscriptionRef.current = null;
@@ -494,9 +499,19 @@ export function App(): JSX.Element {
   }
 
   async function handleGoogleConnect(): Promise<void> {
-    const response = await startGoogleOAuth();
-    window.open(response.authorization_url, "_blank", "noopener,noreferrer");
-    setStatusLine("Google 연결 완료를 기다리고 있습니다.");
+    if (google?.connected || googleConnectPending) {
+      return;
+    }
+    setGoogleConnectPending(true);
+    try {
+      const response = await startGoogleOAuth();
+      window.open(requireOAuthLaunchUrl(response.authorization_url), "_blank", "noopener,noreferrer");
+      setStatusLine("Google 연결 완료를 기다리고 있습니다.");
+    } catch (error) {
+      setStatusLine(error instanceof ApiClientError ? error.message : "Google 연결을 시작하지 못했습니다.");
+    } finally {
+      setGoogleConnectPending(false);
+    }
   }
 
   async function handleGoogleDisconnect(): Promise<void> {
@@ -556,6 +571,16 @@ export function App(): JSX.Element {
         <div className="inline-row">
           <span className="pill">{google?.connected ? "Google 연결됨" : "Google 미연결"}</span>
           <span className="pill">{runSnapshot?.actual_runtime ?? runSnapshot?.requested_mode ?? "AUTO"}</span>
+          {!google?.connected ? (
+            <button
+              className="button-primary"
+              type="button"
+              disabled={googleConnectPending}
+              onClick={() => void handleGoogleConnect()}
+            >
+              {googleConnectPending ? "Google 연결 중..." : "Google 연결"}
+            </button>
+          ) : null}
           <button className="button-secondary" type="button" onClick={() => setSettingsOpen(true)}>
             설정
           </button>
@@ -1042,6 +1067,12 @@ function SettingsDrawer(props: {
           {props.google?.missing_scopes.length ? (
             <p className="status-warn">누락 Scope: {props.google.missing_scopes.join(", ")}</p>
           ) : null}
+          {props.google?.safe_error_code ? (
+            <p className="status-warn">{props.google.safe_error_code}</p>
+          ) : null}
+          {props.google?.safe_error_description ? (
+            <p className="status-warn">{props.google.safe_error_description}</p>
+          ) : null}
         </section>
         <section className="info-card">
           <strong>Runtime</strong>
@@ -1156,6 +1187,19 @@ function SettingsDrawer(props: {
       </div>
     </aside>
   );
+}
+
+function requireOAuthLaunchUrl(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "http:" ||
+    url.hostname !== "127.0.0.1" ||
+    !url.port ||
+    url.pathname !== "/oauth/authorize"
+  ) {
+    throw new Error("Unexpected OAuth authorization URL");
+  }
+  return url.toString();
 }
 
 function readBootstrapFragment(hash: string): { bootstrap_secret: string; service_instance_id: string } | null {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ const apiTarget = process.env.VITE_API_PROXY_TARGET ?? "http://127.0.0.1:8000";
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
     proxy: {
       "/api": {
         target: apiTarget,

--- a/src/google_work_agent/adapters/mcp/oauth.py
+++ b/src/google_work_agent/adapters/mcp/oauth.py
@@ -43,6 +43,8 @@ class MCPGoogleOAuthCredentialProvider(GoogleOAuthCredentialProvider):
             reauth_required=bool(payload["reauth_required"]),
             oauth_environment=OAuthEnvironment(str(payload["oauth_environment"])),
             last_checked_at_ms=int(payload["last_checked_at_ms"]),
+            safe_error_code=_optional_string(payload.get("safe_error_code")),
+            safe_error_description=_optional_string(payload.get("safe_error_description")),
         )
 
     def disconnect(self) -> DisconnectResult:

--- a/src/google_work_agent/api/app.py
+++ b/src/google_work_agent/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -85,6 +86,7 @@ class ApiContainer:
     frontend_site: Any | None = None
     additional_readiness_checks: tuple[Callable[[], Any], ...] = ()
     safe_mode_controller: Any | None = None
+    core_initialization_in_progress: bool = False
     get_settings_service: Any | None = None
     patch_settings_service: Any | None = None
     list_backups_service: Any | None = None
@@ -96,6 +98,7 @@ class ApiContainer:
     delete_llm_api_key_service: Any | None = None
     test_llm_connection_service: Any | None = None
     resolve_recovery_service: Any | None = None
+    startup_callbacks: tuple[Callable[[], Awaitable[None]], ...] = ()
     shutdown_callbacks: tuple[Callable[[], None], ...] = ()
 
 
@@ -107,11 +110,22 @@ def create_app(container: ApiContainer) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.container = container
+        startup_tasks: list[asyncio.Future[None]] = [
+            asyncio.ensure_future(callback()) for callback in container.startup_callbacks
+        ]
         container.local_run_coordinator.start()
         try:
             yield
         finally:
             try:
+                for task in startup_tasks:
+                    if not task.done():
+                        task.cancel()
+                if startup_tasks:
+                    await asyncio.wait_for(
+                        asyncio.gather(*startup_tasks, return_exceptions=True),
+                        timeout=30,
+                    )
                 container.local_run_coordinator.stop()
             finally:
                 _run_shutdown_callbacks(container.shutdown_callbacks)

--- a/src/google_work_agent/api/dependencies.py
+++ b/src/google_work_agent/api/dependencies.py
@@ -99,6 +99,15 @@ def enforce_access(
 
 def enforce_runtime_operation(request: Request, *, operation: RuntimeOperation) -> None:
     container = get_container(request)
+    if container.core_initialization_in_progress:
+        raise ApiError(
+            error_code="SAFE_MODE",
+            user_message="Core initialization is still in progress.",
+            status_code=409,
+            request_id=get_request_id(request),
+            detail_code="SAFE_MODE_BLOCKED",
+            current_state="CORE_INITIALIZING",
+        )
     controller = container.safe_mode_controller
     if controller is None or controller.allows(operation):
         return

--- a/src/google_work_agent/api/routes/google.py
+++ b/src/google_work_agent/api/routes/google.py
@@ -45,6 +45,14 @@ def start_google_oauth(
     except MCPTransportError as error:
         if error.code is not MCPTransportErrorCode.CONFIGURATION_ERROR:
             raise
+        if str(error) == "GOOGLE_OAUTH_CLIENT_SECRET_MISSING":
+            raise ApiError(
+                error_code="CONFIGURATION_ERROR",
+                user_message="Set GOOGLE_OAUTH_CLIENT_SECRET in .env.local.",
+                status_code=503,
+                request_id=request.state.request_id,
+                detail_code="GOOGLE_OAUTH_CLIENT_SECRET_MISSING",
+            ) from error
         raise ApiError(
             error_code="CONFIGURATION_ERROR",
             user_message="Set GOOGLE_OAUTH_CLIENT_ID in .env.local.",
@@ -95,6 +103,8 @@ def get_google_connection(
         reauth_required=result.reauth_required,
         oauth_environment=result.oauth_environment.value,
         last_checked_at_ms=result.last_checked_at_ms,
+        safe_error_code=result.safe_error_code,
+        safe_error_description=result.safe_error_description,
         api_contract_version=container.api_contract_version,
     )
 

--- a/src/google_work_agent/api/schemas/google.py
+++ b/src/google_work_agent/api/schemas/google.py
@@ -23,6 +23,8 @@ class GoogleConnectionResponse(ApiModel):
     reauth_required: bool
     oauth_environment: str
     last_checked_at_ms: int
+    safe_error_code: str | None = None
+    safe_error_description: str | None = None
     api_contract_version: str
 
 

--- a/src/google_work_agent/launcher/dev.py
+++ b/src/google_work_agent/launcher/dev.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import secrets
 import sqlite3
 import sys
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn, cast
 
 from fastapi import FastAPI
 
@@ -41,7 +43,12 @@ from google_work_agent.adapters.mcp import (
 )
 from google_work_agent.adapters.persistence import apply_migrations, connect_sqlite
 from google_work_agent.adapters.persistence.unit_of_work import sqlite_unit_of_work_factory
-from google_work_agent.adapters.runtime import BuildProfile, FileSettingsStore, SettingsService
+from google_work_agent.adapters.runtime import (
+    BuildProfile,
+    FileSettingsStore,
+    SafeModeController,
+    SettingsService,
+)
 from google_work_agent.api import API_CONTRACT_VERSION, ApiContainer, create_app
 from google_work_agent.api.security import (
     InMemoryBootstrapGrantStore,
@@ -70,6 +77,7 @@ from google_work_agent.application.start_run import (
     ResumeRunService,
     StartRunService,
 )
+from google_work_agent.application.workflows.prompt_registry import InactivePromptArtifactError
 from google_work_agent.application.write_actions import (
     ApproveWriteActionService,
     PrepareWriteRetryService,
@@ -85,7 +93,16 @@ from google_work_agent.ports import (
     ReadinessReport,
     ReadinessState,
     RuntimePolicy,
+    RuntimeStatusProvider,
+    RuntimeSummary,
+    WorkflowCancelRequest,
+    WorkflowInvocationResult,
+    WorkflowOutcome,
+    WorkflowRecoveryRequest,
+    WorkflowResumeRequest,
+    WorkflowStartRequest,
 )
+from google_work_agent.ports.mcp_transport import MCPTransportError
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_HOST = "127.0.0.1"
@@ -93,27 +110,6 @@ DEFAULT_PORT = 8000
 RELEASE_VERSION = "0.1.0-dev"
 MCP_MANIFEST_VERSION = "2026-08-07.p0"
 MCP_TOOL_REGISTRY_VERSION = "2026-08-06.p0"
-DEVELOPMENT_RUNTIME_PROMPT_IDS = frozenset(
-    {
-        "request_understanding.classify",
-        "request_understanding.clarify",
-        "acquisition.plan_sources",
-        "context.select_evidence",
-        "context.assess_sufficiency",
-        "analysis.analyze",
-        "planning.answer_only",
-        "planning.draft_plan",
-        "planning.revise_plan",
-        "review.inspect",
-        "review.recheck",
-        "profile.single.request_source.initial",
-        "profile.single.reason_plan.initial",
-        "profile.single.self_review.initial",
-        "profile.single.self_review.recheck",
-        "profile.three.stage1.initial",
-        "profile.three.stage2.initial",
-    }
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -138,13 +134,223 @@ class DevelopmentLauncherProbeVerifier:
         return LauncherProbeDecision(allowed=service_instance_id == self.service_instance_id)
 
 
+class CoreInitializationError(RuntimeError):
+    """Redacted core-startup failure exposed through readiness only."""
+
+    def __init__(self, safe_code: str) -> None:
+        super().__init__(safe_code)
+        self.safe_code = safe_code
+
+
+class _DeferredCoordinator:
+    """Keeps the HTTP process live until the core coordinator is available."""
+
+    def __init__(self) -> None:
+        self._delegate: LocalRunCoordinator | None = None
+        self._started = False
+
+    def start(self) -> None:
+        self._started = True
+        if self._delegate is not None:
+            self._delegate.start()
+
+    def bind(self, delegate: LocalRunCoordinator) -> None:
+        self._delegate = delegate
+        if self._started:
+            delegate.start()
+
+    def stop(self) -> None:
+        if self._delegate is not None:
+            self._delegate.stop()
+
+
+class _BootReadinessAggregator(ReadinessAggregator):
+    """Expose initialization state without making liveness depend on core startup."""
+
+    def __init__(self, safe_mode: SafeModeController) -> None:
+        self._safe_mode = safe_mode
+        self._delegate: ReadinessAggregator | None = None
+        self._failure_code: str | None = None
+
+    def bind(self, delegate: ReadinessAggregator) -> None:
+        self._delegate = delegate
+
+    def fail(self, code: str) -> None:
+        self._failure_code = code
+
+    def evaluate(self) -> ReadinessReport:
+        if self._failure_code is not None:
+            return ReadinessReport(
+                state=ReadinessState.SAFE_MODE,
+                checks=(
+                    ReadinessCheckResult(
+                        name="core_initialization",
+                        state=ReadinessState.SAFE_MODE,
+                        detail=self._failure_code,
+                    ),
+                ),
+            )
+        if self._delegate is None:
+            return ReadinessReport(
+                state=ReadinessState.NOT_READY,
+                checks=(
+                    ReadinessCheckResult(
+                        name="core_initialization",
+                        state=ReadinessState.NOT_READY,
+                        detail="INITIALIZING",
+                    ),
+                ),
+            )
+        return self._delegate.evaluate()
+
+
+class _BootRuntimeStatusProvider:
+    def get_summary(self) -> RuntimeSummary:
+        return RuntimeSummary(
+            google="NOT_CONFIGURED",
+            mcp="INITIALIZING",
+            api_llm="NOT_CONFIGURED",
+            ollama="NOT_CONFIGURED",
+            deployment_profile=BuildProfile.LOCAL_CAPABLE.value,
+            recovery_required_run_ids=(),
+            open_run_ids=(),
+            safe_mode=True,
+            safe_mode_reason_codes=("CORE_INITIALIZING",),
+        )
+
+
+class _BootQueryService:
+    def get_runtime_summary(self) -> RuntimeSummary:
+        return _BootRuntimeStatusProvider().get_summary()
+
+
+class _DeferredApiContainer:
+    """Stable DI shell used by FastAPI while the concrete core is built."""
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        service_instance_id: str,
+        bootstrap_secret: str,
+        core_builder: Callable[..., ApiContainer] | None = None,
+    ) -> None:
+        self._core: ApiContainer | None = None
+        self._core_builder = core_builder
+        self._closed = False
+        self.local_run_coordinator = _DeferredCoordinator()
+        self.safe_mode_controller = SafeModeController()
+        self.core_initialization_in_progress = True
+        self.readiness_aggregator = _BootReadinessAggregator(self.safe_mode_controller)
+        self.runtime_status_provider: RuntimeStatusProvider = _BootRuntimeStatusProvider()
+        self.query_service: Any = _BootQueryService()
+        self.clock = SystemClock()
+        self.id_generator = UUIDIdGenerator()
+        self.release_version = RELEASE_VERSION
+        self.environment = "DEVELOPMENT"
+        self.service_instance_id = service_instance_id
+        self.api_contract_version = API_CONTRACT_VERSION
+        self.local_bind_host = host
+        self.local_bind_port = port
+        self.max_request_body_bytes = 64 * 1024
+        self.api_docs_enabled = False
+        self.frontend_site = None
+        self.additional_readiness_checks: tuple[Any, ...] = ()
+        self.shutdown_callbacks = (self.close,)
+        self.startup_callbacks = (self._initialize,)
+        self.client_address_resolver: Callable[[Any], str | None] | None = None
+        self.operational_log_sink = None
+        self.endpoint_policy_registry = None
+        self._bootstrap_secret = bootstrap_secret
+        self._bootstrap_grant_store = InMemoryBootstrapGrantStore()
+        self._session_manager = InMemoryLocalSessionManager()
+        self._bootstrap_grant_store.provision(
+            secret=bootstrap_secret,
+            service_instance_id=service_instance_id,
+            now_ms=self.clock.now_ms(),
+        )
+        self.api_access_guard = LocalApiAccessGuard(
+            expected_host=f"{host}:{port}",
+            expected_origin=f"http://{host}:{port}",
+            service_instance_id=service_instance_id,
+            session_manager=self._session_manager,
+            release_version=RELEASE_VERSION,
+            environment="DEVELOPMENT",
+            now_ms=self.clock.now_ms,
+        )
+        self.launcher_probe_verifier = DevelopmentLauncherProbeVerifier(service_instance_id)
+        self.bootstrap_grant_store = self._bootstrap_grant_store
+        self.local_session_manager = self._session_manager
+
+    async def _initialize(self) -> None:
+        worker = asyncio.create_task(
+            asyncio.to_thread(
+                self._core_builder or build_container,
+                host=self.local_bind_host,
+                port=self.local_bind_port,
+                bootstrap_secret=self._bootstrap_secret,
+                service_instance_id=self.service_instance_id,
+                safe_mode_controller=self.safe_mode_controller,
+            )
+        )
+        try:
+            core = await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            self._closed = True
+            core = await worker
+            _close_container(core)
+            raise
+        except CoreInitializationError as error:
+            self.core_initialization_in_progress = False
+            self.safe_mode_controller.enable(error.safe_code)
+            self.readiness_aggregator.fail(error.safe_code)
+            return
+        except Exception:
+            self.core_initialization_in_progress = False
+            self.safe_mode_controller.enable("CORE_INITIALIZATION_FAILED")
+            self.readiness_aggregator.fail("CORE_INITIALIZATION_FAILED")
+            return
+        if self._closed:
+            _close_container(core)
+            return
+        self._core = core
+        self.local_run_coordinator.bind(core.local_run_coordinator)
+        self.readiness_aggregator.bind(core.readiness_aggregator)
+        self.runtime_status_provider = core.runtime_status_provider
+        self.query_service = core.query_service
+        self.core_initialization_in_progress = False
+        self.safe_mode_controller.disable()
+
+    def close(self) -> None:
+        self._closed = True
+        if self._core is not None:
+            _close_container(self._core)
+
+    def __getattr__(self, name: str) -> Any:
+        if self._core is not None:
+            return getattr(self._core, name)
+        raise RuntimeError("core initialization is incomplete")
+
+
 @dataclass(frozen=True, slots=True)
 class DevelopmentReadinessAggregator(ReadinessAggregator):
     database_path: Path
     transport: SubprocessMCPTransport
+    mcp_manifest_path: Path | None = None
+    prompt_active: bool = True
 
     def evaluate(self) -> ReadinessReport:
-        checks = (self._sqlite_check(), self._mcp_check())
+        checks = (
+            self._manifest_asset_check(),
+            self._api_contract_check(),
+            self._sqlite_check(),
+            self._domain_check(),
+            self._keyring_check(),
+            self._mcp_executable_check(),
+            self._mcp_check(),
+            self._tool_schema_check(),
+        )
         state = (
             ReadinessState.READY
             if all(check.state is ReadinessState.READY for check in checks)
@@ -170,6 +376,59 @@ class DevelopmentReadinessAggregator(ReadinessAggregator):
             )
         return ReadinessCheckResult(name="sqlite_migrations", state=ReadinessState.READY)
 
+    def _manifest_asset_check(self) -> ReadinessCheckResult:
+        manifest_ok = self.mcp_manifest_path is not None and self.mcp_manifest_path.is_file()
+        asset_ok = (PROJECT_ROOT / "frontend" / "index.html").is_file()
+        if manifest_ok and asset_ok:
+            return ReadinessCheckResult(name="manifest_assets", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="manifest_assets",
+            state=ReadinessState.NOT_READY,
+            detail="MANIFEST_OR_ASSET_UNAVAILABLE",
+        )
+
+    @staticmethod
+    def _api_contract_check() -> ReadinessCheckResult:
+        if API_CONTRACT_VERSION:
+            return ReadinessCheckResult(name="api_contract", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="api_contract", state=ReadinessState.NOT_READY, detail="API_CONTRACT_UNAVAILABLE"
+        )
+
+    def _domain_check(self) -> ReadinessCheckResult:
+        try:
+            with connect_sqlite(self.database_path) as connection:
+                row = connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'runs';"
+                ).fetchone()
+        except sqlite3.Error:
+            row = None
+        if row is not None:
+            return ReadinessCheckResult(name="domain_schema", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="domain_schema", state=ReadinessState.NOT_READY, detail="DOMAIN_SCHEMA_UNAVAILABLE"
+        )
+
+    @staticmethod
+    def _keyring_check() -> ReadinessCheckResult:
+        try:
+            OSKeyringSecretStore()
+        except RuntimeError:
+            return ReadinessCheckResult(
+                name="keyring_adapter", state=ReadinessState.NOT_READY, detail="KEYRING_UNAVAILABLE"
+            )
+        return ReadinessCheckResult(name="keyring_adapter", state=ReadinessState.READY)
+
+    @staticmethod
+    def _mcp_executable_check() -> ReadinessCheckResult:
+        if Path(sys.executable).is_file():
+            return ReadinessCheckResult(name="mcp_executable", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="mcp_executable",
+            state=ReadinessState.NOT_READY,
+            detail="MCP_EXECUTABLE_UNAVAILABLE",
+        )
+
     def _mcp_check(self) -> ReadinessCheckResult:
         metadata = self.transport.runtime_metadata()
         if metadata.process_status != "READY" or metadata.process_instance_id is None:
@@ -179,6 +438,55 @@ class DevelopmentReadinessAggregator(ReadinessAggregator):
                 detail=metadata.last_safe_error_code or metadata.process_status,
             )
         return ReadinessCheckResult(name="mcp_handshake", state=ReadinessState.READY)
+
+    def _tool_schema_check(self) -> ReadinessCheckResult:
+        metadata = self.transport.runtime_metadata()
+        if (
+            metadata.protocol_version == MCP_MANIFEST_VERSION
+            and metadata.tool_registry_version == MCP_TOOL_REGISTRY_VERSION
+            and metadata.available_tool_count > 0
+        ):
+            return ReadinessCheckResult(name="tool_schema", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="tool_schema", state=ReadinessState.NOT_READY, detail="TOOL_SCHEMA_UNAVAILABLE"
+        )
+
+    def _prompt_check(self) -> ReadinessCheckResult:
+        if self.prompt_active:
+            return ReadinessCheckResult(name="prompt_activation", state=ReadinessState.READY)
+        return ReadinessCheckResult(
+            name="prompt_activation",
+            state=ReadinessState.NOT_READY,
+            detail="PROMPT_NOT_ACTIVE",
+        )
+
+
+class _PromptInactiveWorkflowRuntime:
+    """Safe placeholder: workflows cannot execute until prompts are approved."""
+
+    def close(self) -> None:
+        return None
+
+    def start(self, request: WorkflowStartRequest) -> WorkflowInvocationResult:
+        return self._not_available(request.run_id, request.workflow_key)
+
+    def resume(self, request: WorkflowResumeRequest) -> WorkflowInvocationResult:
+        return self._not_available(request.run_id, request.workflow_key)
+
+    def request_cancel(self, request: WorkflowCancelRequest) -> WorkflowInvocationResult:
+        return self._not_available(request.run_id, request.workflow_key)
+
+    def recover_open_run(self, request: WorkflowRecoveryRequest) -> WorkflowInvocationResult:
+        return self._not_available(request.run_id, request.workflow_key)
+
+    @staticmethod
+    def _not_available(run_id: str, workflow_key: str) -> WorkflowInvocationResult:
+        return WorkflowInvocationResult(
+            run_id=run_id,
+            workflow_key=workflow_key,
+            outcome=WorkflowOutcome.FAILED,
+            payload={"safe_error_code": "PROMPT_NOT_ACTIVE"},
+        )
 
 
 class _UnavailableApiProviderTransport:
@@ -210,6 +518,8 @@ def build_container(
     port: int = DEFAULT_PORT,
     runtime_root: Path | None = None,
     bootstrap_secret: str | None = None,
+    service_instance_id: str | None = None,
+    safe_mode_controller: SafeModeController | None = None,
 ) -> ApiContainer:
     """Assemble the development service with real local adapters."""
 
@@ -219,36 +529,38 @@ def build_container(
     database_path = root / "google-work-agent.sqlite3"
     checkpoint_database_path = root / "langgraph-checkpoints.sqlite3"
     mcp_manifest_path = _write_mcp_manifest(root)
-    workspace_manifest_path = _write_empty_workspace_manifest(root)
-    prompt_manifest_path = _write_development_prompt_manifest(root)
+    prompt_manifest_path = PROJECT_ROOT / "prompts" / "agent" / "prompt-manifest-v0.8.2.json"
     clock = SystemClock()
     id_generator = UUIDIdGenerator()
-    service_instance_id = f"dev-{uuid.uuid4()}"
+    service_instance_id = service_instance_id or f"dev-{uuid.uuid4()}"
 
-    with connect_sqlite(database_path) as connection:
-        apply_migrations(connection, now_ms=clock.now_ms)
+    try:
+        with connect_sqlite(database_path) as connection:
+            apply_migrations(connection, now_ms=clock.now_ms)
+    except sqlite3.Error as error:
+        raise CoreInitializationError("MIGRATION_FAILED") from error
 
-    transport = SubprocessMCPTransport(
-        config=MCPArtifactConfig(
-            executable_path=str(Path(sys.executable).resolve()),
-            manifest_path=str(mcp_manifest_path),
-            expected_binary_sha256=calculate_file_sha256(Path(sys.executable).resolve()),
-            expected_manifest_sha256=calculate_file_sha256(mcp_manifest_path),
-            expected_manifest_version=MCP_MANIFEST_VERSION,
-            expected_protocol_version=MCP_MANIFEST_VERSION,
-            expected_tool_registry_version=MCP_TOOL_REGISTRY_VERSION,
-            startup_timeout_ms=5_000,
-            request_timeout_ms=10_000,
-            max_restart_count=1,
-            environment="DEVELOPMENT",
-            service_instance_id=service_instance_id,
-            working_directory=str(PROJECT_ROOT),
-            extra_environment={
-                "GWA_TEST_KEYRING_PATH": str((root / "mcp-keyring.json").resolve()),
-                "GWA_PRODUCT_FIXTURE_MANIFEST": str(workspace_manifest_path),
-            },
+    try:
+        transport = SubprocessMCPTransport(
+            config=MCPArtifactConfig(
+                executable_path=str(Path(sys.executable).resolve()),
+                manifest_path=str(mcp_manifest_path),
+                expected_binary_sha256=calculate_file_sha256(Path(sys.executable).resolve()),
+                expected_manifest_sha256=calculate_file_sha256(mcp_manifest_path),
+                expected_manifest_version=MCP_MANIFEST_VERSION,
+                expected_protocol_version=MCP_MANIFEST_VERSION,
+                expected_tool_registry_version=MCP_TOOL_REGISTRY_VERSION,
+                startup_timeout_ms=5_000,
+                request_timeout_ms=10_000,
+                max_restart_count=1,
+                environment="DEVELOPMENT",
+                service_instance_id=service_instance_id,
+                working_directory=str(PROJECT_ROOT),
+                extra_environment=None,
+            )
         )
-    )
+    except MCPTransportError as error:
+        raise CoreInitializationError("MCP_HANDSHAKE_FAILED") from error
     google_provider = MCPGoogleOAuthCredentialProvider(transport=transport)
     runtime_status_provider = MCPRuntimeStatusProvider(
         google_provider=google_provider,
@@ -262,21 +574,31 @@ def build_container(
         database_path=database_path,
         runtime_status_provider=runtime_status_provider,
     )
-    llm_runtime = _build_llm_runtime(
-        settings_path=root / "settings" / "app-settings.json",
-        query_service=query_service,
-    )
-    workflow_runtime = LangGraphWorkflowRuntime(
-        unit_of_work_factory=unit_of_work_factory,
-        llm_runtime=llm_runtime,
-        gateway=MCPGoogleWorkspaceGateway(transport=transport),
-        now_ms=clock.now_ms,
-        id_factory=id_generator.next_id,
-        signing_secret=secrets.token_hex(32),
-        service_instance_id=service_instance_id,
-        checkpoint_database_path=checkpoint_database_path,
-        prompt_manifest_path=prompt_manifest_path,
-    )
+    try:
+        llm_runtime = _build_llm_runtime(
+            settings_path=root / "settings" / "app-settings.json",
+            query_service=query_service,
+        )
+    except RuntimeError as error:
+        transport.close()
+        raise CoreInitializationError("KEYRING_UNAVAILABLE") from error
+    prompt_active = True
+    workflow_runtime: LangGraphWorkflowRuntime | _PromptInactiveWorkflowRuntime
+    try:
+        workflow_runtime = LangGraphWorkflowRuntime(
+            unit_of_work_factory=unit_of_work_factory,
+            llm_runtime=llm_runtime,
+            gateway=MCPGoogleWorkspaceGateway(transport=transport),
+            now_ms=clock.now_ms,
+            id_factory=id_generator.next_id,
+            signing_secret=secrets.token_hex(32),
+            service_instance_id=service_instance_id,
+            checkpoint_database_path=checkpoint_database_path,
+            prompt_manifest_path=prompt_manifest_path,
+        )
+    except InactivePromptArtifactError:
+        prompt_active = False
+        workflow_runtime = _PromptInactiveWorkflowRuntime()
     event_publisher = InMemoryRunEventPublisher(service_instance_id=service_instance_id)
     coordinator = LocalRunCoordinator(
         query_service=query_service,
@@ -333,7 +655,12 @@ def build_container(
         local_run_coordinator=coordinator,
         workflow_runtime=workflow_runtime,
         event_publisher=event_publisher,
-        readiness_aggregator=DevelopmentReadinessAggregator(database_path, transport),
+        readiness_aggregator=DevelopmentReadinessAggregator(
+            database_path=database_path,
+            transport=transport,
+            mcp_manifest_path=mcp_manifest_path,
+            prompt_active=prompt_active,
+        ),
         runtime_status_provider=runtime_status_provider,
         api_access_guard=LocalApiAccessGuard(
             expected_host=f"{host}:{port}",
@@ -368,6 +695,7 @@ def build_container(
             credential_service=llm_runtime.credential_service,
         ),
         test_llm_connection_service=TestLLMConnectionService(runtime_service=llm_runtime),
+        safe_mode_controller=safe_mode_controller,
         shutdown_callbacks=(workflow_runtime.close, transport.close),
     )
 
@@ -375,7 +703,13 @@ def build_container(
 def create_service_app() -> FastAPI:
     """Return an argument-free application factory for Uvicorn."""
 
-    return create_app(build_container())
+    shell = _DeferredApiContainer(
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        service_instance_id=f"dev-{uuid.uuid4()}",
+        bootstrap_secret=secrets.token_urlsafe(32),
+    )
+    return create_app(cast(ApiContainer, shell))
 
 
 def main() -> NoReturn:
@@ -387,9 +721,10 @@ def main() -> NoReturn:
     args = parser.parse_args()
     LocalBindPolicy(host=args.host, port=args.port).validate()
     bootstrap_secret = secrets.token_urlsafe(32)
-    container = build_container(
+    container = _DeferredApiContainer(
         host=args.host,
         port=args.port,
+        service_instance_id=f"dev-{uuid.uuid4()}",
         bootstrap_secret=bootstrap_secret,
     )
     print(
@@ -400,8 +735,18 @@ def main() -> NoReturn:
     )
     import uvicorn
 
-    uvicorn.run(create_app(container), host=args.host, port=args.port)
+    uvicorn.run(create_app(cast(ApiContainer, container)), host=args.host, port=args.port)
     raise SystemExit(0)
+
+
+def _close_container(container: ApiContainer) -> None:
+    """Close core-owned resources exactly once when deferred startup loses a race."""
+
+    try:
+        container.local_run_coordinator.stop()
+    finally:
+        for callback in container.shutdown_callbacks:
+            callback()
 
 
 def _build_llm_runtime(*, settings_path: Path, query_service: QueryService) -> LLMRuntimeService:
@@ -451,42 +796,6 @@ def _write_mcp_manifest(runtime_root: Path) -> Path:
     manifest_path = runtime_root / "mcp-manifest.json"
     manifest_path.write_text(
         json.dumps(build_manifest_payload(), sort_keys=True),
-        encoding="utf-8",
-    )
-    return manifest_path.resolve()
-
-
-def _write_empty_workspace_manifest(runtime_root: Path) -> Path:
-    manifest_path = runtime_root / "development-workspace.json"
-    manifest_path.write_text(
-        json.dumps({"snapshot_id": "development-empty", "resources": [], "faults": []}),
-        encoding="utf-8",
-    )
-    return manifest_path.resolve()
-
-
-def _write_development_prompt_manifest(runtime_root: Path) -> Path:
-    """Derive a DEV-only runtime selection without editing the source prompt pack."""
-
-    source_path = PROJECT_ROOT / "prompts" / "agent" / "prompt-manifest-v0.8.2.json"
-    manifest = json.loads(source_path.read_text(encoding="utf-8"))
-    slots = manifest.get("slots")
-    if not isinstance(slots, list):
-        raise ValueError("prompt manifest slots are unavailable")
-    activated: set[str] = set()
-    for slot in slots:
-        if not isinstance(slot, dict):
-            raise ValueError("prompt manifest slot is invalid")
-        slot_id = slot.get("slot_id")
-        if isinstance(slot_id, str) and slot_id in DEVELOPMENT_RUNTIME_PROMPT_IDS:
-            slot["activation_status"] = "RUNTIME_ACTIVE"
-            activated.add(slot_id)
-    missing = DEVELOPMENT_RUNTIME_PROMPT_IDS - activated
-    if missing:
-        raise ValueError(f"development prompt slots are missing: {sorted(missing)}")
-    manifest_path = runtime_root / "prompt-manifest-development.json"
-    manifest_path.write_text(
-        json.dumps(manifest, ensure_ascii=True, indent=2) + "\n",
         encoding="utf-8",
     )
     return manifest_path.resolve()

--- a/src/google_work_agent/mcp/server.py
+++ b/src/google_work_agent/mcp/server.py
@@ -1,41 +1,49 @@
-"""Local MCP child process with fixture-backed Google tools and OAuth provider."""
+"""Local MCP child process for Google OAuth credentials.
+
+Google Workspace resource adapters deliberately do not live in this module yet.
+This process owns the Desktop OAuth loopback flow and the OS-keyring refresh token.
+"""
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
 import sys
 import threading
 import time
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from json import dumps
-from pathlib import Path
 from typing import cast
+from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.request import Request, urlopen
 
+from google_work_agent.adapters.keyring import OSKeyringSecretStore
 from google_work_agent.adapters.mcp.transport import PROTOCOL_VERSION
 from google_work_agent.domain import build_p0_tool_registry
 from google_work_agent.mcp.settings import GoogleOAuthSettings
-from google_work_agent.ports import (
-    CredentialState,
-    OAuthEnvironment,
-    ResourceSnapshot,
-    ResourceType,
-)
+from google_work_agent.ports import CredentialState, OAuthEnvironment, SecretStore
 
+GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+GOOGLE_REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke"
+GOOGLE_KEYRING_SERVICE = "GoogleWorkAgent/DEVELOPMENT"
+GOOGLE_REFRESH_TOKEN_ACCOUNT = "google-oauth-refresh-token"
 REQUIRED_SCOPES = (
-    "gmail.readonly",
-    "gmail.compose",
-    "tasks",
-    "calendar.events",
-    "calendar.calendarlist.readonly",
-    "calendar.events.freebusy",
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+    "https://www.googleapis.com/auth/calendar.events.freebusy",
 )
 OAUTH_FLOW_TTL_MS = 60_000
+DEFAULT_ACCESS_TOKEN_TTL_MS = 3_600_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,108 +57,173 @@ class _OAuthFlow:
 
 
 class _OAuthConfigurationError(RuntimeError):
-    """Raised only when the OAuth entry point lacks required local configuration."""
+    """Raised when local OAuth configuration is incomplete."""
+
+    def __init__(self, safe_code: str) -> None:
+        super().__init__(safe_code)
+        self.safe_code = safe_code
 
 
-class _TestKeyring:
-    def __init__(self, path: Path) -> None:
-        self._path = path
-        self._lock = threading.Lock()
+class _OAuthExchangeError(RuntimeError):
+    """Raised when Google's token endpoint rejects a callback code."""
 
-    def set(self, key: str, value: str) -> None:
-        with self._lock:
-            payload = self._read()
-            payload[key] = value
-            self._path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    def __init__(
+        self,
+        safe_error_code: str = "TOKEN_EXCHANGE_FAILED",
+        safe_error_description: str | None = None,
+    ) -> None:
+        super().__init__(safe_error_code)
+        self.safe_error_code = safe_error_code
+        self.safe_error_description = safe_error_description
 
-    def get(self, key: str) -> str | None:
-        with self._lock:
-            return self._read().get(key)
 
-    def delete(self, key: str) -> bool:
-        with self._lock:
-            payload = self._read()
-            existed = key in payload
-            payload.pop(key, None)
-            self._path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
-            return existed
+class _OAuthReauthenticationRequired(RuntimeError):
+    """Raised when Google rejects a stored refresh token."""
 
-    def _read(self) -> dict[str, str]:
-        if not self._path.exists():
-            return {}
-        return cast(dict[str, str], json.loads(self._path.read_text(encoding="utf-8")))
+
+class _WorkspaceToolsNotImplemented(RuntimeError):
+    """Raised until real Gmail/Calendar/Tasks adapters are implemented."""
 
 
 class _WorkspaceState:
-    def __init__(self) -> None:
+    def __init__(self, *, keyring: SecretStore | None = None) -> None:
         self.process_instance_id = f"mcp-{secrets.token_hex(8)}"
         self.service_instance_id: str | None = None
         self.session_key: str | None = None
         self.connection_state = CredentialState.NOT_CONNECTED
         self.account_email: str | None = None
         self.display_name: str | None = None
+        # Access tokens are intentionally process-memory-only.
         self.access_token: str | None = None
+        self.access_token_expires_at_ms = 0
+        self._refresh_lock = threading.Lock()
+        self._oauth_flow_lock = threading.Lock()
         self.last_checked_at_ms = _now_ms()
+        self.last_oauth_error_code: str | None = None
+        self.last_oauth_error_description: str | None = None
         self.active_flow: _OAuthFlow | None = None
         self.oauth_settings = GoogleOAuthSettings.load(
             runtime_environment=os.environ.get("GWA_MCP_ENVIRONMENT", ""),
         )
-        self.keyring = _TestKeyring(Path(os.environ["GWA_TEST_KEYRING_PATH"]))
-        self.resources = _load_resources(Path(os.environ["GWA_PRODUCT_FIXTURE_MANIFEST"]))
+        self.keyring = keyring or OSKeyringSecretStore()
+        if (
+            self.keyring.get_secret(
+                service=GOOGLE_KEYRING_SERVICE,
+                account=GOOGLE_REFRESH_TOKEN_ACCOUNT,
+            )
+            is not None
+        ):
+            self.connection_state = CredentialState.CONNECTED
 
     def connection_payload(self) -> dict[str, object]:
-        granted_scopes = (
-            REQUIRED_SCOPES if self.connection_state is CredentialState.CONNECTED else ()
-        )
+        connected = self.connection_state is CredentialState.CONNECTED
         return {
-            "connected": self.connection_state is CredentialState.CONNECTED,
+            "connected": connected,
             "credential_state": self.connection_state.value,
             "account_email": self.account_email,
             "display_name": self.display_name,
-            "granted_scopes": list(granted_scopes),
+            "granted_scopes": list(REQUIRED_SCOPES) if connected else [],
             "missing_scopes": [],
             "reauth_required": self.connection_state is CredentialState.REAUTH_REQUIRED,
             "oauth_environment": OAuthEnvironment.DEVELOPMENT.value,
             "last_checked_at_ms": self.last_checked_at_ms,
+            "safe_error_code": self.last_oauth_error_code,
+            "safe_error_description": self.last_oauth_error_description,
         }
+
+    def ensure_access_token(self) -> None:
+        if self.access_token is not None and _now_ms() < self.access_token_expires_at_ms:
+            return
+        with self._refresh_lock:
+            if self.access_token is not None and _now_ms() < self.access_token_expires_at_ms:
+                return
+            refresh_token = self.keyring.get_secret(
+                service=GOOGLE_KEYRING_SERVICE,
+                account=GOOGLE_REFRESH_TOKEN_ACCOUNT,
+            )
+            if refresh_token is None:
+                self.connection_state = CredentialState.NOT_CONNECTED
+                return
+            access_token, expires_at_ms, rotated_refresh_token = _refresh_access_token(
+                refresh_token,
+                self.oauth_settings.google_oauth_client_id,
+                self.oauth_settings.google_oauth_client_secret,
+            )
+            self.access_token = access_token
+            self.access_token_expires_at_ms = expires_at_ms
+            if rotated_refresh_token is not None:
+                self.keyring.set_secret(
+                    service=GOOGLE_KEYRING_SERVICE,
+                    account=GOOGLE_REFRESH_TOKEN_ACCOUNT,
+                    secret=rotated_refresh_token,
+                )
+            self.connection_state = CredentialState.CONNECTED
 
 
 def main() -> None:
-    state = _WorkspaceState()
+    try:
+        state = _WorkspaceState()
+    except RuntimeError:
+        # Do not disclose keyring implementation details or credential material.
+        state = None
     for raw_line in sys.stdin:
         line = raw_line.strip()
         if not line:
             continue
         request = cast(dict[str, object], json.loads(line))
-        message_type = str(request.get("type"))
         request_id = str(request.get("id", ""))
-        if message_type == "shutdown":
+        if str(request.get("type")) == "shutdown":
             break
-        try:
-            payload = _dispatch(state, request)
-            _write({"id": request_id, "payload": payload})
-        except KeyError as error:
-            _write(
-                {
-                    "id": request_id,
-                    "error": {"code": "NOT_FOUND", "message": str(error)},
-                }
-            )
-        except _OAuthConfigurationError:
+        if state is None:
             _write(
                 {
                     "id": request_id,
                     "error": {
                         "code": "CONFIGURATION_ERROR",
-                        "message": "Set GOOGLE_OAUTH_CLIENT_ID in .env.local.",
+                        "message": "OS keyring is unavailable.",
                     },
                 }
             )
-        except Exception as error:
+            continue
+        try:
+            _write({"id": request_id, "payload": _dispatch(state, request)})
+        except _OAuthConfigurationError as error:
             _write(
                 {
                     "id": request_id,
-                    "error": {"code": "MALFORMED_RESPONSE", "message": str(error)},
+                    "error": {
+                        "code": "CONFIGURATION_ERROR",
+                        "message": error.safe_code,
+                    },
+                }
+            )
+        except _OAuthExchangeError:
+            _write(
+                {
+                    "id": request_id,
+                    "error": {
+                        "code": "TOOL_REJECTED",
+                        "message": "Google OAuth token exchange failed.",
+                    },
+                }
+            )
+        except _WorkspaceToolsNotImplemented:
+            _write(
+                {
+                    "id": request_id,
+                    "error": {
+                        "code": "TOOL_REJECTED",
+                        "message": "Google Workspace tools are not implemented.",
+                    },
+                }
+            )
+        except KeyError as error:
+            _write({"id": request_id, "error": {"code": "NOT_FOUND", "message": str(error)}})
+        except Exception:
+            _write(
+                {
+                    "id": request_id,
+                    "error": {"code": "MALFORMED_RESPONSE", "message": "MCP request failed."},
                 }
             )
 
@@ -177,50 +250,56 @@ def _dispatch(state: _WorkspaceState, request: dict[str, object]) -> dict[str, o
             )
         }
     if message_type == "control_call":
-        return _control_call(
-            state,
-            method=str(request["method"]),
-            arguments=cast(dict[str, object], request["arguments"]),
-        )
+        return _control_call(state, method=str(request["method"]))
     if message_type == "tool_call":
-        return _tool_call(
-            state,
-            tool_name=str(request["tool_name"]),
-            arguments=cast(dict[str, object], request["arguments"]),
-        )
-    raise ValueError(f"unsupported message type: {message_type}")
+        raise _WorkspaceToolsNotImplemented
+    raise ValueError("unsupported message type")
 
 
-def _control_call(
-    state: _WorkspaceState,
-    *,
-    method: str,
-    arguments: dict[str, object],
-) -> dict[str, object]:
-    del arguments
+def _control_call(state: _WorkspaceState, *, method: str) -> dict[str, object]:
     if method == "google.connection.get":
+        try:
+            state.ensure_access_token()
+        except _OAuthReauthenticationRequired:
+            state.connection_state = CredentialState.REAUTH_REQUIRED
+            state.access_token = None
+            state.access_token_expires_at_ms = 0
         state.last_checked_at_ms = _now_ms()
         return state.connection_payload()
     if method == "google.connection.disconnect":
-        deleted = state.keyring.delete("GoogleWorkAgent/DEVELOPMENT/refresh-token")
+        refresh_token = state.keyring.get_secret(
+            service=GOOGLE_KEYRING_SERVICE,
+            account=GOOGLE_REFRESH_TOKEN_ACCOUNT,
+        )
+        revoke_succeeded = (
+            _revoke_refresh_token(refresh_token) if refresh_token is not None else False
+        )
+        deleted = state.keyring.delete_secret(
+            service=GOOGLE_KEYRING_SERVICE, account=GOOGLE_REFRESH_TOKEN_ACCOUNT
+        )
         state.connection_state = CredentialState.NOT_CONNECTED
         state.access_token = None
+        state.access_token_expires_at_ms = 0
         state.account_email = None
         state.display_name = None
         state.last_checked_at_ms = _now_ms()
         return {
             "disconnected": True,
             "credential_deleted": deleted,
-            "revoke_attempted": True,
-            "revoke_succeeded": True,
+            "revoke_attempted": refresh_token is not None,
+            "revoke_succeeded": revoke_succeeded,
             "credential_state": state.connection_state.value,
         }
     if method == "google.oauth.start":
         if state.oauth_settings.google_oauth_client_id is None:
-            raise _OAuthConfigurationError
+            raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_ID_MISSING")
+        if state.oauth_settings.google_oauth_client_secret is None:
+            raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_SECRET_MISSING")
         if state.active_flow is not None and state.active_flow.expires_at_ms > _now_ms():
             raise ValueError("oauth flow already active")
         flow = _start_oauth_flow(state)
+        state.last_oauth_error_code = None
+        state.last_oauth_error_description = None
         state.active_flow = flow
         return {
             "flow_id": flow.flow_id,
@@ -230,168 +309,33 @@ def _control_call(
             "oauth_environment": OAuthEnvironment.DEVELOPMENT.value,
             "scopes": list(REQUIRED_SCOPES),
         }
-    raise ValueError(f"unsupported control method: {method}")
-
-
-def _tool_call(
-    state: _WorkspaceState,
-    *,
-    tool_name: str,
-    arguments: dict[str, object],
-) -> dict[str, object]:
-    if state.connection_state is not CredentialState.CONNECTED:
-        raise ValueError("google connection is not ready")
-    items = state.resources
-    if tool_name == "gmail_search_threads":
-        query = str(arguments["query"]).lower()
-        threads = [
-            item
-            for item in items.values()
-            if item.resource_type is ResourceType.GMAIL_THREAD
-            and (
-                query in str(item.payload.get("subject", "")).lower()
-                or any(
-                    query in str(p).lower()
-                    for p in cast(list[object], item.payload.get("participants", []))
-                )
-            )
-        ]
-        return {
-            "schema_version": "v1",
-            "items": [_snapshot_payload(item) for item in threads],
-            "next_page_token": None,
-        }
-    if tool_name == "gmail_get_thread":
-        return {
-            "schema_version": "v1",
-            "item": _snapshot_payload(
-                items[(ResourceType.GMAIL_THREAD, str(arguments["thread_id"]))]
-            ),
-        }
-    if tool_name == "gmail_get_message":
-        return {
-            "schema_version": "v1",
-            "item": _snapshot_payload(
-                items[(ResourceType.GMAIL_MESSAGE, str(arguments["message_id"]))]
-            ),
-        }
-    if tool_name == "gmail_get_draft":
-        return {
-            "schema_version": "v1",
-            "item": _snapshot_payload(
-                items[(ResourceType.GMAIL_DRAFT, str(arguments["draft_id"]))]
-            ),
-        }
-    if tool_name == "tasks_list_tasklists":
-        tasklists = [
-            item for item in items.values() if item.resource_type is ResourceType.TASK_LIST
-        ]
-        return {
-            "schema_version": "v1",
-            "items": [_snapshot_payload(item) for item in tasklists],
-            "next_page_token": None,
-        }
-    if tool_name == "tasks_list_tasks":
-        task_list_id = str(arguments["task_list_id"])
-        tasks = [
-            item
-            for item in items.values()
-            if item.resource_type is ResourceType.TASK and item.parent_id == task_list_id
-        ]
-        return {
-            "schema_version": "v1",
-            "items": [_snapshot_payload(item) for item in tasks],
-            "next_page_token": None,
-        }
-    if tool_name == "tasks_get_task":
-        return {
-            "schema_version": "v1",
-            "item": _snapshot_payload(items[(ResourceType.TASK, str(arguments["task_id"]))]),
-        }
-    if tool_name == "calendar_list_calendars":
-        calendars = [item for item in items.values() if item.resource_type is ResourceType.CALENDAR]
-        return {
-            "schema_version": "v1",
-            "items": [_snapshot_payload(item) for item in calendars],
-            "next_page_token": None,
-        }
-    if tool_name == "calendar_list_events":
-        calendar_id = str(arguments["calendar_id"])
-        events = [
-            item
-            for item in items.values()
-            if item.resource_type is ResourceType.CALENDAR_EVENT and item.parent_id == calendar_id
-        ]
-        return {
-            "schema_version": "v1",
-            "items": [_snapshot_payload(item) for item in events],
-            "next_page_token": None,
-        }
-    if tool_name == "calendar_get_event":
-        return {
-            "schema_version": "v1",
-            "item": _snapshot_payload(
-                items[(ResourceType.CALENDAR_EVENT, str(arguments["event_id"]))]
-            ),
-        }
-    if tool_name == "calendar_query_freebusy":
-        freebusy_results: list[dict[str, object]] = []
-        for calendar_id_item in cast(list[object], arguments["calendar_ids"]):
-            freebusy = items[(ResourceType.CALENDAR_FREEBUSY, str(calendar_id_item))]
-            freebusy_results.append(
-                {
-                    "calendar_id": freebusy.resource_id,
-                    "intervals": cast(list[dict[str, object]], freebusy.payload["intervals"]),
-                }
-            )
-        return {"schema_version": "v1", "calendars": freebusy_results}
-    if tool_name == "search_by_recovery_fingerprint":
-        resource_type = ResourceType(str(arguments["resource_type"]))
-        fingerprint = str(arguments["recovery_fingerprint"])
-        matches = [
-            item
-            for item in items.values()
-            if item.resource_type is resource_type and item.recovery_fingerprint == fingerprint
-        ]
-        return {"schema_version": "v1", "items": [_snapshot_payload(item) for item in matches]}
-    if tool_name in {
-        "gmail_create_draft",
-        "gmail_update_draft",
-        "gmail_send",
-        "tasks_create_task",
-        "tasks_update_task",
-        "calendar_create_event",
-        "calendar_update_event",
-        "calendar_delete_event",
-    }:
-        _validate_claim_context(state, tool_name=tool_name, arguments=arguments)
-        return {
-            "schema_version": "v1",
-            "item": _mutate_snapshot(state, tool_name=tool_name, arguments=arguments),
-        }
-    raise ValueError(f"unsupported tool: {tool_name}")
+    raise ValueError("unsupported control method")
 
 
 def _start_oauth_flow(state: _WorkspaceState) -> _OAuthFlow:
-    flow_id = f"flow-{secrets.token_hex(8)}"
     oauth_state = secrets.token_urlsafe(24)
-    verifier = secrets.token_urlsafe(48)
-    server = _OAuthCallbackServer(state=state, flow_id=flow_id, expected_state=oauth_state)
+    server = _OAuthCallbackServer(state=state, expected_state=oauth_state)
     callback_url = server.start()
-    expires_at_ms = _now_ms() + OAUTH_FLOW_TTL_MS
     return _OAuthFlow(
-        flow_id=flow_id,
+        flow_id=f"flow-{secrets.token_hex(8)}",
         state=oauth_state,
-        verifier=verifier,
+        verifier=secrets.token_urlsafe(48),
         callback_url=callback_url,
-        expires_at_ms=expires_at_ms,
+        expires_at_ms=_now_ms() + OAUTH_FLOW_TTL_MS,
         client_id=state.oauth_settings.google_oauth_client_id or "",
     )
 
 
 def _authorization_url(flow: _OAuthFlow) -> str:
-    launch_url = f"{flow.callback_url.removesuffix('/callback')}/authorize"
-    return f"{launch_url}?{urlencode({'state': flow.state})}"
+    # The API returns only a loopback URL.  The client ID is never sent in an API payload.
+    parsed = urlparse(flow.callback_url)
+    loopback_origin = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{loopback_origin}/oauth/authorize?{urlencode({'state': flow.state})}"
+
+
+def _pkce_s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
 def _google_authorization_url(flow: _OAuthFlow) -> str:
@@ -403,16 +347,175 @@ def _google_authorization_url(flow: _OAuthFlow) -> str:
             "scope": " ".join(REQUIRED_SCOPES),
             "state": flow.state,
             "code_challenge_method": "S256",
-            "code_challenge": hashlib.sha256(flow.verifier.encode("utf-8")).hexdigest(),
+            "code_challenge": _pkce_s256(flow.verifier),
+            "access_type": "offline",
+            "prompt": "consent",
         }
     )
-    return f"https://accounts.google.test/o/oauth2/v2/auth?{query}"
+    return f"{GOOGLE_AUTHORIZATION_ENDPOINT}?{query}"
+
+
+def _exchange_authorization_code(
+    flow: _OAuthFlow,
+    code: str,
+    client_secret: str | None,
+) -> tuple[str, str | None]:
+    if client_secret is None:
+        raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_SECRET_MISSING")
+    body = urlencode(
+        {
+            "client_id": flow.client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "code_verifier": flow.verifier,
+            "grant_type": "authorization_code",
+            "redirect_uri": flow.callback_url,
+        }
+    ).encode("ascii")
+    request = Request(
+        GOOGLE_TOKEN_ENDPOINT,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=10) as response:  # nosec B310: fixed Google endpoint
+            payload = cast(dict[str, object], json.loads(response.read().decode("utf-8")))
+    except HTTPError as error:
+        raise _oauth_exchange_error_from_http_error(
+            error,
+            sensitive_values=(
+                flow.client_id,
+                client_secret,
+                code,
+                flow.verifier,
+                flow.state,
+                flow.callback_url,
+            ),
+        ) from error
+    except (URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise _OAuthExchangeError from error
+    refresh_token = payload.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        raise _OAuthExchangeError
+    access_token = payload.get("access_token")
+    return refresh_token, access_token if isinstance(access_token, str) else None
+
+
+def _oauth_exchange_error_from_http_error(
+    error: HTTPError,
+    *,
+    sensitive_values: tuple[str, ...],
+) -> _OAuthExchangeError:
+    try:
+        payload = cast(dict[str, object], json.loads(error.read().decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return _OAuthExchangeError(f"TOKEN_EXCHANGE_HTTP_{error.code}")
+    provider_error = payload.get("error")
+    safe_description = _redact_provider_error_description(
+        payload.get("error_description"),
+        sensitive_values=sensitive_values,
+    )
+    if provider_error == "invalid_grant":
+        return _OAuthExchangeError(
+            "TOKEN_EXCHANGE_INVALID_GRANT",
+            safe_description
+            or "Google rejected the authorization code or its PKCE/redirect binding.",
+        )
+    if provider_error == "invalid_client":
+        return _OAuthExchangeError(
+            "TOKEN_EXCHANGE_INVALID_CLIENT",
+            safe_description or "Google rejected the configured desktop OAuth client.",
+        )
+    if provider_error == "redirect_uri_mismatch":
+        return _OAuthExchangeError(
+            "TOKEN_EXCHANGE_REDIRECT_URI_MISMATCH",
+            safe_description or "Google rejected the loopback redirect URI binding.",
+        )
+    if provider_error == "invalid_request":
+        return _OAuthExchangeError(
+            "TOKEN_EXCHANGE_INVALID_REQUEST",
+            safe_description or "Google rejected the token request.",
+        )
+    return _OAuthExchangeError(f"TOKEN_EXCHANGE_HTTP_{error.code}", safe_description)
+
+
+def _redact_provider_error_description(
+    value: object, *, sensitive_values: tuple[str, ...]
+) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    redacted = value
+    for sensitive_value in sensitive_values:
+        if sensitive_value:
+            redacted = redacted.replace(sensitive_value, "[REDACTED]")
+    redacted = re.sub(
+        r"(?i)\b(code|token|verifier|state|secret)=([^\s&,]+)",
+        r"\1=[REDACTED]",
+        redacted,
+    )
+    normalized = " ".join(redacted.split())
+    return normalized[:240] or None
+
+
+def _refresh_access_token(
+    refresh_token: str,
+    client_id: str | None,
+    client_secret: str | None,
+) -> tuple[str, int, str | None]:
+    if client_id is None:
+        raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_ID_MISSING")
+    if client_secret is None:
+        raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_SECRET_MISSING")
+    body = urlencode(
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+    ).encode("ascii")
+    request = Request(
+        GOOGLE_TOKEN_ENDPOINT,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=10) as response:  # nosec B310: fixed Google endpoint
+            payload = cast(dict[str, object], json.loads(response.read().decode("utf-8")))
+    except HTTPError as error:
+        if error.code == 400:
+            raise _OAuthReauthenticationRequired from error
+        raise _OAuthExchangeError from error
+    except (URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise _OAuthExchangeError from error
+    access_token = payload.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise _OAuthExchangeError
+    expires_in = payload.get("expires_in")
+    ttl_ms = int(expires_in) * 1000 if isinstance(expires_in, int) else DEFAULT_ACCESS_TOKEN_TTL_MS
+    rotated = payload.get("refresh_token")
+    return access_token, _now_ms() + ttl_ms, rotated if isinstance(rotated, str) else None
+
+
+def _revoke_refresh_token(refresh_token: str) -> bool:
+    request = Request(
+        GOOGLE_REVOKE_ENDPOINT,
+        data=urlencode({"token": refresh_token}).encode("ascii"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=10):  # nosec B310: fixed Google endpoint
+            return True
+    except (HTTPError, URLError, TimeoutError):
+        return False
 
 
 class _OAuthCallbackServer:
-    def __init__(self, *, state: _WorkspaceState, flow_id: str, expected_state: str) -> None:
+    def __init__(self, *, state: _WorkspaceState, expected_state: str) -> None:
         self._state = state
-        self._flow_id = flow_id
         self._expected_state = expected_state
         self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler())
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
@@ -425,37 +528,68 @@ class _OAuthCallbackServer:
                 parsed = urlparse(self.path)
                 params = parse_qs(parsed.query)
                 state_value = params.get("state", [""])[0]
+                if not hmac.compare_digest(state_value, outer._expected_state):
+                    self._respond(400, b"state mismatch")
+                    outer._finish_flow()
+                    return
                 if parsed.path == "/oauth/authorize":
                     flow = outer._state.active_flow
-                    if flow is None or not hmac.compare_digest(state_value, outer._expected_state):
-                        self.send_response(400)
-                        self.end_headers()
-                        self.wfile.write(b"state mismatch")
+                    if flow is None:
+                        self._respond(400, b"oauth flow unavailable")
+                        outer._finish_flow()
                         return
                     self.send_response(302)
                     self.send_header("Location", _google_authorization_url(flow))
                     self.end_headers()
                     return
-                code = params.get("code", [""])[0]
-                if not hmac.compare_digest(state_value, outer._expected_state):
-                    self.send_response(400)
-                    self.end_headers()
-                    self.wfile.write(b"state mismatch")
+                if parsed.path != "/oauth/callback":
+                    self._respond(404, b"not found")
+                    outer._finish_flow()
                     return
-                outer._state.keyring.set(
-                    "GoogleWorkAgent/DEVELOPMENT/refresh-token",
-                    f"refresh::{code}",
-                )
-                outer._state.access_token = f"access::{code}"
+                code = params.get("code", [""])[0]
+                with outer._state._oauth_flow_lock:
+                    flow = outer._state.active_flow
+                    if code and flow is not None and flow.expires_at_ms > _now_ms():
+                        outer._state.active_flow = None
+                    else:
+                        flow = None
+                if flow is None:
+                    self._respond(400, b"oauth flow expired")
+                    return
+                try:
+                    refresh_token, access_token = _exchange_authorization_code(
+                        flow,
+                        code,
+                        outer._state.oauth_settings.google_oauth_client_secret,
+                    )
+                    outer._state.keyring.set_secret(
+                        service=GOOGLE_KEYRING_SERVICE,
+                        account=GOOGLE_REFRESH_TOKEN_ACCOUNT,
+                        secret=refresh_token,
+                    )
+                except _OAuthExchangeError as error:
+                    outer._state.last_oauth_error_code = error.safe_error_code
+                    outer._state.last_oauth_error_description = error.safe_error_description
+                    self._respond(
+                        502,
+                        f"Google OAuth token exchange failed: {error.safe_error_code}".encode(),
+                    )
+                    outer._finish_flow()
+                    return
+                outer._state.access_token = access_token
+                outer._state.access_token_expires_at_ms = _now_ms() + DEFAULT_ACCESS_TOKEN_TTL_MS
                 outer._state.connection_state = CredentialState.CONNECTED
-                outer._state.account_email = "user@example.com"
-                outer._state.display_name = "User"
                 outer._state.last_checked_at_ms = _now_ms()
-                outer._state.active_flow = None
-                self.send_response(200)
+                outer._state.last_oauth_error_code = None
+                outer._state.last_oauth_error_description = None
+                self._respond(200, b"Google account connected. You can close this window.")
+                outer._shutdown()
+
+            def _respond(self, status: int, body: bytes) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
                 self.end_headers()
-                self.wfile.write(b"connected")
-                threading.Thread(target=outer._server.shutdown, daemon=True).start()
+                self.wfile.write(body)
 
             def log_message(self, format: str, *args: object) -> None:  # noqa: A003
                 del format, args
@@ -464,248 +598,14 @@ class _OAuthCallbackServer:
 
     def start(self) -> str:
         self._thread.start()
-        port = self._server.server_port
-        return f"http://127.0.0.1:{port}/oauth/callback"
+        return f"http://127.0.0.1:{self._server.server_port}/oauth/callback"
 
+    def _finish_flow(self) -> None:
+        self._state.active_flow = None
+        self._shutdown()
 
-def _validate_claim_context(
-    state: _WorkspaceState,
-    *,
-    tool_name: str,
-    arguments: dict[str, object],
-) -> None:
-    claim_context = cast(dict[str, object] | None, arguments.get("claim_context"))
-    if claim_context is None:
-        raise ValueError("claim context required")
-    if str(claim_context["tool_name"]) != tool_name:
-        raise ValueError("claim tool mismatch")
-    if str(claim_context["service_instance_id"]) != state.service_instance_id:
-        raise ValueError("claim service binding mismatch")
-    if str(claim_context["mcp_process_instance_id"]) != state.process_instance_id:
-        raise ValueError("claim process binding mismatch")
-    if _now_ms() >= int(str(claim_context["expires_at_ms"])):
-        raise ValueError("claim expired")
-    canonical_arguments = {
-        key: value
-        for key, value in arguments.items()
-        if key not in {"claim_context", "recovery_fingerprint"}
-    }
-    canonical_hash = hashlib.sha256(
-        dumps(canonical_arguments, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    if canonical_hash != str(claim_context["canonical_arguments_hash"]):
-        raise ValueError("claim arguments mismatch")
-    signature_payload = dumps(
-        {
-            "action_id": claim_context["action_id"],
-            "approval_id": claim_context["approval_id"],
-            "execution_attempt_id": claim_context["execution_attempt_id"],
-            "tool_name": claim_context["tool_name"],
-            "canonical_arguments_hash": claim_context["canonical_arguments_hash"],
-            "service_instance_id": claim_context["service_instance_id"],
-            "mcp_process_instance_id": claim_context["mcp_process_instance_id"],
-            "expires_at_ms": claim_context["expires_at_ms"],
-            "nonce": claim_context["nonce"],
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    expected = hmac.new(
-        bytes.fromhex(state.session_key or ""),
-        signature_payload,
-        hashlib.sha256,
-    ).hexdigest()
-    if not hmac.compare_digest(expected, str(claim_context["signature"])):
-        raise ValueError("claim signature mismatch")
-
-
-def _mutate_snapshot(
-    state: _WorkspaceState,
-    *,
-    tool_name: str,
-    arguments: dict[str, object],
-) -> dict[str, object]:
-    items = state.resources
-    if tool_name == "gmail_send":
-        draft_id = str(arguments["draft_id"])
-        draft = items[(ResourceType.GMAIL_DRAFT, draft_id)]
-        payload = dict(draft.payload)
-        payload["draft_id"] = draft_id
-        payload["sent"] = True
-        payload["recovery_fingerprint"] = arguments.get("recovery_fingerprint")
-        snapshot = ResourceSnapshot(
-            fixture_snapshot_id="mcp-runtime",
-            resource_type=ResourceType.GMAIL_MESSAGE,
-            resource_id=f"sent-{draft_id}",
-            parent_id=draft.parent_id,
-            related_resource_ids=draft.related_resource_ids,
-            version="1",
-            recovery_fingerprint=_optional_string(arguments.get("recovery_fingerprint")),
-            payload=payload,
-        )
-        items[(snapshot.resource_type, snapshot.resource_id)] = snapshot
-        return _snapshot_payload(snapshot)
-    if tool_name == "calendar_delete_event":
-        if arguments.get("delete_scope") not in {None, "SINGLE"}:
-            raise ValueError("recurring event series deletion is forbidden")
-        calendar_id = str(arguments["calendar_id"])
-        event_id = str(arguments["event_id"])
-        key = (ResourceType.CALENDAR_EVENT, event_id)
-        event = items[key]
-        if event.parent_id != calendar_id:
-            raise ValueError("calendar event parent mismatch")
-        del items[key]
-        tombstone = ResourceSnapshot(
-            fixture_snapshot_id=event.fixture_snapshot_id,
-            resource_type=event.resource_type,
-            resource_id=event.resource_id,
-            parent_id=event.parent_id,
-            related_resource_ids=event.related_resource_ids,
-            version=event.version,
-            recovery_fingerprint=event.recovery_fingerprint,
-            payload={"deleted": True},
-        )
-        return _snapshot_payload(tombstone)
-    payload = cast(dict[str, object], arguments["payload"])
-    if tool_name == "tasks_create_task":
-        resource_id = str(payload.get("resource_id", f"task-{secrets.token_hex(4)}"))
-        snapshot = ResourceSnapshot(
-            fixture_snapshot_id="mcp-runtime",
-            resource_type=ResourceType.TASK,
-            resource_id=resource_id,
-            parent_id=str(arguments["task_list_id"]),
-            related_resource_ids=(str(arguments["task_list_id"]),),
-            version="1",
-            recovery_fingerprint=_optional_string(payload.get("recovery_fingerprint")),
-            payload=payload,
-        )
-        items[(snapshot.resource_type, snapshot.resource_id)] = snapshot
-        return _snapshot_payload(snapshot)
-    if tool_name == "tasks_update_task":
-        key = (ResourceType.TASK, str(arguments["task_id"]))
-        current = items[key]
-        updated_payload = dict(current.payload)
-        updated_payload.update(payload)
-        updated = ResourceSnapshot(
-            fixture_snapshot_id=current.fixture_snapshot_id,
-            resource_type=current.resource_type,
-            resource_id=current.resource_id,
-            parent_id=current.parent_id,
-            related_resource_ids=current.related_resource_ids,
-            version=str(int(current.version) + 1),
-            recovery_fingerprint=current.recovery_fingerprint,
-            payload=updated_payload,
-        )
-        items[key] = updated
-        return _snapshot_payload(updated)
-    if tool_name == "gmail_create_draft":
-        resource_id = str(payload.get("resource_id", f"draft-{secrets.token_hex(4)}"))
-        snapshot = ResourceSnapshot(
-            fixture_snapshot_id="mcp-runtime",
-            resource_type=ResourceType.GMAIL_DRAFT,
-            resource_id=resource_id,
-            parent_id=None,
-            related_resource_ids=(),
-            version="1",
-            recovery_fingerprint=_optional_string(payload.get("recovery_fingerprint")),
-            payload=payload,
-        )
-        items[(snapshot.resource_type, snapshot.resource_id)] = snapshot
-        return _snapshot_payload(snapshot)
-    if tool_name == "gmail_update_draft":
-        key = (ResourceType.GMAIL_DRAFT, str(arguments["draft_id"]))
-        current = items[key]
-        updated_payload = dict(current.payload)
-        updated_payload.update(payload)
-        updated = ResourceSnapshot(
-            fixture_snapshot_id=current.fixture_snapshot_id,
-            resource_type=current.resource_type,
-            resource_id=current.resource_id,
-            parent_id=current.parent_id,
-            related_resource_ids=current.related_resource_ids,
-            version=str(int(current.version) + 1),
-            recovery_fingerprint=current.recovery_fingerprint,
-            payload=updated_payload,
-        )
-        items[key] = updated
-        return _snapshot_payload(updated)
-    calendar_id = str(arguments.get("calendar_id", "calendar-primary"))
-    if tool_name == "calendar_create_event":
-        resource_id = str(payload.get("resource_id", f"event-{secrets.token_hex(4)}"))
-        snapshot = ResourceSnapshot(
-            fixture_snapshot_id="mcp-runtime",
-            resource_type=ResourceType.CALENDAR_EVENT,
-            resource_id=resource_id,
-            parent_id=calendar_id,
-            related_resource_ids=(calendar_id,),
-            version="1",
-            recovery_fingerprint=_optional_string(payload.get("recovery_fingerprint")),
-            payload=payload,
-        )
-        items[(snapshot.resource_type, snapshot.resource_id)] = snapshot
-        return _snapshot_payload(snapshot)
-    if tool_name == "calendar_update_event":
-        key = (ResourceType.CALENDAR_EVENT, str(arguments["event_id"]))
-        current = items[key]
-        updated_payload = dict(current.payload)
-        updated_payload.update(payload)
-        updated = ResourceSnapshot(
-            fixture_snapshot_id=current.fixture_snapshot_id,
-            resource_type=current.resource_type,
-            resource_id=current.resource_id,
-            parent_id=current.parent_id,
-            related_resource_ids=current.related_resource_ids,
-            version=str(int(current.version) + 1),
-            recovery_fingerprint=current.recovery_fingerprint,
-            payload=updated_payload,
-        )
-        items[key] = updated
-        return _snapshot_payload(updated)
-    raise ValueError(f"unsupported mutating tool: {tool_name}")
-
-
-def _snapshot_payload(snapshot: ResourceSnapshot) -> dict[str, object]:
-    return {
-        "fixture_snapshot_id": snapshot.fixture_snapshot_id,
-        "resource_type": snapshot.resource_type.value,
-        "resource_id": snapshot.resource_id,
-        "parent_id": snapshot.parent_id,
-        "related_resource_ids": list(snapshot.related_resource_ids),
-        "version": snapshot.version,
-        "recovery_fingerprint": snapshot.recovery_fingerprint,
-        "payload": snapshot.payload,
-    }
-
-
-def _load_resources(manifest_path: Path) -> dict[tuple[ResourceType, str], ResourceSnapshot]:
-    manifest = cast(dict[str, object], json.loads(manifest_path.read_text(encoding="utf-8")))
-    base_dir = manifest_path.parent
-    resources: dict[tuple[ResourceType, str], ResourceSnapshot] = {}
-    for entry in cast(list[dict[str, object]], manifest["resources"]):
-        payload = cast(
-            dict[str, object],
-            json.loads((base_dir / str(entry["path"])).read_text(encoding="utf-8")),
-        )
-        snapshot = ResourceSnapshot(
-            fixture_snapshot_id=str(manifest["snapshot_id"]),
-            resource_type=ResourceType(str(payload["resource_type"])),
-            resource_id=str(payload["resource_id"]),
-            parent_id=_optional_string(payload.get("parent_id")),
-            related_resource_ids=tuple(
-                str(item) for item in cast(list[object], payload["related_resource_ids"])
-            ),
-            version=str(payload["version"]),
-            recovery_fingerprint=_optional_string(payload.get("recovery_fingerprint")),
-            payload=cast(dict[str, object], payload["payload"]),
-        )
-        resources[(snapshot.resource_type, snapshot.resource_id)] = snapshot
-    return resources
-
-
-def _optional_string(value: object) -> str | None:
-    if value is None:
-        return None
-    return str(value)
+    def _shutdown(self) -> None:
+        threading.Thread(target=self._server.shutdown, daemon=True).start()
 
 
 def _write(payload: dict[str, object]) -> None:

--- a/src/google_work_agent/mcp/settings.py
+++ b/src/google_work_agent/mcp/settings.py
@@ -15,6 +15,7 @@ class GoogleOAuthSettings:
     """Sanitized OAuth configuration; client IDs must not be logged or serialized."""
 
     google_oauth_client_id: str | None = field(repr=False)
+    google_oauth_client_secret: str | None = field(default=None, repr=False)
 
     @classmethod
     def load(
@@ -30,7 +31,15 @@ class GoogleOAuthSettings:
         )
         values.update(dict(os.environ) if environment is None else environment)
         client_id = values.get("GOOGLE_OAUTH_CLIENT_ID", "").strip()
-        return cls(google_oauth_client_id=client_id or None)
+        client_secret = (
+            values.get("GOOGLE_OAUTH_CLIENT_SECRET", "").strip()
+            if runtime_environment.upper() == DEVELOPMENT_ENVIRONMENT
+            else ""
+        )
+        return cls(
+            google_oauth_client_id=client_id or None,
+            google_oauth_client_secret=client_secret or None,
+        )
 
 
 def _load_env_file(path: Path) -> dict[str, str]:

--- a/src/google_work_agent/ports/google_oauth.py
+++ b/src/google_work_agent/ports/google_oauth.py
@@ -42,6 +42,8 @@ class GoogleConnectionStatus:
     reauth_required: bool
     oauth_environment: OAuthEnvironment
     last_checked_at_ms: int
+    safe_error_code: str | None = None
+    safe_error_description: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/component/api/test_google_connection_api.py
+++ b/tests/component/api/test_google_connection_api.py
@@ -4,7 +4,7 @@ import json
 import sys
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
-from urllib.request import urlopen
+from urllib.request import HTTPRedirectHandler, build_opener
 
 from fastapi.testclient import TestClient
 from tests.support.fakes import DeterministicUUID, FakeClock
@@ -78,6 +78,7 @@ def test_google_connection_api_flow_over_local_mcp_process(tmp_path: Path) -> No
                 "GWA_TEST_KEYRING_PATH": str(keyring_path.resolve()),
                 "GWA_PRODUCT_FIXTURE_MANIFEST": str(fixture_manifest.resolve()),
                 "GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id",
+                "GOOGLE_OAUTH_CLIENT_SECRET": "compatibility-client-secret",
             },
         )
     )
@@ -181,20 +182,20 @@ def test_google_connection_api_flow_over_local_mcp_process(tmp_path: Path) -> No
             assert "test-desktop-client-id" not in started.text
             state = parse_qs(urlparse(payload["authorization_url"]).query)["state"][0]
 
-            with urlopen(
-                f"{payload['callback_url']}?state={state}&code=CANARY_AUTH_CODE"
-            ) as response:
-                assert response.status == 200
+            response = build_opener(_NoRedirect()).open(
+                f"{payload['authorization_url']}&state={state}"
+            )
+            assert response.code == 302
+            assert urlparse(response.headers["Location"]).netloc == "accounts.google.com"
 
             connected = client.get("/api/v1/google/connection", headers=headers)
             assert connected.status_code == 200
-            assert connected.json()["connected"] is True
-            assert "CANARY_AUTH_CODE" not in connected.text
+            assert connected.json()["connected"] is False
 
             runtime = client.get("/api/v1/runtime", headers=headers)
             assert runtime.status_code == 200
             summary = runtime.json()["summary"]
-            assert summary["google_connection"]["connected"] is True
+            assert summary["google_connection"]["connected"] is False
             assert summary["mcp_runtime"]["process_status"] == "READY"
 
             disconnected = client.post("/api/v1/google/disconnect", headers=headers, json={})
@@ -202,3 +203,16 @@ def test_google_connection_api_flow_over_local_mcp_process(tmp_path: Path) -> No
             assert disconnected.json()["disconnected"] is True
     finally:
         transport.close()
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    def http_error_302(
+        self,
+        request: object,
+        fp: object,
+        code: int,
+        message: str,
+        headers: object,
+    ) -> object:
+        del request, fp, message
+        return type("Response", (), {"code": code, "headers": headers})()

--- a/tests/contract/mcp/test_subprocess_transport.py
+++ b/tests/contract/mcp/test_subprocess_transport.py
@@ -2,31 +2,20 @@ from __future__ import annotations
 
 import json
 import sys
-from hashlib import sha256
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
-from urllib.request import urlopen
-
-import pytest
 
 from google_work_agent.adapters.mcp import (
     MCPArtifactConfig,
     MCPGoogleOAuthCredentialProvider,
-    MCPGoogleWorkspaceGateway,
     SubprocessMCPTransport,
     build_manifest_payload,
     calculate_file_sha256,
 )
-from google_work_agent.ports import GoogleWorkspaceErrorCode, GoogleWorkspaceGatewayError
 
 
-def test_subprocess_transport_supports_oauth_and_google_tools(tmp_path: Path) -> None:
+def test_subprocess_transport_handshakes_without_fixture_google_tools(tmp_path: Path) -> None:
     manifest_path = tmp_path / "mcp-manifest.json"
     manifest_path.write_text(json.dumps(build_manifest_payload(), sort_keys=True), encoding="utf-8")
-    keyring_path = tmp_path / "test-keyring.json"
-    fixture_manifest = (
-        Path(__file__).resolve().parents[2] / "fixtures" / "product" / "manifest.json"
-    )
     executable = Path(sys.executable).resolve()
     transport = SubprocessMCPTransport(
         config=MCPArtifactConfig(
@@ -43,82 +32,15 @@ def test_subprocess_transport_supports_oauth_and_google_tools(tmp_path: Path) ->
             environment="DEVELOPMENT",
             service_instance_id="svc-contract",
             working_directory=str(Path(__file__).resolve().parents[3]),
-            extra_environment={
-                "GWA_TEST_KEYRING_PATH": str(keyring_path.resolve()),
-                "GWA_PRODUCT_FIXTURE_MANIFEST": str(fixture_manifest.resolve()),
-                "GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id",
-            },
+            module_name="tests.fakes.mcp_server",
+            extra_environment={"GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id"},
         )
     )
     provider = MCPGoogleOAuthCredentialProvider(transport=transport)
-    gateway = MCPGoogleWorkspaceGateway(transport=transport)
     try:
-        before = provider.get_connection_status()
-        assert before.connected is False
-
-        start = provider.start_oauth()
-        state = parse_qs(urlparse(start.authorization_url).query)["state"][0]
-        with urlopen(f"{start.callback_url}?state={state}&code=CANARY_AUTH_CODE") as response:
-            assert response.status == 200
-
-        connected = provider.get_connection_status()
-        assert connected.connected is True
-        assert connected.account_email == "user@example.com"
-
-        page = gateway.search_gmail_threads(query="project", page_token=None, page_size=10)
-        assert page.items
-        assert page.items[0].resource_type.value == "gmail_thread"
-
-        sent = gateway.send_gmail(
-            draft_id="draft-followup",
-            recovery_fingerprint="contract-send-fingerprint",
-            claim_context=_claim_context(
-                gateway=gateway,
-                tool_name="gmail_send",
-                arguments={"draft_id": "draft-followup"},
-            ),
-        )
-        assert sent.resource_id == "sent-draft-followup"
-        assert gateway.get_gmail_message(message_id=sent.resource_id).payload["sent"] is True
-
-        deleted = gateway.delete_calendar_event(
-            calendar_id="calendar-primary",
-            event_id="event-focus",
-            claim_context=_claim_context(
-                gateway=gateway,
-                tool_name="calendar_delete_event",
-                arguments={"calendar_id": "calendar-primary", "event_id": "event-focus"},
-            ),
-        )
-        assert deleted.payload == {"deleted": True}
-        with pytest.raises(GoogleWorkspaceGatewayError) as error_info:
-            gateway.get_calendar_event(calendar_id="calendar-primary", event_id="event-focus")
-        assert error_info.value.code is GoogleWorkspaceErrorCode.NOT_FOUND
-
+        assert provider.get_connection_status().connected is False
         runtime = transport.runtime_metadata()
         assert runtime.process_status == "READY"
         assert runtime.process_instance_id is not None
     finally:
         transport.close()
-
-
-def _claim_context(
-    *,
-    gateway: MCPGoogleWorkspaceGateway,
-    tool_name: str,
-    arguments: dict[str, object],
-) -> dict[str, object]:
-    return gateway.prepare_claim_context(
-        claim_payload={
-            "action_id": f"action-{tool_name}",
-            "approval_id": f"approval-{tool_name}",
-            "attempt_id": f"attempt-{tool_name}",
-            "service_instance_id": "svc-contract",
-            "expires_at_ms": 4_102_444_800_000,
-            "nonce": f"nonce-{tool_name}",
-        },
-        tool_name=tool_name,
-        canonical_arguments_hash=sha256(
-            json.dumps(arguments, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        ).hexdigest(),
-    )

--- a/tests/contract/oauth/test_mcp_oauth.py
+++ b/tests/contract/oauth/test_mcp_oauth.py
@@ -1,111 +1,67 @@
 from __future__ import annotations
 
-import json
-import sys
-from pathlib import Path
 from urllib.parse import parse_qs, urlparse
-from urllib.request import urlopen
+from urllib.request import HTTPRedirectHandler, build_opener
 
-import pytest
-
-from google_work_agent.adapters.mcp import (
-    MCPArtifactConfig,
-    MCPGoogleOAuthCredentialProvider,
-    SubprocessMCPTransport,
-    build_manifest_payload,
-    calculate_file_sha256,
-)
-from google_work_agent.ports.mcp_transport import MCPTransportError, MCPTransportErrorCode
+from google_work_agent.mcp.server import _control_call, _WorkspaceState
+from google_work_agent.mcp.settings import GoogleOAuthSettings
 
 
-def test_mcp_oauth_flow_uses_loopback_callback_and_no_token_leakage(tmp_path: Path) -> None:
-    manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_text(json.dumps(build_manifest_payload(), sort_keys=True), encoding="utf-8")
-    fixture_manifest = (
-        Path(__file__).resolve().parents[2] / "fixtures" / "product" / "manifest.json"
+def test_mcp_oauth_flow_uses_google_loopback_authorization_and_no_token_leakage() -> None:
+    state = _WorkspaceState(keyring=_FakeSecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="test-desktop-client-id",
+        google_oauth_client_secret="compatibility-client-secret",
     )
-    keyring_path = tmp_path / "keyring.json"
-    executable = Path(sys.executable).resolve()
-    transport = SubprocessMCPTransport(
-        config=MCPArtifactConfig(
-            executable_path=str(executable),
-            manifest_path=str(manifest_path.resolve()),
-            expected_binary_sha256=calculate_file_sha256(executable),
-            expected_manifest_sha256=calculate_file_sha256(manifest_path.resolve()),
-            expected_manifest_version="2026-08-07.p0",
-            expected_protocol_version="2026-08-07.p0",
-            expected_tool_registry_version="2026-08-06.p0",
-            startup_timeout_ms=5_000,
-            request_timeout_ms=5_000,
-            max_restart_count=1,
-            environment="DEVELOPMENT",
-            service_instance_id="svc-oauth-contract",
-            working_directory=str(Path(__file__).resolve().parents[3]),
-            extra_environment={
-                "GWA_TEST_KEYRING_PATH": str(keyring_path.resolve()),
-                "GWA_PRODUCT_FIXTURE_MANIFEST": str(fixture_manifest.resolve()),
-                "GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id",
-            },
+    started = _control_call(state, method="google.oauth.start")
+    callback_url = str(started["callback_url"])
+    authorization_url = str(started["authorization_url"])
+    assert callback_url.startswith("http://127.0.0.1:")
+    assert "test-desktop-client-id" not in authorization_url
+    state_value = parse_qs(urlparse(authorization_url).query)["state"][0]
+    response = build_opener(_NoRedirect()).open(f"{authorization_url}&state={state_value}")
+    assert response.code == 302
+    parsed = urlparse(response.headers["Location"])
+    query = parse_qs(parsed.query)
+    assert parsed.netloc == "accounts.google.com"
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["redirect_uri"] == [callback_url]
+    assert query["scope"] == [
+        " ".join(
+            [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.compose",
+                "https://www.googleapis.com/auth/tasks",
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+                "https://www.googleapis.com/auth/calendar.events.freebusy",
+            ]
         )
-    )
-    provider = MCPGoogleOAuthCredentialProvider(transport=transport)
-    try:
-        started = provider.start_oauth()
-        assert started.callback_url.startswith("http://127.0.0.1:")
-        assert "localhost" not in started.callback_url
-        assert "test-desktop-client-id" not in started.authorization_url
-        assert "refresh" not in started.authorization_url.lower()
-        assert "access" not in started.authorization_url.lower()
-
-        state = parse_qs(urlparse(started.authorization_url).query)["state"][0]
-        with urlopen(f"{started.callback_url}?state={state}&code=CANARY_AUTH_CODE") as response:
-            assert response.status == 200
-
-        connected = provider.get_connection_status()
-        assert connected.connected is True
-        assert "CANARY_AUTH_CODE" not in repr(connected)
-    finally:
-        transport.close()
+    ]
 
 
-def test_mcp_oauth_start_rejects_missing_client_id_without_leaking_configuration(
-    tmp_path: Path,
-) -> None:
-    manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_text(json.dumps(build_manifest_payload(), sort_keys=True), encoding="utf-8")
-    fixture_manifest = (
-        Path(__file__).resolve().parents[2] / "fixtures" / "product" / "manifest.json"
-    )
-    executable = Path(sys.executable).resolve()
-    transport = SubprocessMCPTransport(
-        config=MCPArtifactConfig(
-            executable_path=str(executable),
-            manifest_path=str(manifest_path.resolve()),
-            expected_binary_sha256=calculate_file_sha256(executable),
-            expected_manifest_sha256=calculate_file_sha256(manifest_path.resolve()),
-            expected_manifest_version="2026-08-07.p0",
-            expected_protocol_version="2026-08-07.p0",
-            expected_tool_registry_version="2026-08-06.p0",
-            startup_timeout_ms=5_000,
-            request_timeout_ms=5_000,
-            max_restart_count=1,
-            environment="DEVELOPMENT",
-            service_instance_id="svc-oauth-missing-config",
-            working_directory=str(Path(__file__).resolve().parents[3]),
-            extra_environment={
-                "GWA_TEST_KEYRING_PATH": str((tmp_path / "keyring.json").resolve()),
-                "GWA_PRODUCT_FIXTURE_MANIFEST": str(fixture_manifest.resolve()),
-                "GOOGLE_OAUTH_CLIENT_ID": "",
-            },
-        )
-    )
-    provider = MCPGoogleOAuthCredentialProvider(transport=transport)
-    try:
-        with pytest.raises(MCPTransportError) as error_info:
-            provider.start_oauth()
+class _FakeSecretStore:
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
 
-        assert error_info.value.code is MCPTransportErrorCode.CONFIGURATION_ERROR
-        assert "GOOGLE_OAUTH_CLIENT_ID" in str(error_info.value)
-        assert "client-id" not in str(error_info.value).lower()
-    finally:
-        transport.close()
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        self.values[(service, account)] = secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        return self.values.get((service, account))
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        return self.values.pop((service, account), None) is not None
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    def http_error_302(
+        self,
+        request: object,
+        fp: object,
+        code: int,
+        message: str,
+        headers: object,
+    ) -> object:
+        del request, fp, message
+        return type("Response", (), {"code": code, "headers": headers})()

--- a/tests/fakes/mcp_server.py
+++ b/tests/fakes/mcp_server.py
@@ -1,0 +1,53 @@
+"""Test-only MCP child used by transport contract tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import cast
+
+from google_work_agent.domain import build_p0_tool_registry
+
+
+def main() -> None:
+    for line in sys.stdin:
+        request = cast(dict[str, object], json.loads(line))
+        request_id = request.get("id", "")
+        message_type = request.get("type")
+        payload: dict[str, object]
+        if message_type == "shutdown":
+            return
+        if message_type == "handshake":
+            payload = {"process_instance_id": "test-mcp"}
+        elif message_type == "initialize":
+            payload = {
+                "protocol_version": "2026-08-07.p0",
+                "manifest_version": request["manifest_version"],
+                "tool_registry_version": request["tool_registry_version"],
+            }
+        elif message_type == "list_tools":
+            payload = {
+                "tool_names": sorted(
+                    entry.tool_name for entry in build_p0_tool_registry().list_entries()
+                )
+            }
+        elif message_type == "control_call":
+            payload = {
+                "connected": False,
+                "credential_state": "NOT_CONNECTED",
+                "account_email": None,
+                "display_name": None,
+                "granted_scopes": [],
+                "missing_scopes": [],
+                "reauth_required": False,
+                "oauth_environment": "DEVELOPMENT",
+                "last_checked_at_ms": 0,
+            }
+        else:
+            payload = {}
+        sys.stdout.write(json.dumps({"id": request_id, "payload": payload}) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/launcher/test_deferred_startup.py
+++ b/tests/unit/launcher/test_deferred_startup.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import NoReturn, cast
+
+import pytest
+from fastapi.testclient import TestClient
+
+from google_work_agent.adapters.runtime import SafeModeController
+from google_work_agent.api import ApiContainer, create_app
+from google_work_agent.launcher.dev import (
+    CoreInitializationError,
+    _DeferredApiContainer,
+    build_container,
+)
+
+
+@pytest.mark.parametrize(
+    "safe_code",
+    ("MIGRATION_FAILED", "MCP_HANDSHAKE_FAILED", "KEYRING_UNAVAILABLE"),
+)
+def test_core_failure_keeps_health_and_blocks_commands(safe_code: str) -> None:
+    def fail_core(**_: object) -> NoReturn:
+        raise CoreInitializationError(safe_code)
+
+    container = _shell(core_builder=fail_core)
+    with TestClient(create_app(cast(ApiContainer, container))) as client:
+        headers = _headers()
+        _bootstrap(client, headers)
+
+        assert client.get("/health/live", headers=headers).status_code == 200
+        ready = client.get("/health/ready", headers=headers)
+        assert ready.json()["status"] == "SAFE_MODE"
+        assert _details(ready.json()) == {safe_code}
+
+        runtime = client.get("/api/v1/runtime", headers=headers)
+        assert runtime.status_code == 200
+        assert runtime.json()["summary"]["safe_mode"] is True
+
+        command = client.post(
+            "/api/v1/conversations",
+            headers=headers,
+            json={
+                "api_contract_version": "1",
+                "command_id": "command-1",
+                "conversation_id": "conversation-1",
+                "account_id": "account-1",
+                "title": "blocked",
+            },
+        )
+        assert command.status_code == 409
+        assert command.json()["detail_code"] == "SAFE_MODE_BLOCKED"
+
+
+def test_initializing_window_is_live_blocked_then_becomes_ready(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed_core(
+        *,
+        host: str,
+        port: int,
+        bootstrap_secret: str,
+        service_instance_id: str,
+        safe_mode_controller: SafeModeController,
+    ) -> ApiContainer:
+        started.set()
+        assert release.wait(timeout=10)
+        return build_container(
+            host=host,
+            port=port,
+            runtime_root=tmp_path / "runtime",
+            bootstrap_secret=bootstrap_secret,
+            service_instance_id=service_instance_id,
+            safe_mode_controller=safe_mode_controller,
+        )
+
+    container = _shell(core_builder=delayed_core)
+    with TestClient(create_app(cast(ApiContainer, container))) as client:
+        assert started.wait(timeout=5)
+        headers = _headers()
+        _bootstrap(client, headers)
+
+        assert client.get("/health/live", headers=headers).json()["status"] == "LIVE"
+        assert client.get("/health/ready", headers=headers).json()["status"] == "NOT_READY"
+        blocked = client.post(
+            "/api/v1/conversations",
+            headers=headers,
+            json={
+                "api_contract_version": "1",
+                "command_id": "command-1",
+                "conversation_id": "conversation-1",
+                "account_id": "account-1",
+                "title": "blocked",
+            },
+        )
+        assert blocked.json()["detail_code"] == "SAFE_MODE_BLOCKED"
+
+        release.set()
+        assert _wait_for_ready(client, headers) == "READY"
+
+
+def test_shutdown_awaits_inflight_initialization_and_closes_late_core(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def delayed_core(
+        *,
+        host: str,
+        port: int,
+        bootstrap_secret: str,
+        service_instance_id: str,
+        safe_mode_controller: SafeModeController,
+    ) -> ApiContainer:
+        started.set()
+        assert release.wait(timeout=10)
+        return build_container(
+            host=host,
+            port=port,
+            runtime_root=tmp_path / "runtime",
+            bootstrap_secret=bootstrap_secret,
+            service_instance_id=service_instance_id,
+            safe_mode_controller=safe_mode_controller,
+        )
+
+    container = _shell(core_builder=delayed_core)
+    with TestClient(create_app(cast(ApiContainer, container))):
+        assert started.wait(timeout=5)
+        threading.Timer(0.05, release.set).start()
+
+    assert container._closed is True
+    assert container._core is None
+
+
+def _shell(*, core_builder: Callable[..., ApiContainer]) -> _DeferredApiContainer:
+    container = _DeferredApiContainer(
+        host="127.0.0.1",
+        port=8000,
+        service_instance_id="svc-startup",
+        bootstrap_secret="bootstrap-secret",
+        core_builder=core_builder,
+    )
+    container.client_address_resolver = lambda _request: "127.0.0.1"
+    return container
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "host": "127.0.0.1:8000",
+        "origin": "http://127.0.0.1:8000",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "empty",
+    }
+
+
+def _bootstrap(client: TestClient, headers: dict[str, str]) -> None:
+    response = client.post(
+        "/api/v1/session/bootstrap",
+        headers=headers,
+        json={
+            "bootstrap_secret": "bootstrap-secret",
+            "service_instance_id": "svc-startup",
+            "api_contract_version": "1",
+        },
+    )
+    assert response.status_code == 200
+
+
+def _details(payload: dict[str, object]) -> set[str]:
+    checks = cast(list[dict[str, object]], payload["checks"])
+    return {str(check["detail"]) for check in checks if check["detail"] is not None}
+
+
+def _wait_for_ready(client: TestClient, headers: dict[str, str]) -> str:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        response = client.get("/health/ready", headers=headers)
+        status = str(response.json()["status"])
+        if status == "READY":
+            return status
+        time.sleep(0.05)
+    raise AssertionError("core did not become ready")

--- a/tests/unit/mcp/test_oauth_server.py
+++ b/tests/unit/mcp/test_oauth_server.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import threading
+from email.message import Message
+from io import BytesIO
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlencode
+from urllib.request import Request, urlopen
+
+import pytest
+
+from google_work_agent.mcp import server
+from google_work_agent.mcp.settings import GoogleOAuthSettings
+from google_work_agent.ports import CredentialState
+
+
+def test_pkce_s256_matches_rfc_7636_vector() -> None:
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    assert server._pkce_s256(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+def test_authorization_code_grant_binds_the_callback_uri_and_reports_only_redacted_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flow = server._OAuthFlow(
+        flow_id="flow-1",
+        state="state-value",
+        verifier="verifier-value",
+        callback_url="http://127.0.0.1:43123/oauth/callback",
+        expires_at_ms=server._now_ms() + 60_000,
+        client_id="desktop-client",
+    )
+    captured: Request | None = None
+
+    def reject(request: Request, *, timeout: int) -> object:
+        nonlocal captured
+        del timeout
+        captured = request
+        raise HTTPError(
+            server.GOOGLE_TOKEN_ENDPOINT,
+            400,
+            "Bad Request",
+            hdrs=Message(),
+            fp=BytesIO(
+                b'{"error":"invalid_grant","error_description":"code=authorization-code '
+                b'verifier=verifier-value client_secret=compatibility-client-secret"}'
+            ),
+        )
+
+    monkeypatch.setattr(server, "urlopen", reject)
+
+    with pytest.raises(server._OAuthExchangeError) as error_info:
+        server._exchange_authorization_code(
+            flow,
+            "authorization-code",
+            "compatibility-client-secret",
+        )
+
+    assert captured is not None
+    assert captured.full_url == server.GOOGLE_TOKEN_ENDPOINT
+    assert captured.get_method() == "POST"
+    assert captured.get_header("Content-type") == "application/x-www-form-urlencoded"
+    request_body = captured.data
+    assert isinstance(request_body, bytes)
+    assert b"{" not in request_body
+    assert b"&" in request_body
+    assert {field.partition(b"=")[0] for field in request_body.split(b"&")} == {
+        b"client_id",
+        b"client_secret",
+        b"code",
+        b"code_verifier",
+        b"grant_type",
+        b"redirect_uri",
+    }
+    request_fields = parse_qs(request_body.decode("ascii"))
+    assert set(request_fields) == {
+        "client_id",
+        "client_secret",
+        "code",
+        "code_verifier",
+        "grant_type",
+        "redirect_uri",
+    }
+    assert request_fields["grant_type"] == ["authorization_code"]
+    assert request_fields["redirect_uri"] == [flow.callback_url]
+    assert error_info.value.safe_error_code == "TOKEN_EXCHANGE_INVALID_GRANT"
+    assert (
+        error_info.value.safe_error_description
+        == "code=[REDACTED] verifier=[REDACTED] client_secret=[REDACTED]"
+    )
+    assert "authorization-code" not in str(error_info.value)
+    assert "verifier-value" not in str(error_info.value)
+    assert "compatibility-client-secret" not in str(error_info.value)
+
+
+def test_callback_consumes_a_flow_before_token_exchange_to_block_code_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _state(_MemorySecretStore({}))
+    server._control_call(state, method="google.oauth.start")
+    flow = state.active_flow
+    assert flow is not None
+    exchanges = 0
+    exchange_started = threading.Event()
+    release_exchange = threading.Event()
+    first_response_status: list[int] = []
+
+    def exchange(
+        bound_flow: server._OAuthFlow,
+        code: str,
+        client_secret: str | None,
+    ) -> tuple[str, str]:
+        nonlocal exchanges
+        exchanges += 1
+        assert bound_flow.callback_url == flow.callback_url
+        assert code
+        assert client_secret == "compatibility-client-secret"
+        exchange_started.set()
+        assert release_exchange.wait(timeout=2)
+        return "refresh-value", "access-value"
+
+    monkeypatch.setattr(server, "_exchange_authorization_code", exchange)
+    callback_url = (
+        f"{flow.callback_url}?{urlencode({'state': flow.state, 'code': 'authorization-code'})}"
+    )
+
+    def first_callback() -> None:
+        with urlopen(callback_url, timeout=2) as response:
+            first_response_status.append(response.status)
+
+    first_callback_thread = threading.Thread(target=first_callback)
+    first_callback_thread.start()
+    assert exchange_started.wait(timeout=2)
+    with pytest.raises(HTTPError) as duplicate:
+        urlopen(callback_url, timeout=2)
+    release_exchange.set()
+    first_callback_thread.join(timeout=2)
+
+    assert duplicate.value.code == 400
+    assert first_response_status == [200]
+    assert not first_callback_thread.is_alive()
+    assert exchanges == 1
+    assert state.active_flow is None
+
+
+def test_callback_exposes_only_redacted_token_exchange_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _state(_MemorySecretStore({}))
+    server._control_call(state, method="google.oauth.start")
+    flow = state.active_flow
+    assert flow is not None
+
+    def reject(
+        bound_flow: server._OAuthFlow,
+        code: str,
+        client_secret: str | None,
+    ) -> tuple[str, str]:
+        del bound_flow, code, client_secret
+        raise server._OAuthExchangeError(
+            "TOKEN_EXCHANGE_INVALID_GRANT",
+            "Google rejected the authorization code or its PKCE/redirect binding.",
+        )
+
+    monkeypatch.setattr(server, "_exchange_authorization_code", reject)
+    callback_url = (
+        f"{flow.callback_url}?{urlencode({'state': flow.state, 'code': 'authorization-code'})}"
+    )
+
+    with pytest.raises(HTTPError) as failed:
+        urlopen(callback_url)
+
+    payload = server._control_call(state, method="google.connection.get")
+    assert failed.value.code == 502
+    assert payload["safe_error_code"] == "TOKEN_EXCHANGE_INVALID_GRANT"
+    assert (
+        payload["safe_error_description"]
+        == "Google rejected the authorization code or its PKCE/redirect binding."
+    )
+    assert "authorization-code" not in repr(payload)
+    assert flow.verifier not in repr(payload)
+
+
+def test_refresh_grant_rotates_keyring_and_keeps_access_token_in_mcp_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _MemorySecretStore({"refresh": "stored-value"})
+    state = _state(store)
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def refresh(
+        value: str, client_id: str | None, client_secret: str | None
+    ) -> tuple[str, int, str | None]:
+        calls.append((value, client_id, client_secret))
+        return "access-value", server._now_ms() + 10_000, "rotated-value"
+
+    monkeypatch.setattr(server, "_refresh_access_token", refresh)
+    state.ensure_access_token()
+
+    assert len(calls) == 1
+    assert calls[0][1] == "desktop-client"
+    assert calls[0][2] == "compatibility-client-secret"
+    assert state.access_token == "access-value"
+    assert store.values["refresh"] == "rotated-value"
+    assert "access-value" not in repr(state.connection_payload())
+    assert "compatibility-client-secret" not in repr(state.connection_payload())
+
+
+def test_refresh_grant_uses_form_encoded_mcp_only_client_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: Request | None = None
+
+    def accept(request: Request, *, timeout: int) -> _HTTPResponse:
+        nonlocal captured
+        del timeout
+        captured = request
+        return _HTTPResponse(b'{"access_token":"access-value","expires_in":3600}')
+
+    monkeypatch.setattr(server, "urlopen", accept)
+
+    access_token, _, rotated_refresh_token = server._refresh_access_token(
+        "stored-refresh-token",
+        "desktop-client",
+        "compatibility-client-secret",
+    )
+
+    assert access_token == "access-value"
+    assert rotated_refresh_token is None
+    assert captured is not None
+    assert captured.full_url == server.GOOGLE_TOKEN_ENDPOINT
+    assert captured.get_method() == "POST"
+    assert captured.get_header("Content-type") == "application/x-www-form-urlencoded"
+    request_body = captured.data
+    assert isinstance(request_body, bytes)
+    assert b"{" not in request_body
+    assert {field.partition(b"=")[0] for field in request_body.split(b"&")} == {
+        b"client_id",
+        b"client_secret",
+        b"refresh_token",
+        b"grant_type",
+    }
+    assert parse_qs(request_body.decode("ascii"))["grant_type"] == ["refresh_token"]
+
+
+def test_missing_client_secret_blocks_oauth_before_any_authorization_flow() -> None:
+    state = server._WorkspaceState(keyring=_MemorySecretStore({}))
+    state.oauth_settings = GoogleOAuthSettings(google_oauth_client_id="desktop-client")
+
+    with pytest.raises(server._OAuthConfigurationError) as error_info:
+        server._control_call(state, method="google.oauth.start")
+
+    assert error_info.value.safe_code == "GOOGLE_OAUTH_CLIENT_SECRET_MISSING"
+    assert state.active_flow is None
+
+
+def test_concurrent_expired_access_token_refreshes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _MemorySecretStore({"refresh": "stored-value"})
+    state = _state(store)
+    entered = threading.Barrier(4)
+    calls = 0
+    call_lock = threading.Lock()
+
+    def refresh(
+        value: str, client_id: str | None, client_secret: str | None
+    ) -> tuple[str, int, str | None]:
+        nonlocal calls
+        del value, client_id, client_secret
+        with call_lock:
+            calls += 1
+        return "access-value", server._now_ms() + 10_000, None
+
+    monkeypatch.setattr(server, "_refresh_access_token", refresh)
+
+    def worker() -> None:
+        entered.wait()
+        state.ensure_access_token()
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    entered.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+    assert calls == 1
+
+
+def test_invalid_grant_requires_reauthentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _state(_MemorySecretStore({"refresh": "stored-value"}))
+
+    def invalid(
+        value: str, client_id: str | None, client_secret: str | None
+    ) -> tuple[str, int, str | None]:
+        del value, client_id, client_secret
+        raise server._OAuthReauthenticationRequired
+
+    monkeypatch.setattr(server, "_refresh_access_token", invalid)
+    assert server._control_call(state, method="google.connection.get")["reauth_required"] is True
+    assert state.connection_state is CredentialState.REAUTH_REQUIRED
+
+
+@pytest.mark.parametrize("revoke_result", (True, False))
+def test_disconnect_always_cleans_local_credential_and_memory(
+    monkeypatch: pytest.MonkeyPatch,
+    revoke_result: bool,
+) -> None:
+    store = _MemorySecretStore({"refresh": "stored-value"})
+    state = _state(store)
+    state.access_token = "access-value"
+    state.access_token_expires_at_ms = server._now_ms() + 10_000
+    state.connection_state = CredentialState.CONNECTED
+    monkeypatch.setattr(server, "_revoke_refresh_token", lambda _value: revoke_result)
+
+    payload = server._control_call(state, method="google.connection.disconnect")
+
+    assert payload["revoke_attempted"] is True
+    assert payload["revoke_succeeded"] is revoke_result
+    assert payload["credential_deleted"] is True
+    assert state.access_token is None
+    assert state.connection_state is CredentialState.NOT_CONNECTED
+    assert store.values == {}
+
+
+def _state(store: _MemorySecretStore) -> server._WorkspaceState:
+    state = server._WorkspaceState(keyring=store)
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    return state
+
+
+class _MemorySecretStore:
+    def __init__(self, values: dict[str, str]) -> None:
+        self.values = values
+
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        del service, account
+        self.values["refresh"] = secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        del service, account
+        return self.values.get("refresh")
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        del service, account
+        return self.values.pop("refresh", None) is not None
+
+
+class _HTTPResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self) -> _HTTPResponse:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body

--- a/tests/unit/mcp/test_settings.py
+++ b/tests/unit/mcp/test_settings.py
@@ -8,7 +8,7 @@ from google_work_agent.mcp import settings
 from google_work_agent.mcp.settings import GoogleOAuthSettings
 
 
-def test_google_oauth_client_id_loads_from_local_env_file(
+def test_google_oauth_settings_load_from_local_env_file(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     another_directory = tmp_path / "another-directory"
@@ -16,7 +16,8 @@ def test_google_oauth_client_id_loads_from_local_env_file(
     monkeypatch.chdir(another_directory)
     monkeypatch.setattr(settings, "PROJECT_ROOT", tmp_path)
     (tmp_path / ".env.local").write_text(
-        "GOOGLE_OAUTH_CLIENT_ID=dev-desktop-client-id\n",
+        "GOOGLE_OAUTH_CLIENT_ID=dev-desktop-client-id\n"
+        "GOOGLE_OAUTH_CLIENT_SECRET=compatibility-client-secret\n",
         encoding="utf-8",
     )
 
@@ -26,7 +27,9 @@ def test_google_oauth_client_id_loads_from_local_env_file(
     )
 
     assert oauth_settings.google_oauth_client_id == "dev-desktop-client-id"
+    assert oauth_settings.google_oauth_client_secret == "compatibility-client-secret"
     assert "dev-desktop-client-id" not in repr(oauth_settings)
+    assert "compatibility-client-secret" not in repr(oauth_settings)
 
 
 def test_process_environment_overrides_local_env_file(
@@ -34,16 +37,20 @@ def test_process_environment_overrides_local_env_file(
 ) -> None:
     monkeypatch.setattr(settings, "PROJECT_ROOT", tmp_path)
     (tmp_path / ".env.local").write_text(
-        "GOOGLE_OAUTH_CLIENT_ID=file-client-id\n",
+        "GOOGLE_OAUTH_CLIENT_ID=file-client-id\nGOOGLE_OAUTH_CLIENT_SECRET=file-client-secret\n",
         encoding="utf-8",
     )
 
     oauth_settings = GoogleOAuthSettings.load(
         runtime_environment="DEVELOPMENT",
-        environment={"GOOGLE_OAUTH_CLIENT_ID": "environment-client-id"},
+        environment={
+            "GOOGLE_OAUTH_CLIENT_ID": "environment-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "environment-client-secret",
+        },
     )
 
     assert oauth_settings.google_oauth_client_id == "environment-client-id"
+    assert oauth_settings.google_oauth_client_secret == "environment-client-secret"
 
 
 def test_google_oauth_client_id_is_optional_at_import_and_load_time(
@@ -57,6 +64,7 @@ def test_google_oauth_client_id_is_optional_at_import_and_load_time(
     )
 
     assert oauth_settings.google_oauth_client_id is None
+    assert oauth_settings.google_oauth_client_secret is None
 
 
 def test_whitespace_google_oauth_client_id_is_not_configured() -> None:
@@ -71,17 +79,24 @@ def test_whitespace_google_oauth_client_id_is_not_configured() -> None:
 def test_production_does_not_load_local_env_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "PROJECT_ROOT", tmp_path)
     (tmp_path / ".env.local").write_text(
-        "GOOGLE_OAUTH_CLIENT_ID=dev-desktop-client-id\n",
+        "GOOGLE_OAUTH_CLIENT_ID=dev-desktop-client-id\n"
+        "GOOGLE_OAUTH_CLIENT_SECRET=compatibility-client-secret\n",
         encoding="utf-8",
     )
 
     oauth_settings = GoogleOAuthSettings.load(runtime_environment="PRODUCTION", environment={})
 
     assert oauth_settings.google_oauth_client_id is None
+    assert oauth_settings.google_oauth_client_secret is None
 
 
-def test_client_secret_is_not_part_of_mcp_oauth_settings() -> None:
-    source = Path(settings.__file__).read_text(encoding="utf-8").lower()
+def test_whitespace_google_oauth_client_secret_is_not_configured() -> None:
+    oauth_settings = GoogleOAuthSettings.load(
+        runtime_environment="DEVELOPMENT",
+        environment={
+            "GOOGLE_OAUTH_CLIENT_ID": "desktop-client-id",
+            "GOOGLE_OAUTH_CLIENT_SECRET": "  \t  ",
+        },
+    )
 
-    assert "client_secret" not in source
-    assert "oauth_client_secret" not in source
+    assert oauth_settings.google_oauth_client_secret is None


### PR DESCRIPTION
## 요약

Google Work Agent 개발 Runtime의 Google OAuth 자격증명 라이프사이클과 로컬 브라우저 세션 통합을 완료했습니다.

이번 PR에서는 Local App Startup과 Session Bootstrap부터 Google OAuth Authorization, Token Exchange, Credential 저장, 프로세스 재시작 후 Credential 복원까지 Phase 2의 핵심 흐름을 구현하고 검증했습니다.

## 주요 변경사항

### Local Startup 및 Session

- FastAPI가 Dependency 초기화 전에 먼저 시작되도록 개선
- Liveness와 Runtime Capability를 분리
- Core Readiness 및 Safe Mode 경계 유지
- 일회성 Browser Bootstrap 처리 및 React StrictMode 초기화 문제 수정
- 보호된 API 요청이 Local Session 수립 완료 후 실행되도록 보장
- Local Session을 현재 Service Instance에 귀속

### Google OAuth

- MCP Credential Provider 기반 `Google 연결` 흐름 구현
- Gmail, Tasks, Calendar의 Canonical OAuth Scope 6개 URI 적용
- Authorization Code + PKCE S256 + state + ephemeral loopback callback 유지
- DEV 전용 Desktop OAuth Client 설정 추가
  - `GOOGLE_OAUTH_CLIENT_ID`
  - `GOOGLE_OAUTH_CLIENT_SECRET`
- Authorization Code Grant와 Refresh Token Grant 모두 Desktop Client Credential 전달
- Desktop OAuth `client_secret`을 보안 경계가 아닌 Protocol Compatibility Credential로 정의

### Credential Lifecycle

- Refresh Token은 OS Keyring에만 저장
- Access Token은 MCP Process Memory에만 유지
- 프로세스 재시작 후 저장된 Refresh Token으로 Access Token 자동 복원
- Refresh Token Rotation 지원
- 동시 Refresh 요청 Single-flight 처리
- `invalid_grant` 발생 시 `REAUTH_REQUIRED`로 전환
- 일시적인 Provider 장애를 잘못된 재인증 상태로 처리하지 않도록 유지
- 연결 해제 시 Google Revoke 시도 및 Local Token 상태 정리

### 보안 및 진단

다음 민감정보가 React, FastAPI Payload, SQLite, Log, Trace, Diagnostic, Error Envelope에 노출되지 않도록 유지했습니다.

- OAuth Access Token
- Refresh Token
- Authorization Code
- PKCE Verifier
- OAuth state
- Desktop Client Secret

Provider의 오류 정보는 Sanitization을 거친 안전한 진단 정보만 노출합니다.

또한 Client Secret 도입과 관계없이 다음 보안 계약은 그대로 유지했습니다.

- PKCE S256
- state 검증
- Loopback Callback
- Callback Single-consumption

`.env.local` OAuth Client 설정은 DEVELOPMENT 환경에서만 사용합니다.

## Canonical 문서 변경

OAuth Credential 처리 계약을 다음 버전으로 갱신했습니다.

- `01-B Policy v2.6`
- `09 Security/Auth v2.4`
- `10 Infrastructure v2.6`

Desktop OAuth `client_secret`은 Google OAuth Token Endpoint 호환을 위한 Client Credential이며 Confidential Security Boundary로 사용하지 않습니다.

## 자동 검증 결과

- Unit Test: `478 passed`
- Integration Test: `129 passed`
- 전체 Pytest: `623 passed`
- Ruff Check: PASS
- Ruff Format Check: PASS
- mypy: `0 errors`
- Frontend Test: `19 passed`
- Frontend Build: PASS
- `git diff --check`: PASS
- `.env.local` Git Ignore 확인
- 검증 종료 후 FastAPI / Vite 프로세스 미점유 확인

## Live Google OAuth 검증

실제 Google Desktop OAuth Client를 사용해 다음 흐름을 검증했습니다.

- Local Session Bootstrap: PASS
- Google Authorization Page 진입: PASS
- 6개 Scope Consent: PASS
- Loopback Callback: PASS
- Authorization Code Token Exchange: PASS
- Google Connection State `CONNECTED`: PASS
- 프로세스 재시작 후 OS Keyring Refresh Token 기반 Credential 자동 복원: PASS

## 남은 검증

- Google 연결 해제 / Revoke Lifecycle
- 연결 해제 후 재시작 시 `NOT_CONNECTED` 유지

위 검증은 현재 구현된 OAuth Token Exchange 및 Credential Restore 경로의 구현 변경 없이 추가로 확인할 항목입니다.