### PR TITLE
[feat] Google OAuth 및 Gmail·Tasks·Calendar 실제 연동 구현

### DIFF
--- a/src/google_work_agent/adapters/mcp/gateway.py
+++ b/src/google_work_agent/adapters/mcp/gateway.py
@@ -17,6 +17,7 @@ from google_work_agent.ports import (
     ResourcePage,
     ResourceSnapshot,
     ResourceType,
+    TimeRange,
 )
 
 
@@ -182,8 +183,20 @@ class MCPGoogleWorkspaceGateway(GoogleWorkspaceGateway):
             {"calendar_id": calendar_id, "page_token": page_token, "page_size": page_size},
         )
 
-    def query_freebusy(self, *, calendar_ids: tuple[str, ...]) -> tuple[FreeBusyCalendar, ...]:
-        payload = self._call("calendar_query_freebusy", {"calendar_ids": list(calendar_ids)})
+    def query_freebusy(
+        self,
+        *,
+        calendar_ids: tuple[str, ...],
+        time_range: TimeRange,
+    ) -> tuple[FreeBusyCalendar, ...]:
+        payload = self._call(
+            "calendar_query_freebusy",
+            {
+                "calendar_ids": list(calendar_ids),
+                "time_min": time_range.start,
+                "time_max": time_range.end,
+            },
+        )
         results: list[FreeBusyCalendar] = []
         for item in cast(list[dict[str, object]], payload["calendars"]):
             intervals = tuple(
@@ -310,6 +323,18 @@ class MCPGoogleWorkspaceGateway(GoogleWorkspaceGateway):
 
 
 def _google_error_from_transport(error: MCPTransportError) -> GoogleWorkspaceGatewayError:
+    tool_error_map = {
+        "INVALID_ARGUMENT": GoogleWorkspaceErrorCode.INVALID_ARGUMENT,
+        "REAUTH_REQUIRED": GoogleWorkspaceErrorCode.AUTH_EXPIRED,
+        "OAUTH_NOT_CONNECTED": GoogleWorkspaceErrorCode.AUTH_EXPIRED,
+        "PERMISSION_DENIED": GoogleWorkspaceErrorCode.PERMISSION_DENIED,
+        "NOT_FOUND": GoogleWorkspaceErrorCode.NOT_FOUND,
+        "RATE_LIMITED": GoogleWorkspaceErrorCode.RATE_LIMITED,
+        "UPSTREAM_5XX": GoogleWorkspaceErrorCode.UPSTREAM_5XX,
+        "TIMEOUT": GoogleWorkspaceErrorCode.TIMEOUT,
+        "INVALID_MCP_OUTPUT": GoogleWorkspaceErrorCode.RESPONSE_MALFORMED,
+        "MCP_UNAVAILABLE": GoogleWorkspaceErrorCode.CONNECTION_CLOSED,
+    }
     code_map = {
         MCPTransportErrorCode.TIMEOUT: GoogleWorkspaceErrorCode.TIMEOUT,
         MCPTransportErrorCode.CONNECTION_CLOSED: GoogleWorkspaceErrorCode.CONNECTION_CLOSED,
@@ -322,7 +347,7 @@ def _google_error_from_transport(error: MCPTransportError) -> GoogleWorkspaceGat
         MCPTransportErrorCode.ARTIFACT_REJECTED: GoogleWorkspaceErrorCode.CONNECTION_CLOSED,
     }
     return GoogleWorkspaceGatewayError(
-        code=code_map[error.code],
+        code=tool_error_map.get(str(error), code_map[error.code]),
         message=dumps({"safe_error": error.code.value, "detail": str(error)}, sort_keys=True),
         delivered=error.dispatch_started,
         mutated=False,

--- a/src/google_work_agent/api/routes/resources.py
+++ b/src/google_work_agent/api/routes/resources.py
@@ -11,7 +11,11 @@ from google_work_agent.api.dependencies import (
 )
 from google_work_agent.api.errors import ApiError
 from google_work_agent.api.schemas.resources import ResourceListResponse
-from google_work_agent.ports import EndpointPolicy
+from google_work_agent.ports import (
+    EndpointPolicy,
+    GoogleWorkspaceErrorCode,
+    GoogleWorkspaceGatewayError,
+)
 
 router = APIRouter(prefix="/api/v1/resources")
 
@@ -40,7 +44,10 @@ def list_gmail_resources(
             request_id=request.state.request_id,
             detail_code="RESOURCE_QUERY_UNAVAILABLE",
         )
-    page = service.list_gmail_threads(query=query, page_token=page_token, page_size=page_size)
+    try:
+        page = service.list_gmail_threads(query=query, page_token=page_token, page_size=page_size)
+    except GoogleWorkspaceGatewayError as error:
+        _raise_resource_error(error, request_id=request.state.request_id)
     return ResourceListResponse(
         source=page.source,
         items=[asdict(item) for item in page.items],
@@ -73,11 +80,14 @@ def list_task_resources(
             request_id=request.state.request_id,
             detail_code="RESOURCE_QUERY_UNAVAILABLE",
         )
-    page = service.list_tasks(
-        task_list_id=task_list_id,
-        page_token=page_token,
-        page_size=page_size,
-    )
+    try:
+        page = service.list_tasks(
+            task_list_id=task_list_id,
+            page_token=page_token,
+            page_size=page_size,
+        )
+    except GoogleWorkspaceGatewayError as error:
+        _raise_resource_error(error, request_id=request.state.request_id)
     return ResourceListResponse(
         source=page.source,
         items=[asdict(item) for item in page.items],
@@ -110,14 +120,43 @@ def list_calendar_resources(
             request_id=request.state.request_id,
             detail_code="RESOURCE_QUERY_UNAVAILABLE",
         )
-    page = service.list_calendar_resources(
-        calendar_id=calendar_id,
-        page_token=page_token,
-        page_size=page_size,
-    )
+    try:
+        page = service.list_calendar_resources(
+            calendar_id=calendar_id,
+            page_token=page_token,
+            page_size=page_size,
+        )
+    except GoogleWorkspaceGatewayError as error:
+        _raise_resource_error(error, request_id=request.state.request_id)
     return ResourceListResponse(
         source=page.source,
         items=[asdict(item) for item in page.items],
         next_page_token=page.next_page_token,
         api_contract_version=container.api_contract_version,
     )
+
+
+def _raise_resource_error(error: GoogleWorkspaceGatewayError, *, request_id: str) -> None:
+    mapping = {
+        GoogleWorkspaceErrorCode.INVALID_ARGUMENT: ("INVALID_ARGUMENT", 422, False),
+        GoogleWorkspaceErrorCode.AUTH_EXPIRED: ("AUTH_REQUIRED", 401, False),
+        GoogleWorkspaceErrorCode.PERMISSION_DENIED: ("PERMISSION_DENIED", 403, False),
+        GoogleWorkspaceErrorCode.NOT_FOUND: ("NOT_FOUND", 404, False),
+        GoogleWorkspaceErrorCode.RATE_LIMITED: ("UPSTREAM_UNAVAILABLE", 429, True),
+        GoogleWorkspaceErrorCode.UPSTREAM_5XX: ("UPSTREAM_UNAVAILABLE", 502, True),
+        GoogleWorkspaceErrorCode.TIMEOUT: ("UPSTREAM_UNAVAILABLE", 504, True),
+        GoogleWorkspaceErrorCode.CONNECTION_CLOSED: ("SERVICE_BUSY", 503, True),
+        GoogleWorkspaceErrorCode.RESPONSE_MALFORMED: ("UPSTREAM_UNAVAILABLE", 502, False),
+    }
+    error_code, status_code, retryable = mapping.get(
+        error.code,
+        ("UPSTREAM_UNAVAILABLE", 502, False),
+    )
+    raise ApiError(
+        error_code=error_code,
+        user_message="Google resource request could not be completed.",
+        status_code=status_code,
+        request_id=request_id,
+        retryable=retryable,
+        detail_code=f"GOOGLE_{error.code.value}",
+    ) from error

--- a/src/google_work_agent/application/read_only.py
+++ b/src/google_work_agent/application/read_only.py
@@ -36,6 +36,7 @@ from google_work_agent.ports import (
     ResourceSource,
     RunRecord,
     StoredResourceType,
+    TimeRange,
     TraceEventRecord,
     UnitOfWork,
 )
@@ -1138,7 +1139,14 @@ class ExecuteReadActionService:
         arguments: dict[str, object],
     ) -> ExecutedReadAction:
         calendar_ids = _string_tuple_argument(arguments.get("calendar_ids"))
-        result = self._gateway.query_freebusy(calendar_ids=calendar_ids)
+        time_range = TimeRange(
+            start=str(arguments["time_min"]),
+            end=str(arguments["time_max"]),
+        )
+        result = self._gateway.query_freebusy(
+            calendar_ids=calendar_ids,
+            time_range=time_range,
+        )
         return _executed_from_freebusy(run_id=run_id, calendars=result)
 
     def _execute_get_calendar_event(

--- a/src/google_work_agent/launcher/dev.py
+++ b/src/google_work_agent/launcher/dev.py
@@ -70,6 +70,7 @@ from google_work_agent.application.llm import (
     TestLLMConnectionService,
 )
 from google_work_agent.application.queries import QueryService
+from google_work_agent.application.resource_queries import ResourceQueryService
 from google_work_agent.application.start_run import (
     CreateConversationService,
     ModifyWriteActionService,
@@ -584,11 +585,12 @@ def build_container(
         raise CoreInitializationError("KEYRING_UNAVAILABLE") from error
     prompt_active = True
     workflow_runtime: LangGraphWorkflowRuntime | _PromptInactiveWorkflowRuntime
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
     try:
         workflow_runtime = LangGraphWorkflowRuntime(
             unit_of_work_factory=unit_of_work_factory,
             llm_runtime=llm_runtime,
-            gateway=MCPGoogleWorkspaceGateway(transport=transport),
+            gateway=gateway,
             now_ms=clock.now_ms,
             id_factory=id_generator.next_id,
             signing_secret=secrets.token_hex(32),
@@ -684,6 +686,7 @@ def build_container(
         start_google_oauth_service=StartGoogleOAuthService(provider=google_provider),
         get_google_connection_service=GetGoogleConnectionService(provider=google_provider),
         disconnect_google_service=DisconnectGoogleService(provider=google_provider),
+        resource_query_service=ResourceQueryService(gateway=gateway),
         get_llm_connection_service=GetLLMConnectionService(
             runtime_status_service=llm_runtime.status_service,
             settings_service=llm_runtime.settings_service,

--- a/src/google_work_agent/mcp/server.py
+++ b/src/google_work_agent/mcp/server.py
@@ -1,8 +1,4 @@
-"""Local MCP child process for Google OAuth credentials.
-
-Google Workspace resource adapters deliberately do not live in this module yet.
-This process owns the Desktop OAuth loopback flow and the OS-keyring refresh token.
-"""
+"""Local MCP child process for Google OAuth credentials and read tools."""
 
 from __future__ import annotations
 
@@ -18,16 +14,17 @@ import threading
 import time
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from typing import cast
 from urllib.error import HTTPError, URLError
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 from google_work_agent.adapters.keyring import OSKeyringSecretStore
 from google_work_agent.adapters.mcp.transport import PROTOCOL_VERSION
 from google_work_agent.domain import build_p0_tool_registry
 from google_work_agent.mcp.settings import GoogleOAuthSettings
-from google_work_agent.ports import CredentialState, OAuthEnvironment, SecretStore
+from google_work_agent.ports import CredentialState, OAuthEnvironment, SecretStore, TimeRange
 
 GOOGLE_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
@@ -44,6 +41,7 @@ REQUIRED_SCOPES = (
 )
 OAUTH_FLOW_TTL_MS = 60_000
 DEFAULT_ACCESS_TOKEN_TTL_MS = 3_600_000
+GOOGLE_API_TIMEOUT_SECONDS = 30
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,8 +79,12 @@ class _OAuthReauthenticationRequired(RuntimeError):
     """Raised when Google rejects a stored refresh token."""
 
 
-class _WorkspaceToolsNotImplemented(RuntimeError):
-    """Raised until real Gmail/Calendar/Tasks adapters are implemented."""
+class _WorkspaceToolError(RuntimeError):
+    """A sanitized Google Workspace read failure."""
+
+    def __init__(self, safe_code: str) -> None:
+        super().__init__(safe_code)
+        self.safe_code = safe_code
 
 
 class _WorkspaceState:
@@ -105,7 +107,7 @@ class _WorkspaceState:
         self.oauth_settings = GoogleOAuthSettings.load(
             runtime_environment=os.environ.get("GWA_MCP_ENVIRONMENT", ""),
         )
-        self.keyring = keyring or OSKeyringSecretStore()
+        self.keyring = keyring or _credential_store_from_environment()
         if (
             self.keyring.get_secret(
                 service=GOOGLE_KEYRING_SERVICE,
@@ -207,13 +209,13 @@ def main() -> None:
                     },
                 }
             )
-        except _WorkspaceToolsNotImplemented:
+        except _WorkspaceToolError as error:
             _write(
                 {
                     "id": request_id,
                     "error": {
                         "code": "TOOL_REJECTED",
-                        "message": "Google Workspace tools are not implemented.",
+                        "message": error.safe_code,
                     },
                 }
             )
@@ -252,8 +254,489 @@ def _dispatch(state: _WorkspaceState, request: dict[str, object]) -> dict[str, o
     if message_type == "control_call":
         return _control_call(state, method=str(request["method"]))
     if message_type == "tool_call":
-        raise _WorkspaceToolsNotImplemented
+        return _tool_call(
+            state,
+            tool_name=str(request["tool_name"]),
+            arguments=cast(dict[str, object], request["arguments"]),
+        )
     raise ValueError("unsupported message type")
+
+
+def _tool_call(
+    state: _WorkspaceState, *, tool_name: str, arguments: dict[str, object]
+) -> dict[str, object]:
+    read_tools = {
+        "gmail_search_threads": _gmail_search_threads,
+        "gmail_get_thread": _gmail_get_thread,
+        "gmail_get_message": _gmail_get_message,
+        "tasks_list_tasklists": _tasks_list_tasklists,
+        "tasks_list_tasks": _tasks_list_tasks,
+        "tasks_get_task": _tasks_get_task,
+        "calendar_list_calendars": _calendar_list_calendars,
+        "calendar_list_events": _calendar_list_events,
+        "calendar_get_event": _calendar_get_event,
+        "calendar_query_freebusy": _calendar_query_freebusy,
+    }
+    handler = read_tools.get(tool_name)
+    if handler is None:
+        raise _WorkspaceToolError("TOOL_NOT_AVAILABLE")
+    return handler(state, arguments)
+
+
+def _gmail_search_threads(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    query = _text_argument(arguments, "query", maximum=2048, allow_empty=True)
+    params = _page_params(arguments)
+    if query:
+        params["q"] = query
+    payload = _google_api(state, "https://gmail.googleapis.com/gmail/v1/users/me/threads", params)
+    items = []
+    for thread in _object_list(payload.get("threads")):
+        thread_id = _required_response_text(thread, "id")
+        items.append(
+            _snapshot(
+                "gmail_thread",
+                thread_id,
+                None,
+                (),
+                thread.get("historyId"),
+                {"snippet": _optional_text(thread.get("snippet"))},
+            )
+        )
+    return {"items": items, "next_page_token": _optional_text(payload.get("nextPageToken"))}
+
+
+def _gmail_get_thread(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    thread_id = _text_argument(arguments, "thread_id", maximum=2048)
+    payload = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/threads/{quote(thread_id, safe='')}",
+        {"format": "metadata"},
+    )
+    messages = _object_list(payload.get("messages"))
+    headers = _headers(messages[0]) if messages else {}
+    message_ids = tuple(_required_response_text(item, "id") for item in messages)
+    participants = tuple(value for value in (headers.get("from"), headers.get("to")) if value)
+    return {
+        "item": _snapshot(
+            "gmail_thread",
+            thread_id,
+            None,
+            message_ids,
+            payload.get("historyId"),
+            {
+                "subject": headers.get("subject", thread_id),
+                "snippet": _optional_text(payload.get("snippet")),
+                "participants": list(participants),
+                "message_ids": list(message_ids),
+            },
+        )
+    }
+
+
+def _gmail_get_message(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    message_id = _text_argument(arguments, "message_id", maximum=2048)
+    payload = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/messages/{quote(message_id, safe='')}",
+        {"format": "metadata"},
+    )
+    headers = _headers(payload)
+    return {
+        "item": _snapshot(
+            "gmail_message",
+            message_id,
+            _optional_text(payload.get("threadId")),
+            (),
+            payload.get("historyId"),
+            {
+                "subject": headers.get("subject", message_id),
+                "snippet": _optional_text(payload.get("snippet")),
+                "from": headers.get("from"),
+                "to": headers.get("to"),
+                "received_at": headers.get("date"),
+            },
+        )
+    }
+
+
+def _tasks_list_tasklists(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    payload = _google_api(
+        state, "https://tasks.googleapis.com/tasks/v1/users/@me/lists", _page_params(arguments)
+    )
+    items = [
+        _snapshot(
+            "task_list",
+            _required_response_text(item, "id"),
+            None,
+            (),
+            item.get("updated"),
+            {
+                "title": _optional_text(item.get("title")) or _required_response_text(item, "id"),
+                "kind": _optional_text(item.get("kind")),
+            },
+        )
+        for item in _object_list(payload.get("items"))
+    ]
+    return {"items": items, "next_page_token": _optional_text(payload.get("nextPageToken"))}
+
+
+def _tasks_list_tasks(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    task_list_id = _text_argument(arguments, "task_list_id", maximum=2048)
+    payload = _google_api(
+        state,
+        f"https://tasks.googleapis.com/tasks/v1/lists/{quote(task_list_id, safe='')}/tasks",
+        _page_params(arguments),
+    )
+    items = [_task_snapshot(item, task_list_id) for item in _object_list(payload.get("items"))]
+    return {"items": items, "next_page_token": _optional_text(payload.get("nextPageToken"))}
+
+
+def _tasks_get_task(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    task_list_id = _text_argument(arguments, "task_list_id", maximum=2048)
+    task_id = _text_argument(arguments, "task_id", maximum=2048)
+    task_list_path = quote(task_list_id, safe="")
+    task_path = quote(task_id, safe="")
+    payload = _google_api(
+        state,
+        f"https://tasks.googleapis.com/tasks/v1/lists/{task_list_path}/tasks/{task_path}",
+    )
+    return {"item": _task_snapshot(payload, task_list_id)}
+
+
+def _calendar_list_calendars(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    payload = _google_api(
+        state,
+        "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+        _page_params(arguments),
+    )
+    items = [
+        _snapshot(
+            "calendar",
+            _required_response_text(item, "id"),
+            None,
+            (),
+            item.get("etag"),
+            {
+                "summary": _optional_text(item.get("summary"))
+                or _required_response_text(item, "id"),
+                "time_zone": _optional_text(item.get("timeZone")),
+            },
+        )
+        for item in _object_list(payload.get("items"))
+    ]
+    return {"items": items, "next_page_token": _optional_text(payload.get("nextPageToken"))}
+
+
+def _calendar_list_events(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    calendar_id = _text_argument(arguments, "calendar_id", maximum=2048)
+    payload = _google_api(
+        state,
+        f"https://www.googleapis.com/calendar/v3/calendars/{quote(calendar_id, safe='')}/events",
+        _page_params(arguments),
+    )
+    items = [_event_snapshot(item, calendar_id) for item in _object_list(payload.get("items"))]
+    return {"items": items, "next_page_token": _optional_text(payload.get("nextPageToken"))}
+
+
+def _calendar_get_event(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    calendar_id = _text_argument(arguments, "calendar_id", maximum=2048)
+    event_id = _text_argument(arguments, "event_id", maximum=2048)
+    calendar_path = quote(calendar_id, safe="")
+    event_path = quote(event_id, safe="")
+    payload = _google_api(
+        state,
+        f"https://www.googleapis.com/calendar/v3/calendars/{calendar_path}/events/{event_path}",
+    )
+    return {"item": _event_snapshot(payload, calendar_id)}
+
+
+def _calendar_query_freebusy(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    calendar_ids = _calendar_ids_argument(arguments)
+    try:
+        time_range = TimeRange(
+            start=_text_argument(arguments, "time_min", maximum=2048),
+            end=_text_argument(arguments, "time_max", maximum=2048),
+        )
+    except ValueError as error:
+        raise _WorkspaceToolError("INVALID_ARGUMENT") from error
+    payload = _google_api_post(
+        state,
+        "https://www.googleapis.com/calendar/v3/freeBusy",
+        {
+            "timeMin": time_range.start,
+            "timeMax": time_range.end,
+            "items": [{"id": calendar_id} for calendar_id in calendar_ids],
+        },
+    )
+    calendars = cast(dict[str, object], payload.get("calendars") or {})
+    return {
+        "calendars": [
+            {
+                "calendar_id": calendar_id,
+                "intervals": [
+                    {
+                        "start": _required_response_text(interval, "start"),
+                        "end": _required_response_text(interval, "end"),
+                        "transparency": "busy",
+                    }
+                    for interval in _object_list(
+                        cast(dict[str, object], calendars.get(calendar_id) or {}).get("busy")
+                    )
+                ],
+            }
+            for calendar_id in calendar_ids
+        ]
+    }
+
+
+def _task_snapshot(item: dict[str, object], task_list_id: str) -> dict[str, object]:
+    task_id = _required_response_text(item, "id")
+    return _snapshot(
+        "task",
+        task_id,
+        task_list_id,
+        (task_list_id,),
+        item.get("updated"),
+        {
+            "title": _optional_text(item.get("title")) or task_id,
+            "notes": _optional_text(item.get("notes")),
+            "due": _optional_text(item.get("due")),
+            "status": _optional_text(item.get("status")),
+        },
+    )
+
+
+def _event_snapshot(item: dict[str, object], calendar_id: str) -> dict[str, object]:
+    event_id = _required_response_text(item, "id")
+    start = cast(dict[str, object], item.get("start") or {})
+    end = cast(dict[str, object], item.get("end") or {})
+    return _snapshot(
+        "calendar_event",
+        event_id,
+        calendar_id,
+        (calendar_id,),
+        item.get("etag"),
+        {
+            "title": _optional_text(item.get("summary")) or event_id,
+            "status": _optional_text(item.get("status")),
+            "transparency": _optional_text(item.get("transparency")),
+            "event_kind": _optional_text(item.get("eventType")),
+            "start": _optional_text(start.get("dateTime")) or _optional_text(start.get("date")),
+            "end": _optional_text(end.get("dateTime")) or _optional_text(end.get("date")),
+        },
+    )
+
+
+def _snapshot(
+    resource_type: str,
+    resource_id: str,
+    parent_id: str | None,
+    related_resource_ids: tuple[str, ...],
+    version: object,
+    payload: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "fixture_snapshot_id": resource_id,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "parent_id": parent_id,
+        "related_resource_ids": list(related_resource_ids),
+        "version": _optional_text(version) or "",
+        "recovery_fingerprint": None,
+        "payload": {key: value for key, value in payload.items() if value is not None},
+    }
+
+
+def _page_params(arguments: dict[str, object]) -> dict[str, str]:
+    page_size = arguments.get("page_size", 20)
+    if not isinstance(page_size, int) or not 1 <= page_size <= 100:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    params = {"maxResults": str(page_size)}
+    page_token = arguments.get("page_token")
+    if page_token is not None:
+        params["pageToken"] = _text_value(page_token, maximum=2048)
+    return params
+
+
+def _text_argument(
+    arguments: dict[str, object], name: str, *, maximum: int, allow_empty: bool = False
+) -> str:
+    if name not in arguments:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    value = _text_value(arguments[name], maximum=maximum)
+    if not value and not allow_empty:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return value
+
+
+def _text_value(value: object, *, maximum: int) -> str:
+    if not isinstance(value, str) or len(value) > maximum or any(ord(char) < 32 for char in value):
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return value
+
+
+def _calendar_ids_argument(arguments: dict[str, object]) -> tuple[str, ...]:
+    value = arguments.get("calendar_ids")
+    if not isinstance(value, list) or not 1 <= len(value) <= 20:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return tuple(_text_value(item, maximum=2048) for item in value)
+
+
+def _google_api(
+    state: _WorkspaceState, url: str, params: dict[str, str] | None = None
+) -> dict[str, object]:
+    try:
+        state.ensure_access_token()
+    except _OAuthReauthenticationRequired as error:
+        state.connection_state = CredentialState.REAUTH_REQUIRED
+        raise _WorkspaceToolError("REAUTH_REQUIRED") from error
+    if state.access_token is None:
+        raise _WorkspaceToolError("OAUTH_NOT_CONNECTED")
+    request_url = f"{url}?{urlencode(params)}" if params else url
+    request = Request(
+        request_url,
+        headers={"Authorization": f"Bearer {state.access_token}", "Accept": "application/json"},
+    )
+    try:
+        with urlopen(request, timeout=GOOGLE_API_TIMEOUT_SECONDS) as response:  # nosec B310: fixed Google API endpoints
+            return cast(dict[str, object], json.loads(response.read().decode("utf-8")))
+    except HTTPError as error:
+        codes = {
+            401: "REAUTH_REQUIRED",
+            403: "PERMISSION_DENIED",
+            404: "NOT_FOUND",
+            429: "RATE_LIMITED",
+        }
+        if error.code == 401:
+            state.connection_state = CredentialState.REAUTH_REQUIRED
+            state.access_token = None
+            state.access_token_expires_at_ms = 0
+        raise _WorkspaceToolError(
+            codes.get(error.code, "UPSTREAM_5XX" if error.code >= 500 else "GOOGLE_REQUEST_FAILED")
+        ) from error
+    except (URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _WorkspaceToolError(
+            "TIMEOUT" if isinstance(error, TimeoutError) else "MCP_UNAVAILABLE"
+        ) from error
+
+
+def _google_api_post(
+    state: _WorkspaceState, url: str, body: dict[str, object]
+) -> dict[str, object]:
+    try:
+        state.ensure_access_token()
+    except _OAuthReauthenticationRequired as error:
+        state.connection_state = CredentialState.REAUTH_REQUIRED
+        raise _WorkspaceToolError("REAUTH_REQUIRED") from error
+    if state.access_token is None:
+        raise _WorkspaceToolError("OAUTH_NOT_CONNECTED")
+    request = Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {state.access_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=GOOGLE_API_TIMEOUT_SECONDS) as response:  # nosec B310: fixed Google API endpoint
+            return cast(dict[str, object], json.loads(response.read().decode("utf-8")))
+    except HTTPError as error:
+        codes = {
+            401: "REAUTH_REQUIRED",
+            403: "PERMISSION_DENIED",
+            404: "NOT_FOUND",
+            429: "RATE_LIMITED",
+        }
+        if error.code == 401:
+            state.connection_state = CredentialState.REAUTH_REQUIRED
+            state.access_token = None
+            state.access_token_expires_at_ms = 0
+        raise _WorkspaceToolError(
+            codes.get(error.code, "UPSTREAM_5XX" if error.code >= 500 else "GOOGLE_REQUEST_FAILED")
+        ) from error
+    except (URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise _WorkspaceToolError(
+            "TIMEOUT" if isinstance(error, TimeoutError) else "MCP_UNAVAILABLE"
+        ) from error
+
+
+def _credential_store_from_environment() -> SecretStore:
+    test_keyring_path = os.environ.get("GWA_TEST_KEYRING_PATH")
+    if test_keyring_path:
+        return _TestFileSecretStore(Path(test_keyring_path))
+    return OSKeyringSecretStore()
+
+
+class _TestFileSecretStore(SecretStore):
+    """Test-only cross-process store selected by an explicit test environment variable."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        values = self._read()
+        values[f"{service}:{account}"] = secret
+        self._write(values)
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        return self._read().get(f"{service}:{account}")
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        values = self._read()
+        removed = values.pop(f"{service}:{account}", None) is not None
+        self._write(values)
+        return removed
+
+    def _read(self) -> dict[str, str]:
+        if not self._path.is_file():
+            return {}
+        payload = json.loads(self._path.read_text(encoding="utf-8"))
+        return {str(key): str(value) for key, value in cast(dict[str, object], payload).items()}
+
+    def _write(self, values: dict[str, str]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(values, sort_keys=True), encoding="utf-8")
+
+
+def _object_list(value: object) -> list[dict[str, object]]:
+    return (
+        [cast(dict[str, object], item) for item in value if isinstance(item, dict)]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _required_response_text(payload: dict[str, object], name: str) -> str:
+    value = _optional_text(payload.get(name))
+    if value is None:
+        raise _WorkspaceToolError("INVALID_MCP_OUTPUT")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _headers(message: dict[str, object]) -> dict[str, str]:
+    payload = cast(dict[str, object], message.get("payload") or {})
+    return {
+        str(item.get("name", "")).lower(): str(item.get("value", ""))
+        for item in _object_list(payload.get("headers"))
+        if item.get("name") and item.get("value")
+    }
 
 
 def _control_call(state: _WorkspaceState, *, method: str) -> dict[str, object]:

--- a/src/google_work_agent/ports/__init__.py
+++ b/src/google_work_agent/ports/__init__.py
@@ -38,6 +38,7 @@ from google_work_agent.ports.google_workspace import (
     ResourcePage,
     ResourceSnapshot,
     ResourceType,
+    TimeRange,
 )
 from google_work_agent.ports.identity import IdGenerator
 from google_work_agent.ports.launcher_probe import (
@@ -232,6 +233,7 @@ __all__ = [
     "ResourceSnapshot",
     "ResourceSource",
     "ResourceType",
+    "TimeRange",
     "RouteDecision",
     "RouteDecisionInput",
     "RunCreateRecord",

--- a/src/google_work_agent/ports/google_workspace.py
+++ b/src/google_work_agent/ports/google_workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import StrEnum
 from typing import Any, Protocol
 
@@ -61,10 +62,25 @@ class FreeBusyCalendar:
     intervals: tuple[FreeBusyInterval, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class TimeRange:
+    """Explicit timezone-aware range for Calendar free/busy requests."""
+
+    start: str
+    end: str
+
+    def __post_init__(self) -> None:
+        start = _parse_rfc3339(self.start)
+        end = _parse_rfc3339(self.end)
+        if start >= end:
+            raise ValueError("time range start must precede end")
+
+
 class GoogleWorkspaceErrorCode(StrEnum):
     """Deterministic fault codes exposed by the fake gateway."""
 
     AUTH_EXPIRED = "AUTH_EXPIRED"
+    INVALID_ARGUMENT = "INVALID_ARGUMENT"
     PERMISSION_DENIED = "PERMISSION_DENIED"
     NOT_FOUND = "NOT_FOUND"
     CONFLICT = "CONFLICT"
@@ -214,7 +230,12 @@ class GoogleWorkspaceGateway(Protocol):
     ) -> ResourcePage:
         """List calendar events for one calendar."""
 
-    def query_freebusy(self, *, calendar_ids: tuple[str, ...]) -> tuple[FreeBusyCalendar, ...]:
+    def query_freebusy(
+        self,
+        *,
+        calendar_ids: tuple[str, ...],
+        time_range: TimeRange,
+    ) -> tuple[FreeBusyCalendar, ...]:
         """Return free/busy intervals for calendars."""
 
     def get_calendar_event(self, *, calendar_id: str, event_id: str) -> ResourceSnapshot:
@@ -255,3 +276,16 @@ class GoogleWorkspaceGateway(Protocol):
         recovery_fingerprint: str,
     ) -> tuple[ResourceSnapshot, ...]:
         """Return recovery candidates for one fingerprint."""
+
+
+def _parse_rfc3339(value: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError("time range value is required")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise ValueError("time range must use RFC3339") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("time range must include a timezone")
+    return parsed

--- a/tests/integration/persistence/test_read_only.py
+++ b/tests/integration/persistence/test_read_only.py
@@ -326,7 +326,11 @@ def test_read_only_failure_marks_dependency_blocked_and_keeps_independent_branch
                     action_id="action-branch",
                     position=3,
                     tool_name="calendar_query_freebusy",
-                    arguments={"calendar_ids": ["calendar-primary"]},
+                    arguments={
+                        "calendar_ids": ["calendar-primary"],
+                        "time_min": "2026-11-01T00:00:00-07:00",
+                        "time_max": "2026-11-02T00:00:00-08:00",
+                    },
                     expected={"result_kind": "FREEBUSY"},
                     evidence_ids=("evidence-plan-2",),
                 ),

--- a/tests/support/fakes/google_gateway.py
+++ b/tests/support/fakes/google_gateway.py
@@ -15,6 +15,7 @@ from google_work_agent.ports import (
     ResourcePage,
     ResourceSnapshot,
     ResourceType,
+    TimeRange,
 )
 from tests.support.fixtures import ProductFixtureSnapshot
 
@@ -271,13 +272,22 @@ class FakeGoogleGateway:
             page_size=page_size,
         )
 
-    def query_freebusy(self, *, calendar_ids: tuple[str, ...]) -> tuple[FreeBusyCalendar, ...]:
+    def query_freebusy(
+        self,
+        *,
+        calendar_ids: tuple[str, ...],
+        time_range: TimeRange,
+    ) -> tuple[FreeBusyCalendar, ...]:
         operation = "query_freebusy"
         self._check_fault(operation=operation, can_mutate=False)
         self.call_log.append(
             GoogleGatewayCallRecord(
                 operation=operation,
-                arguments={"calendar_ids": list(calendar_ids)},
+                arguments={
+                    "calendar_ids": list(calendar_ids),
+                    "time_min": time_range.start,
+                    "time_max": time_range.end,
+                },
                 delivered=True,
                 mutated=False,
             )

--- a/tests/unit/application/workflows/test_api_acquisition.py
+++ b/tests/unit/application/workflows/test_api_acquisition.py
@@ -35,6 +35,7 @@ from google_work_agent.ports import (
     ResourceType,
     SelectedResourceRef,
     StructuredLLMResult,
+    TimeRange,
     WorkflowCorrelationContext,
     WorkflowStartRequest,
 )
@@ -266,7 +267,13 @@ class RecordingGoogleGateway:
         )
         return ResourcePage(items=tuple(self.events.values())[:page_size], next_page_token=None)
 
-    def query_freebusy(self, *, calendar_ids: tuple[str, ...]) -> tuple[FreeBusyCalendar, ...]:
+    def query_freebusy(
+        self,
+        *,
+        calendar_ids: tuple[str, ...],
+        time_range: TimeRange,
+    ) -> tuple[FreeBusyCalendar, ...]:
+        del calendar_ids, time_range
         raise NotImplementedError
 
     def get_calendar_event(self, *, calendar_id: str, event_id: str) -> ResourceSnapshot:

--- a/tests/unit/mcp/test_workspace_read_tools.py
+++ b/tests/unit/mcp/test_workspace_read_tools.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from tests.support.fakes.mcp_transport import FakeMCPTransport
+
+from google_work_agent.adapters.mcp import MCPGoogleWorkspaceGateway
+from google_work_agent.mcp import server
+from google_work_agent.mcp.settings import GoogleOAuthSettings
+from google_work_agent.ports import TimeRange
+
+
+def test_gmail_list_maps_google_metadata_without_detail_calls(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        calls.append((url, params))
+        return {
+            "threads": [{"id": "thread-1", "historyId": "7", "snippet": "Preview"}],
+            "nextPageToken": "next-1",
+        }
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+
+    payload = server._tool_call(
+        _state(),
+        tool_name="gmail_search_threads",
+        arguments={"query": "label:inbox", "page_size": 20, "page_token": None},
+    )
+
+    assert payload["next_page_token"] == "next-1"
+    assert payload["items"] == [
+        {
+            "fixture_snapshot_id": "thread-1",
+            "resource_type": "gmail_thread",
+            "resource_id": "thread-1",
+            "parent_id": None,
+            "related_resource_ids": [],
+            "version": "7",
+            "recovery_fingerprint": None,
+            "payload": {"snippet": "Preview"},
+        }
+    ]
+    assert calls == [
+        (
+            "https://gmail.googleapis.com/gmail/v1/users/me/threads",
+            {"maxResults": "20", "q": "label:inbox"},
+        )
+    ]
+
+
+def test_tasks_and_calendar_details_map_to_canonical_snapshots(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    responses = [
+        {
+            "id": "task-1",
+            "title": "Follow up",
+            "notes": "Call customer",
+            "due": "2026-08-10T00:00:00.000Z",
+            "status": "needsAction",
+            "updated": "2026-08-09T00:00:00.000Z",
+        },
+        {
+            "id": "event-1",
+            "summary": "Review",
+            "status": "confirmed",
+            "etag": "etag-1",
+            "start": {"dateTime": "2026-08-10T09:00:00+09:00"},
+            "end": {"dateTime": "2026-08-10T10:00:00+09:00"},
+        },
+    ]
+
+    def google_api(
+        _state: server._WorkspaceState, _url: str, _params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        return cast(dict[str, object], responses.pop(0))
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    state = _state()
+
+    task = server._tool_call(
+        state,
+        tool_name="tasks_get_task",
+        arguments={"task_list_id": "list-1", "task_id": "task-1"},
+    )
+    event = server._tool_call(
+        state,
+        tool_name="calendar_get_event",
+        arguments={"calendar_id": "primary", "event_id": "event-1"},
+    )
+
+    task_item = cast(dict[str, object], task["item"])
+    event_item = cast(dict[str, object], event["item"])
+    assert task_item["parent_id"] == "list-1"
+    assert cast(dict[str, object], task_item["payload"])["status"] == "needsAction"
+    assert event_item["parent_id"] == "primary"
+    assert cast(dict[str, object], event_item["payload"])["start"] == "2026-08-10T09:00:00+09:00"
+
+
+def test_read_tool_input_rejects_invalid_page_token(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api", lambda *_args, **_kwargs: {})
+
+    try:
+        server._tool_call(
+            _state(),
+            tool_name="gmail_search_threads",
+            arguments={"query": "", "page_size": 20, "page_token": "bad\nvalue"},
+        )
+    except server._WorkspaceToolError as error:
+        assert error.safe_code == "INVALID_ARGUMENT"
+    else:
+        raise AssertionError("invalid page token must be rejected")
+
+
+def test_freebusy_maps_explicit_range_to_google_request(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    def google_api_post(
+        _state: server._WorkspaceState, url: str, body: dict[str, object]
+    ) -> dict[str, object]:
+        captured["url"] = url
+        captured["body"] = body
+        return {
+            "calendars": {
+                "primary": {
+                    "busy": [
+                        {
+                            "start": "2026-08-10T09:00:00+09:00",
+                            "end": "2026-08-10T10:00:00+09:00",
+                        }
+                    ]
+                }
+            }
+        }
+
+    monkeypatch.setattr(server, "_google_api_post", google_api_post)
+
+    payload = server._calendar_query_freebusy(
+        _state(),
+        {
+            "calendar_ids": ["primary"],
+            "time_min": "2026-08-10T00:00:00+09:00",
+            "time_max": "2026-08-11T00:00:00+09:00",
+        },
+    )
+
+    assert captured == {
+        "url": "https://www.googleapis.com/calendar/v3/freeBusy",
+        "body": {
+            "timeMin": "2026-08-10T00:00:00+09:00",
+            "timeMax": "2026-08-11T00:00:00+09:00",
+            "items": [{"id": "primary"}],
+        },
+    }
+    calendars = cast(list[dict[str, object]], payload["calendars"])
+    intervals = cast(list[dict[str, object]], calendars[0]["intervals"])
+    assert intervals[0]["transparency"] == "busy"
+
+
+def test_freebusy_rejects_invalid_range_without_google_request(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        server,
+        "_google_api_post",
+        lambda *_args, **_kwargs: pytest.fail("Google API must not be called"),
+    )
+
+    with pytest.raises(server._WorkspaceToolError, match="INVALID_ARGUMENT"):
+        server._calendar_query_freebusy(
+            _state(),
+            {
+                "calendar_ids": ["primary"],
+                "time_min": "2026-08-11T00:00:00+09:00",
+                "time_max": "2026-08-10T00:00:00+09:00",
+            },
+        )
+
+
+def test_gateway_preserves_explicit_freebusy_range_in_mcp_arguments() -> None:
+    transport = FakeMCPTransport()
+    transport.queue_response({"calendars": []})
+
+    MCPGoogleWorkspaceGateway(transport=transport).query_freebusy(
+        calendar_ids=("primary",),
+        time_range=TimeRange(
+            start="2026-08-10T00:00:00+09:00",
+            end="2026-08-11T00:00:00+09:00",
+        ),
+    )
+
+    assert transport.call_log[0].arguments == {
+        "calendar_ids": ["primary"],
+        "time_min": "2026-08-10T00:00:00+09:00",
+        "time_max": "2026-08-11T00:00:00+09:00",
+    }
+
+
+def _state() -> server._WorkspaceState:
+    state = server._WorkspaceState(keyring=_MemorySecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    return state
+
+
+class _MemorySecretStore:
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        del service, account, secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        del service, account
+        return None
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        del service, account
+        return True


### PR DESCRIPTION
## 요약

Google OAuth Credential Lifecycle을 실제 Google 환경에 연결하고,
Gmail · Tasks · Calendar의 실제 Workspace READ 경로를 MCP 기반으로 구현했습니다.

Local Session Bootstrap부터 Google OAuth 연결, 재시작 후 Credential 복원,
Workspace Resource 목록/상세 조회 및 Calendar FreeBusy까지 실제 동작 가능한 상태로 완성했습니다.

## 주요 변경사항

### OAuth / Credential Lifecycle

- Desktop OAuth Client ID / Client Secret DEV 설정 지원
- Authorization Code Grant에 Client Secret 적용
- Refresh Token Grant에 Client Secret 적용
- PKCE S256 / state / loopback callback 유지
- Refresh Token OS Keyring 저장
- Access Token MCP Process Memory 유지
- 프로세스 재시작 후 Refresh Token 기반 자동 연결 복원
- OAuth 오류 정보 Sanitization
- Credential / Token / Client Secret 외부 노출 방지

### Local Session / Bootstrap

- 일회성 Bootstrap 기반 Local Session 초기화
- 보호된 `/api/v1/*` 요청의 Local Session 보장
- Backend 재시작 시 새로운 Bootstrap Session 사용
- Startup / Readiness / Safe Mode 경계 유지

### Google Workspace READ

- `resource_query_service` DI와 MCP `tool_call` 연결
- Gmail 실제 목록 / 상세 READ 구현
- Google Tasks 실제 목록 / 상세 READ 구현
- Google Calendar 실제 목록 / 상세 READ 구현
- Task List / Calendar discovery 지원
- ID가 없는 경우 임의 기본 Resource를 선택하지 않도록 처리
- metadata-first / detail-on-demand 유지
- 목록 조회 시 상세 N+1 호출 방지

### Calendar FreeBusy

- 기존 `query_freebusy(calendar_ids)` 계약을
  `query_freebusy(calendar_ids, time_range)`로 보완
- RFC3339 / timezone 포함 시간 범위 검증
- `start < end` 검증
- `calendar_ids`, `time_min`, `time_max`를 MCP → Google freeBusy 요청에 전달
- 잘못된 시간 범위는 Google 호출 전에 차단

### 테스트 격리

- OAuth Component Test가 실제 OS Keyring을 읽던 문제 수정
- `GWA_TEST_KEYRING_PATH` 사용 시 테스트 전용 SecretStore 사용
- Automated Test가 실제 Google 계정 / OS Keyring / `.env.local` 상태와 독립적으로 실행되도록 수정

## 보존한 계약

- Refresh Token → OS Keyring
- Access Token → MCP Process Memory
- React / FastAPI에 OAuth Credential 노출 금지
- 일반 READ는 Approval / ExecutionAttempt / Verification 미생성
- Metadata-first / Detail-on-demand
- Google / MCP 오류의 안전한 FastAPI Error Envelope 변환

## 검증 결과

- Unit: `484 passed`
- Integration: `129 passed`
- Full pytest: `629 passed, 0 failed`
- Ruff: PASS
- Ruff Format: PASS
- mypy: PASS
- `git diff --check`: PASS

## Live 검증

실제 Google 계정에서 다음을 확인했습니다.

- Google OAuth 연결: PASS
- Authorization Code Token Exchange: PASS
- `CONNECTED`: PASS
- Backend/MCP 재시작 후 Credential 자동 복원: PASS
- Gmail READ: PASS
- Tasks READ: PASS
- Calendar READ: PASS
- FreeBusy READ: PASS