### PR TITLE
[feat] Google Workspace 쓰기 런타임 및 계정 연동 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,13 +62,13 @@ config.local.*
 # ------------------------------------------------------------
 # Google Work Agent local runtime data
 # ------------------------------------------------------------
-data/
-backups/
-logs/
-diagnostics/
-runtime/
-cache/
-local-data/
+/data/
+/backups/
+/logs/
+/diagnostics/
+/runtime/
+/cache/
+/local-data/
 
 *.db
 *.db-wal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,324 @@
+Google Work Agent — Claude Code Instructions
+
+Purpose
+
+This file defines how Claude Code should work in this repository.
+
+It does not replace product, architecture, policy, domain, interface, security, test, or evaluation documents.Do not duplicate detailed contracts here.
+
+When implementation details matter, read the current Canonical documents in docs/.
+
+Communication
+
+Respond to the user in Korean unless the user requests another language.
+
+Keep explanations concise and engineering-focused.
+
+Clearly separate:
+
+current repository facts,
+
+canonical document requirements,
+
+implementation gaps,
+
+assumptions or recommendations.
+
+Source of truth
+
+Before substantial work:
+
+Inspect the actual repository.
+
+Read docs/00-PROJECT-SOURCE-GUIDE.md.
+
+Identify the Canonical owner of the concern being changed.
+
+Read only the related documents and tests needed for that concern.
+
+Use:
+
+Canonical documents to understand how the system should behave.
+
+Source code, tests, migrations, and configuration to understand what is implemented now.
+
+If they disagree, do not silently choose one.Identify the mismatch and resolve it according to the documented concern ownership.
+
+Do not invent missing contracts.
+
+Working method
+
+Before editing:
+
+inspect Git status and current branch;
+
+locate the relevant implementation;
+
+locate existing tests;
+
+understand current dependency direction and boundaries;
+
+determine the smallest correct change.
+
+Prefer modifying existing patterns over introducing parallel abstractions.
+
+Do not redesign unrelated parts of the system as incidental cleanup.
+
+Do not implement something that already exists without first confirming the actual gap.
+
+Architecture
+
+Preserve the current architectural boundaries and dependency direction.
+
+General principle:
+
+UI
+→ Local API
+→ Application / Workflow
+→ Domain / Policy
+→ Adapters
+→ External Systems
+
+Responsibilities should remain in their owning layer.
+
+In particular:
+
+UI must not bypass backend/domain boundaries.
+
+API handlers must not replace domain rules.
+
+Workflow or Agent code must not become the authority for deterministic product state.
+
+LLM reasoning must not replace deterministic policy, authorization, state-transition, execution, verification, or recovery rules.
+
+External adapters must not bypass upstream safety contracts.
+
+When adding a feature, fit it into the existing architecture unless the Canonical architecture itself is intentionally being changed.
+
+Safety and external effects
+
+Treat operations that can change external state as safety-sensitive.
+
+Follow the current Canonical contracts for:
+
+authorization and approval;
+
+execution authority;
+
+argument integrity;
+
+idempotency;
+
+delivery uncertainty;
+
+verification;
+
+recovery;
+
+cancellation.
+
+Do not weaken these contracts for convenience.
+
+Do not treat an external API response alone as proof that the intended product state is correct when the Canonical design requires verification.
+
+When execution outcome is uncertain, preserve uncertainty and follow the defined recovery path rather than blindly repeating side effects.
+
+State and persistence
+
+Treat Domain state and persistent data as authoritative according to the Canonical Domain contracts.
+
+Do not invent undocumented states or transitions.
+
+Do not mutate persistent state from inappropriate layers.
+
+Preserve optimistic concurrency and command/idempotency rules where defined.
+
+Keep database transactions short.
+
+Do not hold a database write transaction open while waiting on external or long-running I/O.
+
+Migrations are historical artifacts.
+
+Do not rewrite existing migrations to represent a new change.Add a new migration only when the current schema genuinely requires one.
+
+Agent and LLM behavior
+
+Use LLMs for responsibilities that require interpretation or reasoning.
+
+Keep deterministic responsibilities in deterministic code.
+
+Agents should follow the current Workflow and Prompt contracts rather than creating new routing, memory, tool, or state semantics.
+
+Do not:
+
+let Agents bypass the Supervisor/Application boundaries;
+
+move policy or execution authority into prompts;
+
+inject evaluation gold, grader answers, or hidden benchmark information into product prompts;
+
+add long-term Agent memory unless explicitly defined by the Canonical design.
+
+Data and secrets
+
+Minimize sensitive data exposure.
+
+Never intentionally expose secrets or private user data through:
+
+source code,
+
+commits,
+
+logs,
+
+traces,
+
+test output,
+
+diagnostics,
+
+prompts,
+
+generated documentation.
+
+Use the repository's fake/stub/synthetic test infrastructure where possible.
+
+Do not use real credentials or live user data for ordinary automated tests.
+
+Do not perform live destructive or externally visible actions unless the user explicitly requested the live operation.
+
+Scope discipline
+
+Make the smallest complete change that satisfies the request and the Canonical contracts.
+
+Avoid:
+
+unrelated refactors;
+
+broad renames;
+
+dependency-wide upgrades;
+
+architecture redesign outside the requested concern;
+
+large formatting-only diffs;
+
+weakening tests to make code pass;
+
+temporary workarounds presented as permanent design.
+
+If multiple files are genuinely affected by one contract, update the necessary set rather than forcing the change into one file.
+
+Frontend
+
+When changing frontend code:
+
+follow the current UI/UX document;
+
+inspect the existing component/state patterns first;
+
+use the documented Local API contract;
+
+do not make frontend state authoritative for backend/domain facts;
+
+do not mix a visual-only task with backend/domain redesign unless the contract requires both.
+
+Testing
+
+Use the repository's actual configured commands.
+
+Do not guess script names.
+
+Run:
+
+focused tests for the changed behavior;
+
+relevant contract/integration tests;
+
+broader regression checks appropriate to the change.
+
+If the repository defines lint, formatting, type-check, build, or other gates relevant to modified code, run them before declaring completion.
+
+Do not claim completion while a relevant safety, state, interface, or regression test is failing.
+
+Repository hygiene
+
+Unless explicitly requested:
+
+do not commit;
+
+do not push;
+
+do not merge or rebase;
+
+do not change branches;
+
+do not use destructive Git commands.
+
+Do not create root-level:
+
+changelogs,
+
+handoff files,
+
+status reports,
+
+scratch documents,
+
+temporary design summaries.
+
+Keep work inside the existing repository structure.
+
+When blocked or uncertain
+
+Investigate before asking the user.
+
+Check:
+
+existing code,
+
+tests,
+
+migrations,
+
+configuration,
+
+Canonical documents.
+
+If a required contract is still missing or contradictory:
+
+do not invent a new one;
+
+identify the exact ambiguity;
+
+preserve the safer existing behavior;
+
+explain which Canonical concerns are affected.
+
+If a true contract change is required, identify its impact before implementing it.
+
+Completion report
+
+At the end of a coding task, report concisely:
+
+what changed;
+
+files changed;
+
+important contract or boundary preserved;
+
+tests/checks executed and results;
+
+remaining manual/live verification;
+
+any repository-vs-document mismatch discovered.
+
+Do not create a separate report file unless explicitly requested.
+
+Core principle
+
+Prefer:
+
+contract consistency, deterministic safety, recoverability, minimal change, and verifiable behavior
+
+over convenience, speculative redesign, or shorter code.

--- a/src/google_work_agent/adapters/mcp/gateway.py
+++ b/src/google_work_agent/adapters/mcp/gateway.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from base64 import urlsafe_b64decode
 from json import dumps
 from typing import Any, cast
 
 from google_work_agent.ports import (
     FreeBusyCalendar,
     FreeBusyInterval,
+    GmailAttachmentBytes,
     GoogleWorkspaceErrorCode,
     GoogleWorkspaceGateway,
     GoogleWorkspaceGatewayError,
@@ -21,6 +23,37 @@ from google_work_agent.ports import (
 )
 
 
+class MCPGmailAttachmentGateway:
+    """Gmail attachment READ gateway implemented over the MCP transport.
+
+    Kept separate from ``MCPGoogleWorkspaceGateway`` deliberately: attachment
+    bytes have no place moving through the write/verification port that the
+    rest of the application depends on, so this stays a narrow, standalone
+    adapter used only by the attachment download route.
+    """
+
+    def __init__(self, *, transport: MCPTransport) -> None:
+        self._transport = transport
+
+    def get_gmail_attachment(self, *, message_id: str, attachment_id: str) -> GmailAttachmentBytes:
+        try:
+            payload = self._transport.call_tool(
+                tool_name="gmail_get_attachment",
+                arguments={"message_id": message_id, "attachment_id": attachment_id},
+            ).payload
+        except MCPTransportError as error:
+            raise _google_error_from_transport(error) from error
+        raw_value = str(payload["data_base64url"])
+        padding = "=" * (-len(raw_value) % 4)
+        return GmailAttachmentBytes(
+            message_id=str(payload["message_id"]),
+            attachment_id=str(payload["attachment_id"]),
+            size_bytes=int(cast(int, payload["size_bytes"])),
+            sha256=str(payload["sha256"]),
+            data=urlsafe_b64decode(raw_value + padding),
+        )
+
+
 class MCPGoogleWorkspaceGateway(GoogleWorkspaceGateway):
     def __init__(self, *, transport: MCPTransport) -> None:
         self._transport = transport
@@ -30,20 +63,34 @@ class MCPGoogleWorkspaceGateway(GoogleWorkspaceGateway):
         *,
         claim_payload: dict[str, object],
         tool_name: str,
-        canonical_arguments_hash: str,
+        approval_arguments_hash: str,
+        execution_arguments_hash: str,
     ) -> dict[str, object]:
+        """Build and sign the R8.4 ClaimContextV2 envelope for one MCP write call.
+
+        ``approval_arguments_hash`` binds the business arguments the user
+        approved; ``execution_arguments_hash`` binds the actual final
+        arguments about to be dispatched (including any server-generated
+        metadata). MCP independently re-derives the latter from the
+        arguments it actually receives, so the two hashes must be kept
+        separate rather than collapsed into one value.
+        """
+
         transport = cast(Any, self._transport)
         process_instance_id = cast(str | None, getattr(transport, "process_instance_id", None))
         if process_instance_id is None:
             raise RuntimeError("mcp process instance id is unavailable")
         payload = {
+            "claim_version": 2,
             "action_id": str(claim_payload["action_id"]),
             "approval_id": str(claim_payload["approval_id"]),
             "execution_attempt_id": str(claim_payload["attempt_id"]),
             "tool_name": tool_name,
-            "canonical_arguments_hash": canonical_arguments_hash,
+            "approval_arguments_hash": approval_arguments_hash,
+            "execution_arguments_hash": execution_arguments_hash,
             "service_instance_id": str(claim_payload["service_instance_id"]),
             "mcp_process_instance_id": process_instance_id,
+            "issued_at_ms": int(str(claim_payload["issued_at_ms"])),
             "expires_at_ms": int(str(claim_payload["expires_at_ms"])),
             "nonce": str(claim_payload["nonce"]),
         }

--- a/src/google_work_agent/adapters/mcp/transport.py
+++ b/src/google_work_agent/adapters/mcp/transport.py
@@ -420,7 +420,6 @@ class SubprocessMCPTransport:
             try:
                 payload = self._wait_for_response(request_id=request_id)
             except MCPTransportError as error:
-                error.dispatch_started = True
                 self._last_safe_error_code = error.code.value
                 if (
                     error.code
@@ -464,26 +463,33 @@ class SubprocessMCPTransport:
                     raise MCPTransportError(
                         code=MCPTransportErrorCode.CONNECTION_CLOSED,
                         message="mcp child exited before responding",
+                        dispatch_started=True,
                     ) from error
                 continue
             if str(message.get("id")) != request_id:
                 raise MCPTransportError(
                     code=MCPTransportErrorCode.MALFORMED_RESPONSE,
                     message="unexpected response id",
+                    dispatch_started=True,
                 )
             if "error" in message:
                 error_payload = cast(dict[str, object], message["error"])
+                # A structured error response proves the child process ran the
+                # request and answered; only the server can know whether that
+                # answer came before or after any Google dispatch occurred.
                 raise MCPTransportError(
                     code=MCPTransportErrorCode(
                         str(error_payload.get("code", "MALFORMED_RESPONSE"))
                     ),
                     message=str(error_payload.get("message", "mcp request failed")),
+                    dispatch_started=bool(error_payload.get("dispatch_started", True)),
                 )
             response_payload = cast(JsonObject, message.get("payload", {}))
             return response_payload
         raise MCPTransportError(
             code=MCPTransportErrorCode.TIMEOUT,
             message="mcp request timed out",
+            dispatch_started=True,
         )
 
     def _read_stdout(self) -> None:

--- a/src/google_work_agent/adapters/runtime/attachment_staging.py
+++ b/src/google_work_agent/adapters/runtime/attachment_staging.py
@@ -1,0 +1,186 @@
+"""Local filesystem staging for outbound Gmail attachment bytes.
+
+Only this module ever holds raw attachment bytes. Every caller outside of
+this module (API routes, Application services, the MCP write handlers)
+exchanges an ``AttachmentDescriptor`` -- filename/mime_type/size_bytes/sha256
+plus a random staging identity -- never the bytes themselves. This keeps
+attachment content out of the domain database, LLM input, agent state, and
+trace/audit output by construction rather than by convention.
+
+The MCP child process and the local API service are separate processes on
+the same machine; they share this staging directory by path (see
+``GWA_ATTACHMENT_STAGING_DIR``) rather than through any RPC channel, so
+attachment bytes never cross the size-limited MCP stdio transport.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+STAGING_TTL_MS = 15 * 60 * 1000
+MAX_STAGED_FILE_BYTES = 8 * 1024 * 1024
+_ID_ALPHABET_BYTES = 24
+
+
+def _default_now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class AttachmentStagingError(RuntimeError):
+    """A sanitized staging failure. ``safe_code`` never contains file content."""
+
+    def __init__(self, safe_code: str) -> None:
+        super().__init__(safe_code)
+        self.safe_code = safe_code
+
+
+@dataclass(frozen=True, slots=True)
+class AttachmentDescriptor:
+    """Minimal Attachment Descriptor carried in Business Arguments and Claims."""
+
+    staged_attachment_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    sha256: str
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "staged_attachment_id": self.staged_attachment_id,
+            "filename": self.filename,
+            "mime_type": self.mime_type,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_json(cls, payload: dict[str, object]) -> AttachmentDescriptor:
+        try:
+            return cls(
+                staged_attachment_id=str(payload["staged_attachment_id"]),
+                filename=str(payload["filename"]),
+                mime_type=str(payload["mime_type"]),
+                size_bytes=int(cast(int, payload["size_bytes"])),
+                sha256=str(payload["sha256"]),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise AttachmentStagingError("ATTACHMENT_DESCRIPTOR_MALFORMED") from error
+
+
+class LocalAttachmentStaging:
+    """User-scoped, TTL'd, filesystem-backed attachment byte staging area."""
+
+    def __init__(
+        self,
+        *,
+        staging_dir: Path,
+        now_ms: Callable[[], int] = _default_now_ms,
+    ) -> None:
+        self._staging_dir = staging_dir
+        self._staging_dir.mkdir(parents=True, exist_ok=True)
+        self._now_ms = now_ms
+
+    def cleanup_expired(self) -> None:
+        """Remove every staged file/metadata pair past its TTL.
+
+        Safe to call at any time, including at process startup: it only
+        ever removes files whose recorded ``expires_at_ms`` has passed.
+        """
+
+        if not self._staging_dir.is_dir():
+            return
+        now_ms = self._now_ms()
+        for meta_path in self._staging_dir.glob("*.meta.json"):
+            staged_attachment_id = meta_path.name.removesuffix(".meta.json")
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+                expired = int(meta["expires_at_ms"]) <= now_ms
+            except (OSError, ValueError, KeyError, json.JSONDecodeError):
+                expired = True
+            if expired:
+                self._remove(staged_attachment_id)
+
+    def stage(self, *, data: bytes, filename: str, mime_type: str) -> AttachmentDescriptor:
+        if not data:
+            raise AttachmentStagingError("ATTACHMENT_EMPTY")
+        if len(data) > MAX_STAGED_FILE_BYTES:
+            raise AttachmentStagingError("ATTACHMENT_TOO_LARGE")
+        if not filename or len(filename) > 255 or "/" in filename or "\\" in filename:
+            raise AttachmentStagingError("ATTACHMENT_FILENAME_INVALID")
+        staged_attachment_id = secrets.token_urlsafe(_ID_ALPHABET_BYTES)
+        digest = hashlib.sha256(data).hexdigest()
+        expires_at_ms = self._now_ms() + STAGING_TTL_MS
+        self._data_path(staged_attachment_id).write_bytes(data)
+        self._meta_path(staged_attachment_id).write_text(
+            json.dumps(
+                {
+                    "filename": filename,
+                    "mime_type": mime_type,
+                    "size_bytes": len(data),
+                    "sha256": digest,
+                    "expires_at_ms": expires_at_ms,
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        return AttachmentDescriptor(
+            staged_attachment_id=staged_attachment_id,
+            filename=filename,
+            mime_type=mime_type,
+            size_bytes=len(data),
+            sha256=digest,
+        )
+
+    def read_verified(self, descriptor: AttachmentDescriptor) -> bytes:
+        """Re-read staged bytes and verify them against ``descriptor``.
+
+        Raises on anything that would let stale, tampered, or mismatched
+        content reach a Google write: missing staging id, expired TTL, size
+        mismatch, hash mismatch, or a descriptor that no longer matches what
+        was actually staged.
+        """
+
+        meta_path = self._meta_path(descriptor.staged_attachment_id)
+        data_path = self._data_path(descriptor.staged_attachment_id)
+        if not meta_path.is_file() or not data_path.is_file():
+            raise AttachmentStagingError("ATTACHMENT_STAGING_MISSING")
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise AttachmentStagingError("ATTACHMENT_STAGING_MISSING") from error
+        if int(meta["expires_at_ms"]) <= self._now_ms():
+            self._remove(descriptor.staged_attachment_id)
+            raise AttachmentStagingError("ATTACHMENT_STAGING_EXPIRED")
+        if (
+            str(meta["filename"]) != descriptor.filename
+            or str(meta["mime_type"]) != descriptor.mime_type
+        ):
+            raise AttachmentStagingError("ATTACHMENT_DESCRIPTOR_MISMATCH")
+        if int(meta["size_bytes"]) != descriptor.size_bytes:
+            raise AttachmentStagingError("ATTACHMENT_SIZE_MISMATCH")
+        if str(meta["sha256"]) != descriptor.sha256:
+            raise AttachmentStagingError("ATTACHMENT_HASH_MISMATCH")
+        data = data_path.read_bytes()
+        if len(data) != descriptor.size_bytes:
+            raise AttachmentStagingError("ATTACHMENT_SIZE_MISMATCH")
+        if hashlib.sha256(data).hexdigest() != descriptor.sha256:
+            raise AttachmentStagingError("ATTACHMENT_HASH_MISMATCH")
+        return data
+
+    def _remove(self, staged_attachment_id: str) -> None:
+        for path in (self._data_path(staged_attachment_id), self._meta_path(staged_attachment_id)):
+            path.unlink(missing_ok=True)
+
+    def _data_path(self, staged_attachment_id: str) -> Path:
+        return self._staging_dir / f"{staged_attachment_id}.bin"
+
+    def _meta_path(self, staged_attachment_id: str) -> Path:
+        return self._staging_dir / f"{staged_attachment_id}.meta.json"

--- a/src/google_work_agent/api/app.py
+++ b/src/google_work_agent/api/app.py
@@ -16,6 +16,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from google_work_agent.api.errors import ApiError, api_error_from_http, api_error_from_validation
 from google_work_agent.api.routes import (
     actions,
+    attachments,
     conversations,
     events,
     google,
@@ -98,6 +99,8 @@ class ApiContainer:
     delete_llm_api_key_service: Any | None = None
     test_llm_connection_service: Any | None = None
     resolve_recovery_service: Any | None = None
+    get_gmail_attachment_service: Any | None = None
+    stage_attachment_service: Any | None = None
     startup_callbacks: tuple[Callable[[], Awaitable[None]], ...] = ()
     shutdown_callbacks: tuple[Callable[[], None], ...] = ()
 
@@ -230,6 +233,7 @@ def create_app(container: ApiContainer) -> FastAPI:
     app.include_router(resources.router)
     app.include_router(settings.router)
     app.include_router(llm.router)
+    app.include_router(attachments.router)
 
     @app.api_route("/api/v1/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
     async def reject_unknown_api_path(request: Request, path: str) -> Response:

--- a/src/google_work_agent/api/routes/attachments.py
+++ b/src/google_work_agent/api/routes/attachments.py
@@ -1,0 +1,157 @@
+"""Gmail attachment download and outbound staging routes.
+
+Both routes are local-session gated like every other mutating/reading Local
+API endpoint. Neither route persists attachment bytes anywhere, logs them,
+or hands them to an LLM/agent: the download route streams bytes straight to
+the browser and discards them, and the staging route returns only an
+AttachmentDescriptor (metadata + hash), never the bytes it just staged.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import StreamingResponse
+
+from google_work_agent.adapters.runtime.attachment_staging import AttachmentStagingError
+from google_work_agent.api.dependencies import (
+    enforce_access,
+    enforce_api_contract_version,
+    get_container,
+)
+from google_work_agent.api.errors import ApiError
+from google_work_agent.api.schemas.attachments import (
+    AttachmentDescriptorResponse,
+    StageAttachmentRequest,
+)
+from google_work_agent.ports import (
+    EndpointPolicy,
+    GoogleWorkspaceErrorCode,
+    GoogleWorkspaceGatewayError,
+)
+
+router = APIRouter(prefix="/api/v1")
+
+_STAGING_ERROR_STATUS = {
+    "ATTACHMENT_EMPTY": 422,
+    "ATTACHMENT_TOO_LARGE": 413,
+    "ATTACHMENT_FILENAME_INVALID": 422,
+}
+
+
+@router.get("/gmail/messages/{message_id}/attachments/{attachment_id}")
+def download_gmail_attachment(
+    message_id: str,
+    attachment_id: str,
+    request: Request,
+    x_api_contract_version: str | None = Header(default=None),
+) -> StreamingResponse:
+    container = get_container(request)
+    enforce_access(request, policy=EndpointPolicy.API_SESSION_REQUIRED)
+    enforce_api_contract_version(
+        container=container,
+        request_id=request.state.request_id,
+        request_version=x_api_contract_version,
+    )
+    service = container.get_gmail_attachment_service
+    if service is None:
+        raise ApiError(
+            error_code="SERVICE_BUSY",
+            user_message="Attachment provider is not configured.",
+            status_code=503,
+            request_id=request.state.request_id,
+            detail_code="ATTACHMENT_SERVICE_UNAVAILABLE",
+        )
+    try:
+        attachment = service(message_id=message_id, attachment_id=attachment_id)
+    except GoogleWorkspaceGatewayError as error:
+        _raise_attachment_gateway_error(error, request_id=request.state.request_id)
+    return StreamingResponse(
+        iter([attachment.data]),
+        media_type="application/octet-stream",
+        headers={
+            "Content-Length": str(attachment.size_bytes),
+            "Content-Disposition": "attachment",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.post("/attachments/stage", response_model=AttachmentDescriptorResponse)
+def stage_attachment(
+    body: StageAttachmentRequest,
+    request: Request,
+    x_api_contract_version: str | None = Header(default=None),
+) -> AttachmentDescriptorResponse:
+    container = get_container(request)
+    enforce_access(request, policy=EndpointPolicy.API_SESSION_REQUIRED)
+    enforce_api_contract_version(
+        container=container,
+        request_id=request.state.request_id,
+        request_version=x_api_contract_version,
+    )
+    service = container.stage_attachment_service
+    if service is None:
+        raise ApiError(
+            error_code="SERVICE_BUSY",
+            user_message="Attachment staging is not configured.",
+            status_code=503,
+            request_id=request.state.request_id,
+            detail_code="ATTACHMENT_STAGING_SERVICE_UNAVAILABLE",
+        )
+    try:
+        data = base64.b64decode(body.data_base64, validate=True)
+    except binascii.Error as error:
+        raise ApiError(
+            error_code="INVALID_ATTACHMENT",
+            user_message="The attachment could not be staged.",
+            status_code=422,
+            request_id=request.state.request_id,
+            detail_code="ATTACHMENT_ENCODING_INVALID",
+        ) from error
+    try:
+        descriptor = service(data=data, filename=body.filename, mime_type=body.mime_type)
+    except AttachmentStagingError as error:
+        raise ApiError(
+            error_code="INVALID_ATTACHMENT",
+            user_message="The attachment could not be staged.",
+            status_code=_STAGING_ERROR_STATUS.get(error.safe_code, 422),
+            request_id=request.state.request_id,
+            detail_code=error.safe_code,
+        ) from error
+    return AttachmentDescriptorResponse(
+        staged_attachment_id=descriptor.staged_attachment_id,
+        filename=descriptor.filename,
+        mime_type=descriptor.mime_type,
+        size_bytes=descriptor.size_bytes,
+        sha256=descriptor.sha256,
+        api_contract_version=container.api_contract_version,
+    )
+
+
+def _raise_attachment_gateway_error(error: GoogleWorkspaceGatewayError, *, request_id: str) -> None:
+    mapping = {
+        GoogleWorkspaceErrorCode.INVALID_ARGUMENT: ("INVALID_ARGUMENT", 422, False),
+        GoogleWorkspaceErrorCode.AUTH_EXPIRED: ("AUTH_REQUIRED", 401, False),
+        GoogleWorkspaceErrorCode.PERMISSION_DENIED: ("PERMISSION_DENIED", 403, False),
+        GoogleWorkspaceErrorCode.NOT_FOUND: ("NOT_FOUND", 404, False),
+        GoogleWorkspaceErrorCode.RATE_LIMITED: ("UPSTREAM_UNAVAILABLE", 429, True),
+        GoogleWorkspaceErrorCode.UPSTREAM_5XX: ("UPSTREAM_UNAVAILABLE", 502, True),
+        GoogleWorkspaceErrorCode.TIMEOUT: ("UPSTREAM_UNAVAILABLE", 504, True),
+        GoogleWorkspaceErrorCode.CONNECTION_CLOSED: ("SERVICE_BUSY", 503, True),
+        GoogleWorkspaceErrorCode.RESPONSE_MALFORMED: ("UPSTREAM_UNAVAILABLE", 502, False),
+    }
+    error_code, status_code, retryable = mapping.get(
+        error.code,
+        ("UPSTREAM_UNAVAILABLE", 502, False),
+    )
+    raise ApiError(
+        error_code=error_code,
+        user_message="Google attachment request could not be completed.",
+        status_code=status_code,
+        request_id=request_id,
+        retryable=retryable,
+        detail_code=f"GOOGLE_{error.code.value}",
+    ) from error

--- a/src/google_work_agent/api/schemas/attachments.py
+++ b/src/google_work_agent/api/schemas/attachments.py
@@ -1,0 +1,25 @@
+"""Gmail attachment staging API schemas."""
+
+from google_work_agent.api.schemas.common import ApiModel
+
+
+class StageAttachmentRequest(ApiModel):
+    """Base64-encoded upload body.
+
+    The mutation endpoints in this API only ever accept
+    ``Content-Type: application/json`` (see access_guard's CSRF content-type
+    check), so this stays a JSON body rather than a multipart upload.
+    """
+
+    filename: str
+    mime_type: str
+    data_base64: str
+
+
+class AttachmentDescriptorResponse(ApiModel):
+    staged_attachment_id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    sha256: str
+    api_contract_version: str

--- a/src/google_work_agent/application/attachments.py
+++ b/src/google_work_agent/application/attachments.py
@@ -1,0 +1,31 @@
+"""Application services for Gmail attachment READ and outbound staging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from google_work_agent.adapters.runtime.attachment_staging import (
+    AttachmentDescriptor,
+    LocalAttachmentStaging,
+)
+from google_work_agent.ports import GmailAttachmentBytes, GmailAttachmentGateway
+
+
+@dataclass(frozen=True, slots=True)
+class GetGmailAttachmentService:
+    """Fetch one Gmail attachment's bytes for the download route to stream."""
+
+    gateway: GmailAttachmentGateway
+
+    def __call__(self, *, message_id: str, attachment_id: str) -> GmailAttachmentBytes:
+        return self.gateway.get_gmail_attachment(message_id=message_id, attachment_id=attachment_id)
+
+
+@dataclass(frozen=True, slots=True)
+class StageAttachmentService:
+    """Stage one outbound attachment's bytes and return its descriptor."""
+
+    staging: LocalAttachmentStaging
+
+    def __call__(self, *, data: bytes, filename: str, mime_type: str) -> AttachmentDescriptor:
+        return self.staging.stage(data=data, filename=filename, mime_type=mime_type)

--- a/src/google_work_agent/application/google_connection.py
+++ b/src/google_work_agent/application/google_connection.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from typing import Protocol
 
 from google_work_agent.ports import (
     DisconnectResult,
@@ -10,6 +12,18 @@ from google_work_agent.ports import (
     GoogleOAuthCredentialProvider,
     OAuthStartResult,
 )
+
+
+class GoogleAccountProvisioner(Protocol):
+    """Identity-record side of an observed Google connection.
+
+    Kept as a narrow Protocol so GetGoogleConnectionService does not need to
+    know about SQLite or the `google_accounts` table directly.
+    """
+
+    def ensure_google_account_connected(
+        self, *, email: str, display_name: str | None, now_ms: int
+    ) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,9 +37,23 @@ class StartGoogleOAuthService:
 @dataclass(frozen=True, slots=True)
 class GetGoogleConnectionService:
     provider: GoogleOAuthCredentialProvider
+    account_provisioner: GoogleAccountProvisioner | None = None
+    now_ms: Callable[[], int] | None = None
 
     def __call__(self) -> GoogleConnectionStatus:
-        return self.provider.get_connection_status()
+        status = self.provider.get_connection_status()
+        if (
+            self.account_provisioner is not None
+            and self.now_ms is not None
+            and status.connected
+            and status.account_email is not None
+        ):
+            self.account_provisioner.ensure_google_account_connected(
+                email=status.account_email,
+                display_name=status.display_name,
+                now_ms=self.now_ms(),
+            )
+        return status
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/google_work_agent/application/queries.py
+++ b/src/google_work_agent/application/queries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from hashlib import sha256
 from json import loads
 from pathlib import Path
 from sqlite3 import Row
@@ -456,6 +457,37 @@ class QueryService:
             display_name=None if row["display_name"] is None else str(row["display_name"]),
         )
 
+    def ensure_google_account_connected(
+        self, *, email: str, display_name: str | None, now_ms: int
+    ) -> None:
+        """Provision or reactivate the `google_accounts` row for one email.
+
+        This is the only writer of `google_accounts`: it runs whenever the
+        API observes a resolved, connected account (see
+        GetGoogleConnectionService), keyed by email so a reconnect with the
+        same Google account reuses its existing id rather than orphaning
+        conversations that reference it as a foreign key.
+        """
+
+        account_id = _google_account_id_for_email(email)
+        with connect_sqlite(self._database_path) as connection:
+            connection.execute(
+                """
+                INSERT INTO google_accounts
+                    (id, email, display_name, connected_at_ms, disconnected_at_ms)
+                VALUES (:id, :email, :display_name, :now_ms, NULL)
+                ON CONFLICT(email) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    disconnected_at_ms = NULL;
+                """,
+                {
+                    "id": account_id,
+                    "email": email,
+                    "display_name": display_name,
+                    "now_ms": now_ms,
+                },
+            )
+
 
 def _validated_page_size(page_size: int) -> int:
     if page_size < 1:
@@ -463,6 +495,13 @@ def _validated_page_size(page_size: int) -> int:
     if page_size > MAX_PAGE_SIZE:
         raise ValueError(f"page_size must be <= {MAX_PAGE_SIZE}")
     return page_size
+
+
+def _google_account_id_for_email(email: str) -> str:
+    """Deterministic id so re-provisioning the same email is naturally idempotent."""
+
+    digest = sha256(email.strip().lower().encode("utf-8")).hexdigest()
+    return f"acct-{digest[:24]}"
 
 
 def _parse_keyset_cursor(cursor: str) -> tuple[int, str]:

--- a/src/google_work_agent/application/write_actions.py
+++ b/src/google_work_agent/application/write_actions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
@@ -1040,6 +1041,7 @@ class ExecuteWriteActionService:
         self._signing_secret = signing_secret
         self._service_instance_id = service_instance_id
         self._used_nonces: set[str] = set()
+        self._nonce_lock = threading.Lock()
 
     def __call__(self, *, action_id: str, claim_token: str) -> ExecutedWriteActionResult:
         payload = read_claim_token(claim_token, signing_secret=self._signing_secret)
@@ -1048,34 +1050,53 @@ class ExecuteWriteActionService:
         if self._now_ms() >= _coerce_int(payload["expires_at_ms"]):
             raise PermissionError("claim token has expired")
         nonce = str(payload["nonce"])
-        if nonce in self._used_nonces:
-            raise PermissionError("claim token has already been used")
+        # Atomically check-and-reserve the nonce before doing anything else so
+        # two concurrent callers holding the same claim token can never both
+        # pass this gate, regardless of what happens to either request next.
+        with self._nonce_lock:
+            if nonce in self._used_nonces:
+                raise PermissionError("claim token has already been used")
+            self._used_nonces.add(nonce)
 
-        with self._unit_of_work_factory() as unit_of_work:
-            action = _require_action(unit_of_work, action_id)
-            plan = _require_plan(unit_of_work, action.plan_id)
-            run = _require_run(unit_of_work, plan.run_id)
-            if run.status in {RunStatus.CANCEL_REQUESTED, RunStatus.CANCELLED}:
-                raise PermissionError("run cancellation forbids Google write dispatch")
-            approval = _require_approval(unit_of_work, str(payload["approval_id"]))
-            attempt = _require_attempt(unit_of_work, str(payload["attempt_id"]))
-            if action.id != str(payload["action_id"]):
-                raise PermissionError("claim token action binding mismatch")
-            if action.tool_name != str(payload["tool_name"]):
-                raise PermissionError("claim token tool binding mismatch")
-            if action.arguments_hash != str(payload["arguments_hash"]):
-                raise PermissionError("claim token arguments binding mismatch")
-            if approval.action_id != action.id or attempt.approval_id != approval.id:
-                raise PermissionError("claim token persistence binding mismatch")
-            if attempt.status is not ExecutionAttemptStatus.CLAIMED:
-                raise PermissionError("execution attempt is not claimable")
+        try:
+            with self._unit_of_work_factory() as unit_of_work:
+                action = _require_action(unit_of_work, action_id)
+                plan = _require_plan(unit_of_work, action.plan_id)
+                run = _require_run(unit_of_work, plan.run_id)
+                if run.status in {RunStatus.CANCEL_REQUESTED, RunStatus.CANCELLED}:
+                    raise PermissionError("run cancellation forbids Google write dispatch")
+                approval = _require_approval(unit_of_work, str(payload["approval_id"]))
+                attempt = _require_attempt(unit_of_work, str(payload["attempt_id"]))
+                if action.id != str(payload["action_id"]):
+                    raise PermissionError("claim token action binding mismatch")
+                if action.tool_name != str(payload["tool_name"]):
+                    raise PermissionError("claim token tool binding mismatch")
+                if action.arguments_hash != str(payload["arguments_hash"]):
+                    raise PermissionError("claim token arguments binding mismatch")
+                if approval.action_id != action.id or attempt.approval_id != approval.id:
+                    raise PermissionError("claim token persistence binding mismatch")
+                if attempt.status is not ExecutionAttemptStatus.CLAIMED:
+                    raise PermissionError("execution attempt is not claimable")
+        except Exception:
+            # Nothing was dispatched: release the nonce so a legitimate retry
+            # of this same claim token (e.g. a langgraph resume that re-runs
+            # execution after a transient pre-dispatch validation failure) is
+            # not permanently blocked by a claim that never reached Google.
+            with self._nonce_lock:
+                self._used_nonces.discard(nonce)
+            raise
 
-        self._used_nonces.add(nonce)
+        final_arguments = _build_final_dispatch_arguments(
+            action.tool_name,
+            loads(action.arguments_json),
+            recovery_fingerprint=approval.recovery_fingerprint,
+        )
         claim_context = _prepare_gateway_claim_context(
             gateway=self._gateway,
             claim_payload=payload,
             tool_name=action.tool_name,
-            canonical_arguments_hash=action.arguments_hash,
+            approval_arguments_hash=action.arguments_hash,
+            execution_arguments_hash=calculate_canonical_json_hash(final_arguments),
         )
         snapshot = _dispatch_write_action(
             self._gateway,
@@ -2883,26 +2904,30 @@ def _validate_write_plan(
         )
 
 
-def _dispatch_write_action(
-    gateway: GoogleWorkspaceGateway,
+def _build_final_dispatch_arguments(
     tool_name: str,
     arguments: dict[str, object],
     *,
-    recovery_fingerprint: str | None = None,
-    claim_context: dict[str, object] | None = None,
-) -> ResourceSnapshot:
+    recovery_fingerprint: str | None,
+) -> dict[str, object]:
+    """Build the exact argument dict a write tool call dispatches with.
+
+    ``ExecuteWriteActionService`` also canonicalizes this same dict to
+    compute ClaimContextV2's ``execution_arguments_hash``, so it must stay
+    byte-for-byte identical to what ``_dispatch_write_action`` sends to the
+    gateway/MCP tool below.
+    """
+
     if tool_name == "gmail_send":
-        return gateway.send_gmail(
-            draft_id=_required_argument_string(arguments, "draft_id"),
-            recovery_fingerprint=recovery_fingerprint,
-            claim_context=claim_context,
-        )
+        return {
+            "draft_id": _required_argument_string(arguments, "draft_id"),
+            "recovery_fingerprint": recovery_fingerprint,
+        }
     if tool_name == "calendar_delete_event":
-        return gateway.delete_calendar_event(
-            calendar_id=_required_argument_string(arguments, "calendar_id"),
-            event_id=_required_argument_string(arguments, "event_id"),
-            claim_context=claim_context,
-        )
+        return {
+            "calendar_id": _required_argument_string(arguments, "calendar_id"),
+            "event_id": _required_argument_string(arguments, "event_id"),
+        }
     payload = _dict_argument(arguments.get("payload"))
     payload_with_recovery = dict(payload)
     if recovery_fingerprint is not None and tool_name in {
@@ -2912,40 +2937,92 @@ def _dispatch_write_action(
     }:
         payload_with_recovery["recovery_fingerprint"] = recovery_fingerprint
     if tool_name == "gmail_create_draft":
+        return {"payload": payload_with_recovery}
+    if tool_name == "gmail_update_draft":
+        return {"draft_id": str(arguments["draft_id"]), "payload": payload}
+    if tool_name == "tasks_create_task":
+        return {
+            "task_list_id": str(arguments["task_list_id"]),
+            "payload": payload_with_recovery,
+        }
+    if tool_name == "tasks_update_task":
+        return {
+            "task_list_id": str(arguments["task_list_id"]),
+            "task_id": str(arguments["task_id"]),
+            "payload": payload,
+        }
+    if tool_name == "calendar_create_event":
+        return {
+            "calendar_id": str(arguments["calendar_id"]),
+            "payload": payload_with_recovery,
+        }
+    if tool_name == "calendar_update_event":
+        return {
+            "calendar_id": str(arguments["calendar_id"]),
+            "event_id": str(arguments["event_id"]),
+            "payload": payload,
+        }
+    raise LookupError(f"unsupported write tool: {tool_name}")
+
+
+def _dispatch_write_action(
+    gateway: GoogleWorkspaceGateway,
+    tool_name: str,
+    arguments: dict[str, object],
+    *,
+    recovery_fingerprint: str | None = None,
+    claim_context: dict[str, object] | None = None,
+) -> ResourceSnapshot:
+    final_arguments = _build_final_dispatch_arguments(
+        tool_name, arguments, recovery_fingerprint=recovery_fingerprint
+    )
+    if tool_name == "gmail_send":
+        return gateway.send_gmail(
+            draft_id=cast(str, final_arguments["draft_id"]),
+            recovery_fingerprint=cast(str | None, final_arguments["recovery_fingerprint"]),
+            claim_context=claim_context,
+        )
+    if tool_name == "calendar_delete_event":
+        return gateway.delete_calendar_event(
+            calendar_id=cast(str, final_arguments["calendar_id"]),
+            event_id=cast(str, final_arguments["event_id"]),
+            claim_context=claim_context,
+        )
+    if tool_name == "gmail_create_draft":
         return gateway.create_gmail_draft(
-            payload=payload_with_recovery,
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     if tool_name == "gmail_update_draft":
         return gateway.update_gmail_draft(
-            draft_id=str(arguments["draft_id"]),
-            payload=payload,
+            draft_id=cast(str, final_arguments["draft_id"]),
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     if tool_name == "tasks_create_task":
         return gateway.create_task(
-            task_list_id=str(arguments["task_list_id"]),
-            payload=payload_with_recovery,
+            task_list_id=cast(str, final_arguments["task_list_id"]),
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     if tool_name == "tasks_update_task":
         return gateway.update_task(
-            task_list_id=str(arguments["task_list_id"]),
-            task_id=str(arguments["task_id"]),
-            payload=payload,
+            task_list_id=cast(str, final_arguments["task_list_id"]),
+            task_id=cast(str, final_arguments["task_id"]),
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     if tool_name == "calendar_create_event":
         return gateway.create_calendar_event(
-            calendar_id=str(arguments["calendar_id"]),
-            payload=payload_with_recovery,
+            calendar_id=cast(str, final_arguments["calendar_id"]),
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     if tool_name == "calendar_update_event":
         return gateway.update_calendar_event(
-            calendar_id=str(arguments["calendar_id"]),
-            event_id=str(arguments["event_id"]),
-            payload=payload,
+            calendar_id=cast(str, final_arguments["calendar_id"]),
+            event_id=cast(str, final_arguments["event_id"]),
+            payload=cast(dict[str, object], final_arguments["payload"]),
             claim_context=claim_context,
         )
     raise LookupError(f"unsupported write tool: {tool_name}")
@@ -2956,7 +3033,8 @@ def _prepare_gateway_claim_context(
     gateway: GoogleWorkspaceGateway,
     claim_payload: dict[str, object],
     tool_name: str,
-    canonical_arguments_hash: str,
+    approval_arguments_hash: str,
+    execution_arguments_hash: str,
 ) -> dict[str, object] | None:
     prepare = getattr(gateway, "prepare_claim_context", None)
     if not callable(prepare):
@@ -2966,7 +3044,8 @@ def _prepare_gateway_claim_context(
         prepare(
             claim_payload=claim_payload,
             tool_name=tool_name,
-            canonical_arguments_hash=canonical_arguments_hash,
+            approval_arguments_hash=approval_arguments_hash,
+            execution_arguments_hash=execution_arguments_hash,
         ),
     )
 

--- a/src/google_work_agent/launcher/dev.py
+++ b/src/google_work_agent/launcher/dev.py
@@ -684,7 +684,11 @@ def build_container(
         bootstrap_grant_store=grant_store,
         local_session_manager=session_manager,
         start_google_oauth_service=StartGoogleOAuthService(provider=google_provider),
-        get_google_connection_service=GetGoogleConnectionService(provider=google_provider),
+        get_google_connection_service=GetGoogleConnectionService(
+            provider=google_provider,
+            account_provisioner=query_service,
+            now_ms=clock.now_ms,
+        ),
         disconnect_google_service=DisconnectGoogleService(provider=google_provider),
         resource_query_service=ResourceQueryService(gateway=gateway),
         get_llm_connection_service=GetLLMConnectionService(

--- a/src/google_work_agent/mcp/server.py
+++ b/src/google_work_agent/mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -13,6 +14,9 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
+from email import policy
+from email.message import EmailMessage
+from email.parser import BytesParser
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import cast
@@ -21,8 +25,13 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 from google_work_agent.adapters.keyring import OSKeyringSecretStore
-from google_work_agent.adapters.mcp.transport import PROTOCOL_VERSION
-from google_work_agent.domain import build_p0_tool_registry
+from google_work_agent.adapters.mcp.transport import MANIFEST_MESSAGE_LIMIT_BYTES, PROTOCOL_VERSION
+from google_work_agent.adapters.runtime.attachment_staging import (
+    AttachmentDescriptor,
+    AttachmentStagingError,
+    LocalAttachmentStaging,
+)
+from google_work_agent.domain import build_p0_tool_registry, calculate_canonical_json_hash
 from google_work_agent.mcp.settings import GoogleOAuthSettings
 from google_work_agent.ports import CredentialState, OAuthEnvironment, SecretStore, TimeRange
 
@@ -32,6 +41,8 @@ GOOGLE_REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke"
 GOOGLE_KEYRING_SERVICE = "GoogleWorkAgent/DEVELOPMENT"
 GOOGLE_REFRESH_TOKEN_ACCOUNT = "google-oauth-refresh-token"
 REQUIRED_SCOPES = (
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.compose",
     "https://www.googleapis.com/auth/tasks",
@@ -42,6 +53,31 @@ REQUIRED_SCOPES = (
 OAUTH_FLOW_TTL_MS = 60_000
 DEFAULT_ACCESS_TOKEN_TTL_MS = 3_600_000
 GOOGLE_API_TIMEOUT_SECONDS = 30
+
+CLAIM_CONTEXT_VERSION = 2
+CLAIM_CONTEXT_MAX_TTL_MS = 60_000
+CLAIM_CONTEXT_REQUIRED_FIELDS = (
+    "claim_version",
+    "service_instance_id",
+    "mcp_process_instance_id",
+    "action_id",
+    "approval_id",
+    "execution_attempt_id",
+    "tool_name",
+    "approval_arguments_hash",
+    "execution_arguments_hash",
+    "issued_at_ms",
+    "expires_at_ms",
+    "nonce",
+    "signature",
+)
+RECOVERY_MARKER_PREFIX = chr(0x200B) + "gwa-recovery-fingerprint:"
+
+# The whole outer JSON-RPC line (id + payload + base64 attachment data) must
+# fit inside MANIFEST_MESSAGE_LIMIT_BYTES on the stdio transport. Base64
+# inflates raw bytes by ~4/3; this leaves headroom for JSON/envelope overhead.
+MAX_ATTACHMENT_READ_BYTES = int(MANIFEST_MESSAGE_LIMIT_BYTES * 0.7 / 1.35)
+ATTACHMENT_STAGING_DIR_ENV = "GWA_ATTACHMENT_STAGING_DIR"
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,11 +116,21 @@ class _OAuthReauthenticationRequired(RuntimeError):
 
 
 class _WorkspaceToolError(RuntimeError):
-    """A sanitized Google Workspace read failure."""
+    """A sanitized Google Workspace tool failure.
 
-    def __init__(self, safe_code: str) -> None:
+    ``dispatch_started`` records whether a real Google API request may have
+    already been sent when this error was raised. It defaults to ``False``
+    because most raise sites (argument validation, claim rejection, missing
+    OAuth connection) run strictly before any Google call. Call sites that
+    raise after invoking ``urlopen`` must pass ``dispatch_started=True`` so
+    the client cannot mistake an ambiguous post-dispatch failure for a
+    provably-not-sent one.
+    """
+
+    def __init__(self, safe_code: str, *, dispatch_started: bool = False) -> None:
         super().__init__(safe_code)
         self.safe_code = safe_code
+        self.dispatch_started = dispatch_started
 
 
 class _WorkspaceState:
@@ -92,6 +138,10 @@ class _WorkspaceState:
         self.process_instance_id = f"mcp-{secrets.token_hex(8)}"
         self.service_instance_id: str | None = None
         self.session_key: str | None = None
+        # Consumed ClaimContextV2 nonces. The stdin dispatch loop in main()
+        # processes one request at a time, so no lock is required: a claim
+        # can only be validated and consumed by one in-flight request.
+        self.used_nonces: set[str] = set()
         self.connection_state = CredentialState.NOT_CONNECTED
         self.account_email: str | None = None
         self.display_name: str | None = None
@@ -146,13 +196,20 @@ class _WorkspaceState:
             if refresh_token is None:
                 self.connection_state = CredentialState.NOT_CONNECTED
                 return
-            access_token, expires_at_ms, rotated_refresh_token = _refresh_access_token(
-                refresh_token,
-                self.oauth_settings.google_oauth_client_id,
-                self.oauth_settings.google_oauth_client_secret,
+            access_token, expires_at_ms, rotated_refresh_token, refreshed_email = (
+                _refresh_access_token(
+                    refresh_token,
+                    self.oauth_settings.google_oauth_client_id,
+                    self.oauth_settings.google_oauth_client_secret,
+                )
             )
             self.access_token = access_token
             self.access_token_expires_at_ms = expires_at_ms
+            if refreshed_email is not None:
+                # Access tokens (and the id_token that arrives with them) are
+                # process-memory-only, so a restarted MCP process re-derives
+                # the account email here instead of requiring reconnect.
+                self.account_email = refreshed_email
             if rotated_refresh_token is not None:
                 self.keyring.set_secret(
                     service=GOOGLE_KEYRING_SERVICE,
@@ -206,6 +263,8 @@ def main() -> None:
                     "error": {
                         "code": "TOOL_REJECTED",
                         "message": "Google OAuth token exchange failed.",
+                        # Token refresh always runs before any workspace write dispatch.
+                        "dispatch_started": False,
                     },
                 }
             )
@@ -216,16 +275,30 @@ def main() -> None:
                     "error": {
                         "code": "TOOL_REJECTED",
                         "message": error.safe_code,
+                        "dispatch_started": error.dispatch_started,
                     },
                 }
             )
         except KeyError as error:
-            _write({"id": request_id, "error": {"code": "NOT_FOUND", "message": str(error)}})
+            _write(
+                {
+                    "id": request_id,
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": str(error),
+                        "dispatch_started": True,
+                    },
+                }
+            )
         except Exception:
             _write(
                 {
                     "id": request_id,
-                    "error": {"code": "MALFORMED_RESPONSE", "message": "MCP request failed."},
+                    "error": {
+                        "code": "MALFORMED_RESPONSE",
+                        "message": "MCP request failed.",
+                        "dispatch_started": True,
+                    },
                 }
             )
 
@@ -265,19 +338,30 @@ def _dispatch(state: _WorkspaceState, request: dict[str, object]) -> dict[str, o
 def _tool_call(
     state: _WorkspaceState, *, tool_name: str, arguments: dict[str, object]
 ) -> dict[str, object]:
-    read_tools = {
+    tools = {
         "gmail_search_threads": _gmail_search_threads,
         "gmail_get_thread": _gmail_get_thread,
         "gmail_get_message": _gmail_get_message,
+        "gmail_get_draft": _gmail_get_draft,
+        "gmail_get_attachment": _gmail_get_attachment,
+        "gmail_create_draft": _gmail_create_draft,
+        "gmail_update_draft": _gmail_update_draft,
+        "gmail_send": _gmail_send,
         "tasks_list_tasklists": _tasks_list_tasklists,
         "tasks_list_tasks": _tasks_list_tasks,
         "tasks_get_task": _tasks_get_task,
+        "tasks_create_task": _tasks_create_task,
+        "tasks_update_task": _tasks_update_task,
         "calendar_list_calendars": _calendar_list_calendars,
         "calendar_list_events": _calendar_list_events,
         "calendar_get_event": _calendar_get_event,
         "calendar_query_freebusy": _calendar_query_freebusy,
+        "calendar_create_event": _calendar_create_event,
+        "calendar_update_event": _calendar_update_event,
+        "calendar_delete_event": _calendar_delete_event,
+        "search_by_recovery_fingerprint": _search_by_recovery_fingerprint,
     }
-    handler = read_tools.get(tool_name)
+    handler = tools.get(tool_name)
     if handler is None:
         raise _WorkspaceToolError("TOOL_NOT_AVAILABLE")
     return handler(state, arguments)
@@ -361,6 +445,389 @@ def _gmail_get_message(state: _WorkspaceState, arguments: dict[str, object]) -> 
     }
 
 
+def _gmail_get_draft(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    draft_id = _text_argument(arguments, "draft_id", maximum=2048)
+    payload = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{quote(draft_id, safe='')}",
+        {"format": "metadata"},
+    )
+    return {"item": _gmail_draft_snapshot(payload)}
+
+
+def _gmail_get_attachment(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    """Return one Gmail attachment's bytes for the FastAPI download route to stream.
+
+    This tool never touches Agent state, SQLite, or trace/audit output --
+    the caller (a Local API route) streams the returned bytes straight to
+    the browser and discards them. Attachments that would not fit inside a
+    single stdio message are rejected rather than silently truncated.
+    """
+
+    message_id = _text_argument(arguments, "message_id", maximum=2048)
+    attachment_id = _text_argument(arguments, "attachment_id", maximum=2048)
+    payload = _google_api(
+        state,
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages/"
+        f"{quote(message_id, safe='')}/attachments/{quote(attachment_id, safe='')}",
+    )
+    raw_value = _optional_text(payload.get("data"))
+    if raw_value is None:
+        raise _WorkspaceToolError("INVALID_MCP_OUTPUT", dispatch_started=True)
+    data = _b64url_decode(raw_value)
+    if len(data) > MAX_ATTACHMENT_READ_BYTES:
+        raise _WorkspaceToolError("ATTACHMENT_TOO_LARGE", dispatch_started=True)
+    return {
+        "message_id": message_id,
+        "attachment_id": attachment_id,
+        "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "data_base64url": _b64url_encode(data),
+    }
+
+
+def _gmail_draft_snapshot(payload: dict[str, object]) -> dict[str, object]:
+    draft_id = _required_response_text(payload, "id")
+    message = cast(dict[str, object], payload.get("message") or {})
+    headers = _headers(message)
+    return _snapshot(
+        "gmail_draft",
+        draft_id,
+        _optional_text(message.get("threadId")),
+        (),
+        message.get("historyId"),
+        {
+            "subject": headers.get("subject", draft_id),
+            "to": headers.get("to"),
+            "message_id": _optional_text(message.get("id")),
+            "thread_id": _optional_text(message.get("threadId")),
+        },
+    )
+
+
+def _gmail_create_draft(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="gmail_create_draft",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    mime_bytes = _build_gmail_mime(payload)
+    body: dict[str, object] = {"message": {"raw": _b64url_encode(mime_bytes)}}
+    thread_id = _optional_text(payload.get("thread_id"))
+    if thread_id:
+        cast(dict[str, object], body["message"])["threadId"] = thread_id
+    response = _google_api_post(
+        state, "https://gmail.googleapis.com/gmail/v1/users/me/drafts", body
+    )
+    return {"item": _gmail_draft_snapshot(response)}
+
+
+def _gmail_update_draft(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    draft_id = _text_argument(arguments, "draft_id", maximum=2048)
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="gmail_update_draft",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    mime_bytes = _build_gmail_mime(payload)
+    body: dict[str, object] = {"message": {"raw": _b64url_encode(mime_bytes)}}
+    thread_id = _optional_text(payload.get("thread_id"))
+    if thread_id:
+        cast(dict[str, object], body["message"])["threadId"] = thread_id
+    response = _google_api_call(
+        state,
+        "PUT",
+        f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{quote(draft_id, safe='')}",
+        body=body,
+    )
+    return {"item": _gmail_draft_snapshot(response)}
+
+
+def _gmail_send(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    draft_id = _text_argument(arguments, "draft_id", maximum=2048)
+    recovery_fingerprint = _optional_text(arguments.get("recovery_fingerprint"))
+    _validate_claim_context(
+        state,
+        tool_name="gmail_send",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    if recovery_fingerprint:
+        _embed_send_recovery_marker(
+            state, draft_id=draft_id, recovery_fingerprint=recovery_fingerprint
+        )
+    response = _google_api_post(
+        state,
+        "https://gmail.googleapis.com/gmail/v1/users/me/drafts/send",
+        {"id": draft_id},
+    )
+    headers = _headers(response)
+    message_id = _required_response_text(response, "id")
+    return {
+        "item": _snapshot(
+            "gmail_message",
+            message_id,
+            _optional_text(response.get("threadId")),
+            (),
+            response.get("historyId"),
+            {
+                "subject": headers.get("subject"),
+                "sent": True,
+                "draft_id": draft_id,
+            },
+        )
+    }
+
+
+def _embed_send_recovery_marker(
+    state: _WorkspaceState, *, draft_id: str, recovery_fingerprint: str
+) -> None:
+    """Append a SEND-time recovery marker to the draft body before sending.
+
+    A SEND's own recovery fingerprint differs from the CREATE draft's, and
+    Gmail's send call cannot carry extra metadata, so the only way to make
+    an uncertain SEND recoverable by content search is to fold the marker
+    into the draft immediately before send -- an operational, server-generated
+    edit ClaimContextV2's execution_arguments_hash already accounts for, not
+    a change to any approved business content.
+    """
+
+    existing = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{quote(draft_id, safe='')}",
+        {"format": "raw"},
+    )
+    raw_message = cast(dict[str, object], existing.get("message") or {})
+    raw_value = _optional_text(raw_message.get("raw"))
+    if raw_value is None:
+        raise _WorkspaceToolError("INVALID_MCP_OUTPUT", dispatch_started=True)
+    parsed = BytesParser(policy=policy.default).parsebytes(_b64url_decode(raw_value))
+    body_text = ""
+    if not parsed.is_multipart():
+        content = parsed.get_content()
+        if isinstance(content, str):
+            body_text = content
+    rebuilt = EmailMessage()
+    for header in ("To", "Cc", "Bcc", "Subject"):
+        value = parsed.get(header)
+        if value is not None:
+            rebuilt[header] = str(value)
+    marker = _recovery_marker(recovery_fingerprint)
+    rebuilt.set_content(f"{body_text}\n\n{marker}" if body_text else marker)
+    _google_api_call(
+        state,
+        "PUT",
+        f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{quote(draft_id, safe='')}",
+        body={"message": {"raw": _b64url_encode(rebuilt.as_bytes())}},
+    )
+
+
+def _gmail_recipients(payload: dict[str, object], name: str, *, required: bool) -> list[str]:
+    value = payload.get(name)
+    if value is None:
+        if required:
+            raise _WorkspaceToolError("INVALID_ARGUMENT")
+        return []
+    if not isinstance(value, list) or not value:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return [_text_value(item, maximum=320) for item in cast(list[object], value)]
+
+
+def _build_gmail_mime(payload: dict[str, object]) -> bytes:
+    to = _gmail_recipients(payload, "to", required=True)
+    cc = _gmail_recipients(payload, "cc", required=False)
+    bcc = _gmail_recipients(payload, "bcc", required=False)
+    if len(to) + len(cc) + len(bcc) > 50:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    subject = _text_argument(payload, "subject", maximum=998, allow_empty=True)
+    body = _text_argument(payload, "body", maximum=65536, allow_empty=True)
+    message = EmailMessage()
+    message["To"] = ", ".join(to)
+    if cc:
+        message["Cc"] = ", ".join(cc)
+    if bcc:
+        message["Bcc"] = ", ".join(bcc)
+    message["Subject"] = subject
+    # Only CREATE dispatch injects recovery_fingerprint into the payload
+    # (see _build_final_dispatch_arguments); gmail_update_draft payloads
+    # never carry it, so updates never gain or lose the marker.
+    recovery_fingerprint = _optional_text(payload.get("recovery_fingerprint"))
+    content = (
+        f"{body}\n\n{_recovery_marker(recovery_fingerprint)}" if recovery_fingerprint else body
+    )
+    message.set_content(content)
+    _attach_staged_files(message, payload)
+    return message.as_bytes()
+
+
+def _attachment_staging() -> LocalAttachmentStaging:
+    staging_dir = os.environ.get(ATTACHMENT_STAGING_DIR_ENV)
+    if not staging_dir:
+        raise _WorkspaceToolError("ATTACHMENT_STAGING_UNAVAILABLE")
+    return LocalAttachmentStaging(staging_dir=Path(staging_dir))
+
+
+def _attach_staged_files(message: EmailMessage, payload: dict[str, object]) -> None:
+    """Read and MIME-embed each staged attachment, re-verifying it first.
+
+    Only descriptors (identity + hash) ever travel through Approval, Claim,
+    and this argument payload; the actual bytes are read fresh from local
+    staging immediately before assembly and are re-verified against the
+    descriptor's recorded size/sha256 -- never trusted from the descriptor
+    alone.
+    """
+
+    if "attachments" not in payload:
+        return
+    attachments = payload.get("attachments")
+    if not isinstance(attachments, list) or len(attachments) > 10:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    staging = _attachment_staging()
+    for item in cast(list[object], attachments):
+        if not isinstance(item, dict):
+            raise _WorkspaceToolError("INVALID_ARGUMENT")
+        try:
+            descriptor = AttachmentDescriptor.from_json(cast(dict[str, object], item))
+            data = staging.read_verified(descriptor)
+        except AttachmentStagingError as error:
+            raise _WorkspaceToolError(error.safe_code) from error
+        maintype, _, subtype = descriptor.mime_type.partition("/")
+        message.add_attachment(
+            data,
+            maintype=maintype or "application",
+            subtype=subtype or "octet-stream",
+            filename=descriptor.filename,
+        )
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _recovery_marker(recovery_fingerprint: str) -> str:
+    """Zero-width, body-embedded marker used to locate a write's own effect.
+
+    Recovery search for CREATE/SEND has no server-assigned recovery ID to
+    key off before the write happens, so the deterministic
+    ``recovery_fingerprint`` computed at approval time is embedded into the
+    resource's own searchable text (Gmail body, Task notes, Event
+    description) and later located with a full-text/notes search. The
+    leading zero-width space keeps it effectively invisible to the user
+    without altering the approved visible content.
+    """
+
+    return f"{RECOVERY_MARKER_PREFIX}{recovery_fingerprint}"
+
+
+def _dict_argument(arguments: dict[str, object], name: str) -> dict[str, object]:
+    value = arguments.get(name)
+    if not isinstance(value, dict):
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return cast(dict[str, object], value)
+
+
+def _execution_arguments(arguments: dict[str, object]) -> dict[str, object]:
+    """Return the tool arguments that ClaimContextV2 binds by hash.
+
+    ``claim_context`` itself is excluded: it is the envelope carrying the
+    hash, not part of the hashed payload.
+    """
+
+    return {key: value for key, value in arguments.items() if key != "claim_context"}
+
+
+def _canonical_json_hash(value: object) -> str:
+    return calculate_canonical_json_hash(value)
+
+
+def _sign_claim_context(session_key: str, payload: dict[str, object]) -> str:
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(bytes.fromhex(session_key), normalized, hashlib.sha256).hexdigest()
+
+
+def _validate_claim_context(
+    state: _WorkspaceState,
+    *,
+    tool_name: str,
+    claim_context: object,
+    execution_arguments: dict[str, object],
+) -> None:
+    """Validate a signed ClaimContextV2 payload before any write dispatch.
+
+    Every check below must pass before the nonce is consumed and before the
+    caller performs any real Google mutation. On rejection the caller never
+    reaches the Google API call, so ``dispatch_started`` stays ``False``.
+    """
+
+    if (
+        state.session_key is None
+        or state.service_instance_id is None
+        or state.process_instance_id is None
+    ):
+        raise _WorkspaceToolError("CLAIM_SERVICE_UNAVAILABLE")
+    if not isinstance(claim_context, dict):
+        raise _WorkspaceToolError("CLAIM_MISSING")
+    claim = cast(dict[str, object], claim_context)
+    for field in CLAIM_CONTEXT_REQUIRED_FIELDS:
+        if field not in claim:
+            raise _WorkspaceToolError("CLAIM_MISSING")
+    if claim.get("claim_version") != CLAIM_CONTEXT_VERSION:
+        raise _WorkspaceToolError("CLAIM_VERSION_MISMATCH")
+    signature = claim.get("signature")
+    if not isinstance(signature, str) or not signature:
+        raise _WorkspaceToolError("CLAIM_INVALID_SIGNATURE")
+    unsigned = {key: value for key, value in claim.items() if key != "signature"}
+    expected_signature = _sign_claim_context(state.session_key, unsigned)
+    if not hmac.compare_digest(signature, expected_signature):
+        raise _WorkspaceToolError("CLAIM_INVALID_SIGNATURE")
+    for identity_field in ("action_id", "approval_id", "execution_attempt_id"):
+        value = claim.get(identity_field)
+        if not isinstance(value, str) or not value:
+            raise _WorkspaceToolError("CLAIM_MALFORMED")
+    if str(claim.get("tool_name")) != tool_name:
+        raise _WorkspaceToolError("CLAIM_TOOL_MISMATCH")
+    if str(claim.get("service_instance_id")) != state.service_instance_id:
+        raise _WorkspaceToolError("CLAIM_SERVICE_INSTANCE_MISMATCH")
+    if str(claim.get("mcp_process_instance_id")) != state.process_instance_id:
+        raise _WorkspaceToolError("CLAIM_PROCESS_INSTANCE_MISMATCH")
+    issued_at_ms = claim.get("issued_at_ms")
+    expires_at_ms = claim.get("expires_at_ms")
+    if not isinstance(issued_at_ms, int) or not isinstance(expires_at_ms, int):
+        raise _WorkspaceToolError("CLAIM_MALFORMED")
+    if expires_at_ms <= issued_at_ms or expires_at_ms - issued_at_ms > CLAIM_CONTEXT_MAX_TTL_MS:
+        raise _WorkspaceToolError("CLAIM_TTL_EXCEEDED")
+    if _now_ms() >= expires_at_ms:
+        raise _WorkspaceToolError("CLAIM_EXPIRED")
+    nonce = claim.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        raise _WorkspaceToolError("CLAIM_MALFORMED")
+    if nonce in state.used_nonces:
+        raise _WorkspaceToolError("CLAIM_TOKEN_REUSED")
+    approval_hash = claim.get("approval_arguments_hash")
+    if not isinstance(approval_hash, str) or not approval_hash:
+        raise _WorkspaceToolError("CLAIM_MALFORMED")
+    execution_hash = claim.get("execution_arguments_hash")
+    if not isinstance(execution_hash, str) or not execution_hash:
+        raise _WorkspaceToolError("CLAIM_MALFORMED")
+    recomputed_hash = _canonical_json_hash(execution_arguments)
+    if not hmac.compare_digest(recomputed_hash, execution_hash):
+        raise _WorkspaceToolError("CLAIM_ARGUMENTS_MISMATCH")
+    # Every check passed: consume the nonce now. main() dispatches one stdin
+    # request at a time, so this is atomic with respect to concurrent claims.
+    state.used_nonces.add(nonce)
+
+
 def _tasks_list_tasklists(
     state: _WorkspaceState, arguments: dict[str, object]
 ) -> dict[str, object]:
@@ -405,6 +872,74 @@ def _tasks_get_task(state: _WorkspaceState, arguments: dict[str, object]) -> dic
         f"https://tasks.googleapis.com/tasks/v1/lists/{task_list_path}/tasks/{task_path}",
     )
     return {"item": _task_snapshot(payload, task_list_id)}
+
+
+def _tasks_create_task(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    task_list_id = _text_argument(arguments, "task_list_id", maximum=2048)
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="tasks_create_task",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    body = _task_write_body(payload, title_required=True)
+    response = _google_api_post(
+        state,
+        f"https://tasks.googleapis.com/tasks/v1/lists/{quote(task_list_id, safe='')}/tasks",
+        body,
+    )
+    return {"item": _task_snapshot(response, task_list_id)}
+
+
+def _tasks_update_task(state: _WorkspaceState, arguments: dict[str, object]) -> dict[str, object]:
+    task_list_id = _text_argument(arguments, "task_list_id", maximum=2048)
+    task_id = _text_argument(arguments, "task_id", maximum=2048)
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="tasks_update_task",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    body = _task_write_body(payload, title_required=False)
+    if not body:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    task_list_path = quote(task_list_id, safe="")
+    task_path = quote(task_id, safe="")
+    response = _google_api_call(
+        state,
+        "PATCH",
+        f"https://tasks.googleapis.com/tasks/v1/lists/{task_list_path}/tasks/{task_path}",
+        body=body,
+    )
+    return {"item": _task_snapshot(response, task_list_id)}
+
+
+def _task_write_body(payload: dict[str, object], *, title_required: bool) -> dict[str, object]:
+    body: dict[str, object] = {}
+    if "title" in payload or title_required:
+        body["title"] = _text_argument(payload, "title", maximum=1024)
+    # Only CREATE dispatch injects recovery_fingerprint into the payload
+    # (see _build_final_dispatch_arguments); tasks_update_task never carries it.
+    recovery_fingerprint = _optional_text(payload.get("recovery_fingerprint"))
+    if "notes" in payload or recovery_fingerprint:
+        notes = _optional_text(payload.get("notes"))
+        if recovery_fingerprint:
+            marker = _recovery_marker(recovery_fingerprint)
+            notes = f"{notes}\n\n{marker}" if notes else marker
+        if notes:
+            body["notes"] = notes
+    if "due" in payload:
+        due = _optional_text(payload.get("due"))
+        if due:
+            body["due"] = due
+    if "status" in payload:
+        status = _optional_text(payload.get("status"))
+        if status not in {"needsAction", "completed"}:
+            raise _WorkspaceToolError("INVALID_ARGUMENT")
+        body["status"] = status
+    return body
 
 
 def _calendar_list_calendars(
@@ -456,6 +991,244 @@ def _calendar_get_event(state: _WorkspaceState, arguments: dict[str, object]) ->
         f"https://www.googleapis.com/calendar/v3/calendars/{calendar_path}/events/{event_path}",
     )
     return {"item": _event_snapshot(payload, calendar_id)}
+
+
+def _calendar_create_event(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    calendar_id = _text_argument(arguments, "calendar_id", maximum=2048)
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="calendar_create_event",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    body: dict[str, object] = {
+        "summary": _text_argument(payload, "title", maximum=1024),
+        "start": {"dateTime": _text_argument(payload, "start", maximum=64)},
+        "end": {"dateTime": _text_argument(payload, "end", maximum=64)},
+    }
+    description = _optional_text(payload.get("description"))
+    # Only CREATE dispatch injects recovery_fingerprint into the payload
+    # (see _build_final_dispatch_arguments); calendar_update_event never
+    # carries it.
+    recovery_fingerprint = _optional_text(payload.get("recovery_fingerprint"))
+    if recovery_fingerprint:
+        marker = _recovery_marker(recovery_fingerprint)
+        description = f"{description}\n\n{marker}" if description else marker
+    if description:
+        body["description"] = description
+    attendees = _calendar_attendees_argument(payload)
+    if attendees is not None:
+        body["attendees"] = attendees
+    response = _google_api_post(
+        state,
+        f"https://www.googleapis.com/calendar/v3/calendars/{quote(calendar_id, safe='')}/events",
+        body,
+    )
+    return {"item": _event_snapshot(response, calendar_id)}
+
+
+def _calendar_update_event(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    calendar_id = _text_argument(arguments, "calendar_id", maximum=2048)
+    event_id = _text_argument(arguments, "event_id", maximum=2048)
+    payload = _dict_argument(arguments, "payload")
+    _validate_claim_context(
+        state,
+        tool_name="calendar_update_event",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    body: dict[str, object] = {}
+    if "title" in payload:
+        body["summary"] = _text_argument(payload, "title", maximum=1024, allow_empty=True)
+    if "start" in payload:
+        body["start"] = {"dateTime": _text_argument(payload, "start", maximum=64)}
+    if "end" in payload:
+        body["end"] = {"dateTime": _text_argument(payload, "end", maximum=64)}
+    if "description" in payload:
+        description = _optional_text(payload.get("description"))
+        if description:
+            body["description"] = description
+    attendees = _calendar_attendees_argument(payload)
+    if attendees is not None:
+        body["attendees"] = attendees
+    if not body:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    calendar_path = quote(calendar_id, safe="")
+    event_path = quote(event_id, safe="")
+    response = _google_api_call(
+        state,
+        "PATCH",
+        f"https://www.googleapis.com/calendar/v3/calendars/{calendar_path}/events/{event_path}",
+        body=body,
+    )
+    return {"item": _event_snapshot(response, calendar_id)}
+
+
+def _calendar_delete_event(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    calendar_id = _text_argument(arguments, "calendar_id", maximum=2048)
+    event_id = _text_argument(arguments, "event_id", maximum=2048)
+    _validate_claim_context(
+        state,
+        tool_name="calendar_delete_event",
+        claim_context=arguments.get("claim_context"),
+        execution_arguments=_execution_arguments(arguments),
+    )
+    calendar_path = quote(calendar_id, safe="")
+    event_path = quote(event_id, safe="")
+    _google_api_call(
+        state,
+        "DELETE",
+        f"https://www.googleapis.com/calendar/v3/calendars/{calendar_path}/events/{event_path}",
+    )
+    return {
+        "item": _snapshot(
+            "calendar_event",
+            event_id,
+            calendar_id,
+            (calendar_id,),
+            "deleted",
+            {"status": "cancelled"},
+        )
+    }
+
+
+def _calendar_attendees_argument(payload: dict[str, object]) -> list[dict[str, object]] | None:
+    if "attendees" not in payload:
+        return None
+    value = payload.get("attendees")
+    if not isinstance(value, list):
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return [{"email": _text_value(item, maximum=320)} for item in cast(list[object], value)]
+
+
+def _search_by_recovery_fingerprint(
+    state: _WorkspaceState, arguments: dict[str, object]
+) -> dict[str, object]:
+    """Locate resources by their embedded recovery marker.
+
+    This is a READ-only lookup used exclusively by UNKNOWN_RESULT recovery
+    (never by ordinary write dispatch), so it carries no claim_context: it
+    cannot mutate anything, and the caller's own domain/application layer
+    is responsible for treating anything other than exactly one match as
+    unresolved (see RecoverUnknownCreateActionService).
+    """
+
+    resource_type = _text_argument(arguments, "resource_type", maximum=64)
+    fingerprint = _text_argument(arguments, "recovery_fingerprint", maximum=512)
+    marker = _recovery_marker(fingerprint)
+    if resource_type == "gmail_draft":
+        items = _search_gmail_drafts_by_marker(state, marker)
+    elif resource_type == "gmail_message":
+        items = _search_gmail_messages_by_marker(state, marker)
+    elif resource_type == "task":
+        items = _search_tasks_by_marker(state, marker)
+    elif resource_type == "calendar_event":
+        items = _search_calendar_events_by_marker(state, marker)
+    else:
+        raise _WorkspaceToolError("INVALID_ARGUMENT")
+    return {"items": items}
+
+
+def _search_gmail_drafts_by_marker(state: _WorkspaceState, marker: str) -> list[dict[str, object]]:
+    payload = _google_api(
+        state,
+        "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
+        {"q": marker, "maxResults": "10"},
+    )
+    draft_ids = [
+        _required_response_text(item, "id") for item in _object_list(payload.get("drafts"))
+    ]
+    if len(draft_ids) != 1:
+        # Zero or multiple candidates: the caller only accepts an exact
+        # single match, so minimal identity-only snapshots are enough.
+        return [_snapshot("gmail_draft", draft_id, None, (), None, {}) for draft_id in draft_ids]
+    detail = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/drafts/{quote(draft_ids[0], safe='')}",
+        {"format": "metadata"},
+    )
+    return [_gmail_draft_snapshot(detail)]
+
+
+def _search_gmail_messages_by_marker(
+    state: _WorkspaceState, marker: str
+) -> list[dict[str, object]]:
+    payload = _google_api(
+        state,
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+        {"q": marker, "maxResults": "10"},
+    )
+    message_ids = [
+        _required_response_text(item, "id") for item in _object_list(payload.get("messages"))
+    ]
+    if len(message_ids) != 1:
+        return [
+            _snapshot("gmail_message", message_id, None, (), None, {}) for message_id in message_ids
+        ]
+    detail = _google_api(
+        state,
+        f"https://gmail.googleapis.com/gmail/v1/users/me/messages/{quote(message_ids[0], safe='')}",
+        {"format": "metadata"},
+    )
+    headers = _headers(detail)
+    return [
+        _snapshot(
+            "gmail_message",
+            message_ids[0],
+            _optional_text(detail.get("threadId")),
+            (),
+            detail.get("historyId"),
+            {"subject": headers.get("subject", message_ids[0]), "sent": True},
+        )
+    ]
+
+
+def _search_tasks_by_marker(state: _WorkspaceState, marker: str) -> list[dict[str, object]]:
+    matches: list[dict[str, object]] = []
+    task_lists_payload = _google_api(
+        state, "https://tasks.googleapis.com/tasks/v1/users/@me/lists", {"maxResults": "100"}
+    )
+    for task_list in _object_list(task_lists_payload.get("items")):
+        task_list_id = _required_response_text(task_list, "id")
+        tasks_payload = _google_api(
+            state,
+            f"https://tasks.googleapis.com/tasks/v1/lists/{quote(task_list_id, safe='')}/tasks",
+            {"maxResults": "100", "showHidden": "true"},
+        )
+        for item in _object_list(tasks_payload.get("items")):
+            notes = _optional_text(item.get("notes"))
+            if notes and marker in notes:
+                matches.append(_task_snapshot(item, task_list_id))
+    return matches
+
+
+def _search_calendar_events_by_marker(
+    state: _WorkspaceState, marker: str
+) -> list[dict[str, object]]:
+    matches: list[dict[str, object]] = []
+    calendars_payload = _google_api(
+        state,
+        "https://www.googleapis.com/calendar/v3/users/me/calendarList",
+        {"maxResults": "100"},
+    )
+    for calendar in _object_list(calendars_payload.get("items")):
+        calendar_id = _required_response_text(calendar, "id")
+        calendar_path = quote(calendar_id, safe="")
+        events_payload = _google_api(
+            state,
+            f"https://www.googleapis.com/calendar/v3/calendars/{calendar_path}/events",
+            {"q": marker, "maxResults": "10"},
+        )
+        for item in _object_list(events_payload.get("items")):
+            matches.append(_event_snapshot(item, calendar_id))
+    return matches
 
 
 def _calendar_query_freebusy(
@@ -592,8 +1365,13 @@ def _calendar_ids_argument(arguments: dict[str, object]) -> tuple[str, ...]:
     return tuple(_text_value(item, maximum=2048) for item in value)
 
 
-def _google_api(
-    state: _WorkspaceState, url: str, params: dict[str, str] | None = None
+def _google_api_call(
+    state: _WorkspaceState,
+    method: str,
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+    body: dict[str, object] | None = None,
 ) -> dict[str, object]:
     try:
         state.ensure_access_token()
@@ -603,74 +1381,53 @@ def _google_api(
     if state.access_token is None:
         raise _WorkspaceToolError("OAUTH_NOT_CONNECTED")
     request_url = f"{url}?{urlencode(params)}" if params else url
-    request = Request(
-        request_url,
-        headers={"Authorization": f"Bearer {state.access_token}", "Accept": "application/json"},
-    )
+    headers = {"Authorization": f"Bearer {state.access_token}", "Accept": "application/json"}
+    data: bytes | None = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = Request(request_url, data=data, headers=headers, method=method)
     try:
         with urlopen(request, timeout=GOOGLE_API_TIMEOUT_SECONDS) as response:  # nosec B310: fixed Google API endpoints
-            return cast(dict[str, object], json.loads(response.read().decode("utf-8")))
+            raw = response.read()
+            if not raw:
+                return {}
+            return cast(dict[str, object], json.loads(raw.decode("utf-8")))
     except HTTPError as error:
         codes = {
             401: "REAUTH_REQUIRED",
             403: "PERMISSION_DENIED",
             404: "NOT_FOUND",
+            409: "CONFLICT",
+            412: "CONFLICT",
             429: "RATE_LIMITED",
         }
         if error.code == 401:
             state.connection_state = CredentialState.REAUTH_REQUIRED
             state.access_token = None
             state.access_token_expires_at_ms = 0
+        # A response (even an error one) proves the request reached Google.
         raise _WorkspaceToolError(
-            codes.get(error.code, "UPSTREAM_5XX" if error.code >= 500 else "GOOGLE_REQUEST_FAILED")
+            codes.get(error.code, "UPSTREAM_5XX" if error.code >= 500 else "GOOGLE_REQUEST_FAILED"),
+            dispatch_started=True,
         ) from error
     except (URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise _WorkspaceToolError(
-            "TIMEOUT" if isinstance(error, TimeoutError) else "MCP_UNAVAILABLE"
+            "TIMEOUT" if isinstance(error, TimeoutError) else "MCP_UNAVAILABLE",
+            dispatch_started=True,
         ) from error
+
+
+def _google_api(
+    state: _WorkspaceState, url: str, params: dict[str, str] | None = None
+) -> dict[str, object]:
+    return _google_api_call(state, "GET", url, params=params)
 
 
 def _google_api_post(
     state: _WorkspaceState, url: str, body: dict[str, object]
 ) -> dict[str, object]:
-    try:
-        state.ensure_access_token()
-    except _OAuthReauthenticationRequired as error:
-        state.connection_state = CredentialState.REAUTH_REQUIRED
-        raise _WorkspaceToolError("REAUTH_REQUIRED") from error
-    if state.access_token is None:
-        raise _WorkspaceToolError("OAUTH_NOT_CONNECTED")
-    request = Request(
-        url,
-        data=json.dumps(body).encode("utf-8"),
-        headers={
-            "Authorization": f"Bearer {state.access_token}",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
-    try:
-        with urlopen(request, timeout=GOOGLE_API_TIMEOUT_SECONDS) as response:  # nosec B310: fixed Google API endpoint
-            return cast(dict[str, object], json.loads(response.read().decode("utf-8")))
-    except HTTPError as error:
-        codes = {
-            401: "REAUTH_REQUIRED",
-            403: "PERMISSION_DENIED",
-            404: "NOT_FOUND",
-            429: "RATE_LIMITED",
-        }
-        if error.code == 401:
-            state.connection_state = CredentialState.REAUTH_REQUIRED
-            state.access_token = None
-            state.access_token_expires_at_ms = 0
-        raise _WorkspaceToolError(
-            codes.get(error.code, "UPSTREAM_5XX" if error.code >= 500 else "GOOGLE_REQUEST_FAILED")
-        ) from error
-    except (URLError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise _WorkspaceToolError(
-            "TIMEOUT" if isinstance(error, TimeoutError) else "MCP_UNAVAILABLE"
-        ) from error
+    return _google_api_call(state, "POST", url, body=body)
 
 
 def _credential_store_from_environment() -> SecretStore:
@@ -842,7 +1599,7 @@ def _exchange_authorization_code(
     flow: _OAuthFlow,
     code: str,
     client_secret: str | None,
-) -> tuple[str, str | None]:
+) -> tuple[str, str | None, str | None]:
     if client_secret is None:
         raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_SECRET_MISSING")
     body = urlencode(
@@ -882,7 +1639,35 @@ def _exchange_authorization_code(
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise _OAuthExchangeError
     access_token = payload.get("access_token")
-    return refresh_token, access_token if isinstance(access_token, str) else None
+    id_token = payload.get("id_token")
+    email = _verified_email_from_id_token(id_token) if isinstance(id_token, str) else None
+    return (
+        refresh_token,
+        access_token if isinstance(access_token, str) else None,
+        email,
+    )
+
+
+def _verified_email_from_id_token(id_token: str) -> str | None:
+    """Extract the account email from Google's ID token, if present.
+
+    The token was just fetched directly from Google's token endpoint over
+    TLS (not presented by an untrusted client), so this only decodes the
+    payload segment rather than verifying its signature -- there is no
+    front-channel replay/injection risk to guard against here. Only an
+    explicitly verified email claim is used, matching Google's own
+    ``email_verified`` semantics.
+    """
+
+    try:
+        _header, payload_segment, _signature = id_token.split(".", 2)
+        claims = cast(dict[str, object], json.loads(_b64url_decode(payload_segment)))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
+        return None
+    if claims.get("email_verified") is not True:
+        return None
+    email = claims.get("email")
+    return email if isinstance(email, str) and email.strip() else None
 
 
 def _oauth_exchange_error_from_http_error(
@@ -945,7 +1730,7 @@ def _refresh_access_token(
     refresh_token: str,
     client_id: str | None,
     client_secret: str | None,
-) -> tuple[str, int, str | None]:
+) -> tuple[str, int, str | None, str | None]:
     if client_id is None:
         raise _OAuthConfigurationError("GOOGLE_OAUTH_CLIENT_ID_MISSING")
     if client_secret is None:
@@ -979,7 +1764,14 @@ def _refresh_access_token(
     expires_in = payload.get("expires_in")
     ttl_ms = int(expires_in) * 1000 if isinstance(expires_in, int) else DEFAULT_ACCESS_TOKEN_TTL_MS
     rotated = payload.get("refresh_token")
-    return access_token, _now_ms() + ttl_ms, rotated if isinstance(rotated, str) else None
+    id_token = payload.get("id_token")
+    email = _verified_email_from_id_token(id_token) if isinstance(id_token, str) else None
+    return (
+        access_token,
+        _now_ms() + ttl_ms,
+        rotated if isinstance(rotated, str) else None,
+        email,
+    )
 
 
 def _revoke_refresh_token(refresh_token: str) -> bool:
@@ -1040,7 +1832,7 @@ class _OAuthCallbackServer:
                     self._respond(400, b"oauth flow expired")
                     return
                 try:
-                    refresh_token, access_token = _exchange_authorization_code(
+                    refresh_token, access_token, email = _exchange_authorization_code(
                         flow,
                         code,
                         outer._state.oauth_settings.google_oauth_client_secret,
@@ -1061,6 +1853,7 @@ class _OAuthCallbackServer:
                     return
                 outer._state.access_token = access_token
                 outer._state.access_token_expires_at_ms = _now_ms() + DEFAULT_ACCESS_TOKEN_TTL_MS
+                outer._state.account_email = email
                 outer._state.connection_state = CredentialState.CONNECTED
                 outer._state.last_checked_at_ms = _now_ms()
                 outer._state.last_oauth_error_code = None

--- a/src/google_work_agent/ports/__init__.py
+++ b/src/google_work_agent/ports/__init__.py
@@ -10,6 +10,7 @@ from google_work_agent.ports.artifact_verifier import (
     ArtifactSignatureDecision,
     ArtifactSignatureVerifier,
 )
+from google_work_agent.ports.attachments import GmailAttachmentBytes, GmailAttachmentGateway
 from google_work_agent.ports.clock import Clock
 from google_work_agent.ports.event_publisher import (
     BufferStatus,
@@ -180,6 +181,8 @@ __all__ = [
     "ExecutionAttemptRepository",
     "FreeBusyCalendar",
     "FreeBusyInterval",
+    "GmailAttachmentBytes",
+    "GmailAttachmentGateway",
     "GoogleConnectionStatus",
     "GoogleOAuthCredentialProvider",
     "GoogleWorkspaceErrorCode",

--- a/src/google_work_agent/ports/attachments.py
+++ b/src/google_work_agent/ports/attachments.py
@@ -1,0 +1,29 @@
+"""Gmail attachment READ gateway port definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class GmailAttachmentBytes:
+    """One Gmail attachment's bytes plus the metadata needed to stream it.
+
+    Instances of this type must never be persisted, logged, or handed to an
+    LLM/agent -- only the FastAPI download route consumes ``data``, and only
+    to stream it straight back to the browser.
+    """
+
+    message_id: str
+    attachment_id: str
+    size_bytes: int
+    sha256: str
+    data: bytes
+
+
+class GmailAttachmentGateway(Protocol):
+    """Read-only gateway over one Gmail message's attachment bytes."""
+
+    def get_gmail_attachment(self, *, message_id: str, attachment_id: str) -> GmailAttachmentBytes:
+        """Return one Gmail attachment's bytes."""

--- a/tests/component/api/test_attachment_api.py
+++ b/tests/component/api/test_attachment_api.py
@@ -1,0 +1,269 @@
+"""Component tests for the Gmail attachment download and staging routes (WP4)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from tests.support.fakes import DeterministicUUID, FakeClock
+
+from google_work_agent.adapters.mcp import (
+    MCPArtifactConfig,
+    SubprocessMCPTransport,
+    build_manifest_payload,
+    calculate_file_sha256,
+)
+from google_work_agent.adapters.mcp.gateway import MCPGmailAttachmentGateway
+from google_work_agent.adapters.readiness.composite import (
+    StaticLauncherProbeVerifier,
+    StaticReadinessAggregator,
+)
+from google_work_agent.adapters.runtime.attachment_staging import LocalAttachmentStaging
+from google_work_agent.api import ApiContainer, create_app
+from google_work_agent.api.security import (
+    InMemoryBootstrapGrantStore,
+    InMemoryLocalSessionManager,
+    LocalApiAccessGuard,
+)
+from google_work_agent.application.attachments import (
+    GetGmailAttachmentService,
+    StageAttachmentService,
+)
+from google_work_agent.ports import LauncherProbeDecision, ReadinessReport, ReadinessState
+
+
+class _CoordinatorStub:
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+def _start_transport(tmp_path: Path, *, service_instance_id: str) -> SubprocessMCPTransport:
+    manifest_path = tmp_path / "mcp-manifest.json"
+    manifest_path.write_text(json.dumps(build_manifest_payload(), sort_keys=True), encoding="utf-8")
+    executable = Path(sys.executable).resolve()
+    return SubprocessMCPTransport(
+        config=MCPArtifactConfig(
+            executable_path=str(executable),
+            manifest_path=str(manifest_path.resolve()),
+            expected_binary_sha256=calculate_file_sha256(executable),
+            expected_manifest_sha256=calculate_file_sha256(manifest_path.resolve()),
+            expected_manifest_version="2026-08-07.p0",
+            expected_protocol_version="2026-08-07.p0",
+            expected_tool_registry_version="2026-08-06.p0",
+            startup_timeout_ms=5_000,
+            request_timeout_ms=5_000,
+            max_restart_count=1,
+            environment="DEVELOPMENT",
+            service_instance_id=service_instance_id,
+            working_directory=str(Path(__file__).resolve().parents[3]),
+            extra_environment={
+                "GWA_TEST_KEYRING_PATH": str((tmp_path / "keyring.json").resolve()),
+                "GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id",
+                "GOOGLE_OAUTH_CLIENT_SECRET": "compatibility-client-secret",
+            },
+        )
+    )
+
+
+def _container(
+    tmp_path: Path,
+    *,
+    service_instance_id: str,
+    transport: SubprocessMCPTransport,
+    staging_dir: Path,
+) -> ApiContainer:
+    clock = FakeClock(100)
+    bootstrap_store = InMemoryBootstrapGrantStore()
+    bootstrap_store.provision(
+        secret="bootstrap-secret", service_instance_id=service_instance_id, now_ms=clock.now_ms()
+    )
+    session_manager = InMemoryLocalSessionManager()
+    attachment_gateway = MCPGmailAttachmentGateway(transport=transport)
+    staging = LocalAttachmentStaging(staging_dir=staging_dir)
+    return ApiContainer(
+        unit_of_work_factory=lambda: None,
+        query_service=None,
+        create_conversation_service=lambda command: command,
+        start_run_service=lambda command: command,
+        approve_action_service=lambda command: command,
+        modify_action_service=lambda command: command,
+        reject_action_service=lambda command: command,
+        prepare_retry_service=lambda command: command,
+        cancel_run_service=lambda command: command,
+        resume_run_service=lambda command: command,
+        local_run_coordinator=_CoordinatorStub(),
+        workflow_runtime=type("Runtime", (), {"close": lambda self: None})(),
+        event_publisher=type(
+            "Publisher",
+            (),
+            {
+                "replay": lambda self, **kwargs: (),
+                "subscribe": lambda self, run_id: type(
+                    "Subscription", (), {"poll": lambda self, timeout_seconds: None}
+                )(),
+                "close_subscription": lambda self, subscription: None,
+                "publish": lambda self, event: None,
+            },
+        )(),
+        readiness_aggregator=StaticReadinessAggregator(
+            ReadinessReport(state=ReadinessState.READY, checks=())
+        ),
+        runtime_status_provider=type("RuntimeStatus", (), {"get_summary": lambda self: {}})(),
+        api_access_guard=LocalApiAccessGuard(
+            expected_host="127.0.0.1:8767",
+            expected_origin="http://127.0.0.1:8767",
+            service_instance_id=service_instance_id,
+            session_manager=session_manager,
+            release_version="test",
+            environment="test",
+            now_ms=clock.now_ms,
+        ),
+        clock=clock,
+        id_generator=DeterministicUUID(prefix="req"),
+        release_version="test",
+        environment="test",
+        service_instance_id=service_instance_id,
+        local_bind_host="127.0.0.1",
+        local_bind_port=8767,
+        bootstrap_grant_store=bootstrap_store,
+        local_session_manager=session_manager,
+        launcher_probe_verifier=StaticLauncherProbeVerifier(LauncherProbeDecision(allowed=True)),
+        client_address_resolver=lambda _request: "127.0.0.1",
+        get_gmail_attachment_service=GetGmailAttachmentService(gateway=attachment_gateway),
+        stage_attachment_service=StageAttachmentService(staging=staging),
+    )
+
+
+_HEADERS = {
+    "Origin": "http://127.0.0.1:8767",
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Dest": "empty",
+}
+
+
+def _bootstrap(client: TestClient, *, service_instance_id: str) -> None:
+    response = client.post(
+        "/api/v1/session/bootstrap",
+        json={
+            "bootstrap_secret": "bootstrap-secret",
+            "service_instance_id": service_instance_id,
+            "api_contract_version": "1",
+        },
+        headers=_HEADERS,
+    )
+    assert response.status_code == 200
+
+
+def test_stage_attachment_returns_descriptor_not_bytes(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-attachment-stage")
+    container = _container(
+        tmp_path,
+        service_instance_id="svc-attachment-stage",
+        transport=transport,
+        staging_dir=tmp_path / "staging",
+    )
+    try:
+        with TestClient(create_app(container), base_url="http://127.0.0.1:8767") as client:
+            _bootstrap(client, service_instance_id="svc-attachment-stage")
+
+            response = client.post(
+                "/api/v1/attachments/stage",
+                headers=_HEADERS,
+                json={
+                    "filename": "report.pdf",
+                    "mime_type": "application/pdf",
+                    "data_base64": base64.b64encode(b"pdf bytes").decode("ascii"),
+                },
+            )
+
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload["filename"] == "report.pdf"
+            assert payload["mime_type"] == "application/pdf"
+            assert payload["size_bytes"] == len(b"pdf bytes")
+            assert len(payload["sha256"]) == 64
+            assert "data" not in payload
+            assert b"pdf bytes" not in response.content
+    finally:
+        transport.close()
+
+
+def test_stage_attachment_rejects_empty_upload(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-attachment-empty")
+    container = _container(
+        tmp_path,
+        service_instance_id="svc-attachment-empty",
+        transport=transport,
+        staging_dir=tmp_path / "staging",
+    )
+    try:
+        with TestClient(create_app(container), base_url="http://127.0.0.1:8767") as client:
+            _bootstrap(client, service_instance_id="svc-attachment-empty")
+
+            response = client.post(
+                "/api/v1/attachments/stage",
+                headers=_HEADERS,
+                json={"filename": "empty.txt", "mime_type": "text/plain", "data_base64": ""},
+            )
+
+            assert response.status_code == 422
+            assert response.json()["detail_code"] == "ATTACHMENT_EMPTY"
+    finally:
+        transport.close()
+
+
+def test_stage_attachment_requires_local_session(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-attachment-noauth")
+    container = _container(
+        tmp_path,
+        service_instance_id="svc-attachment-noauth",
+        transport=transport,
+        staging_dir=tmp_path / "staging",
+    )
+    try:
+        with TestClient(create_app(container), base_url="http://127.0.0.1:8767") as client:
+            response = client.post(
+                "/api/v1/attachments/stage",
+                headers=_HEADERS,
+                json={
+                    "filename": "a.txt",
+                    "mime_type": "text/plain",
+                    "data_base64": base64.b64encode(b"data").decode("ascii"),
+                },
+            )
+            assert response.status_code in (401, 403)
+    finally:
+        transport.close()
+
+
+def test_download_attachment_reaches_real_google_dispatch_gate(tmp_path: Path) -> None:
+    """No OAuth credential is configured, so the request must fail only after
+    passing local-session auth and reaching the real MCP attachment tool --
+    proving the route -> service -> gateway -> MCP wiring is real, not stubbed."""
+
+    transport = _start_transport(tmp_path, service_instance_id="svc-attachment-download")
+    container = _container(
+        tmp_path,
+        service_instance_id="svc-attachment-download",
+        transport=transport,
+        staging_dir=tmp_path / "staging",
+    )
+    try:
+        with TestClient(create_app(container), base_url="http://127.0.0.1:8767") as client:
+            _bootstrap(client, service_instance_id="svc-attachment-download")
+
+            response = client.get(
+                "/api/v1/gmail/messages/msg-1/attachments/att-1", headers=_HEADERS
+            )
+
+            assert response.status_code == 401
+            assert response.json()["detail_code"] == "GOOGLE_AUTH_EXPIRED"
+    finally:
+        transport.close()

--- a/tests/contract/mcp/test_claim_context_v2.py
+++ b/tests/contract/mcp/test_claim_context_v2.py
@@ -1,0 +1,297 @@
+"""End-to-end R8.4 ClaimContextV2 contract test against the real MCP server.
+
+Unlike test_subprocess_transport.py (which drives the read-only fake server),
+this spins up the actual google_work_agent.mcp.server module as a child
+process and drives it through the real SubprocessMCPTransport / gateway
+signing path. No live Google credentials are configured, which lets each
+test distinguish two outcomes by error code alone:
+
+- a claim that is rejected before any Google call is made surfaces a
+  CLAIM_* safe code with NOT_SENT delivery certainty;
+- a claim that passes validation and reaches the real dispatch path fails
+  with AUTH_EXPIRED (mapped from OAUTH_NOT_CONNECTED) because no OAuth
+  credential exists in the test keyring -- proving the request reached the
+  Google-dispatch gate rather than being rejected earlier.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from google_work_agent.adapters.mcp import (
+    MCPArtifactConfig,
+    MCPGoogleWorkspaceGateway,
+    SubprocessMCPTransport,
+    build_manifest_payload,
+    calculate_file_sha256,
+)
+from google_work_agent.domain import calculate_canonical_json_hash
+from google_work_agent.ports import (
+    DeliveryCertainty,
+    GoogleWorkspaceErrorCode,
+    GoogleWorkspaceGatewayError,
+    ResourceType,
+)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _start_transport(tmp_path: Path, *, service_instance_id: str) -> SubprocessMCPTransport:
+    manifest_path = tmp_path / "mcp-manifest.json"
+    manifest_path.write_text(json.dumps(build_manifest_payload(), sort_keys=True), encoding="utf-8")
+    executable = Path(sys.executable).resolve()
+    keyring_path = tmp_path / "keyring.json"
+    return SubprocessMCPTransport(
+        config=MCPArtifactConfig(
+            executable_path=str(executable),
+            manifest_path=str(manifest_path.resolve()),
+            expected_binary_sha256=calculate_file_sha256(executable),
+            expected_manifest_sha256=calculate_file_sha256(manifest_path.resolve()),
+            expected_manifest_version="2026-08-07.p0",
+            expected_protocol_version="2026-08-07.p0",
+            expected_tool_registry_version="2026-08-06.p0",
+            startup_timeout_ms=5_000,
+            request_timeout_ms=5_000,
+            max_restart_count=1,
+            environment="DEVELOPMENT",
+            service_instance_id=service_instance_id,
+            working_directory=str(Path(__file__).resolve().parents[3]),
+            module_name="google_work_agent.mcp.server",
+            extra_environment={
+                "GOOGLE_OAUTH_CLIENT_ID": "test-desktop-client-id",
+                "GWA_TEST_KEYRING_PATH": str(keyring_path),
+            },
+        )
+    )
+
+
+def _claim_payload(*, service_instance_id: str, nonce: str) -> dict[str, object]:
+    issued_at_ms = _now_ms()
+    return {
+        "action_id": "action-1",
+        "approval_id": "approval-1",
+        "attempt_id": "attempt-1",
+        "service_instance_id": service_instance_id,
+        "issued_at_ms": issued_at_ms,
+        "expires_at_ms": issued_at_ms + 30_000,
+        "nonce": nonce,
+    }
+
+
+def test_valid_claim_reaches_the_real_google_dispatch_gate(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-valid")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+        execution_arguments = {"payload": payload}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-valid-1"
+            ),
+            tool_name="gmail_create_draft",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_gmail_draft(payload=payload, claim_context=claim_context)
+
+        # No OAuth credential is configured, so a claim that passed
+        # validation and actually reached the dispatch path fails here --
+        # never with a CLAIM_* rejection.
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.AUTH_EXPIRED
+    finally:
+        transport.close()
+
+
+def test_tampered_signature_is_rejected_with_zero_google_calls(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-tampered")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+        execution_arguments = {"payload": payload}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-tampered-1"
+            ),
+            tool_name="gmail_create_draft",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+        tampered = dict(claim_context)
+        tampered["nonce"] = "a-different-nonce"  # invalidates the signature
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_gmail_draft(payload=payload, claim_context=tampered)
+
+        assert exc_info.value.delivery_certainty is DeliveryCertainty.NOT_SENT
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.PERMISSION_DENIED
+    finally:
+        transport.close()
+
+
+def test_valid_tasks_claim_reaches_the_real_google_dispatch_gate(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-tasks-valid")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        payload: dict[str, object] = {"title": "Follow up"}
+        execution_arguments = {"task_list_id": "list-1", "payload": payload}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-tasks-valid-1"
+            ),
+            tool_name="tasks_create_task",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_task(task_list_id="list-1", payload=payload, claim_context=claim_context)
+
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.AUTH_EXPIRED
+    finally:
+        transport.close()
+
+
+def test_tasks_claim_rejected_before_google_dispatch_on_expiry(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-tasks-expired")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        payload: dict[str, object] = {"title": "Follow up"}
+        execution_arguments = {"task_list_id": "list-1", "payload": payload}
+        claim_payload = _claim_payload(
+            service_instance_id=transport.service_instance_id, nonce="nonce-tasks-expired-1"
+        )
+        claim_payload["issued_at_ms"] = _now_ms() - 120_000
+        claim_payload["expires_at_ms"] = _now_ms() - 90_000
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=claim_payload,
+            tool_name="tasks_create_task",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_task(task_list_id="list-1", payload=payload, claim_context=claim_context)
+
+        assert exc_info.value.delivery_certainty is DeliveryCertainty.NOT_SENT
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.PERMISSION_DENIED
+    finally:
+        transport.close()
+
+
+def test_valid_calendar_claim_reaches_the_real_google_dispatch_gate(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-calendar-valid")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        payload: dict[str, object] = {
+            "title": "Review",
+            "start": "2026-08-10T09:00:00+09:00",
+            "end": "2026-08-10T10:00:00+09:00",
+        }
+        execution_arguments = {"calendar_id": "primary", "payload": payload}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-calendar-valid-1"
+            ),
+            tool_name="calendar_create_event",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_calendar_event(
+                calendar_id="primary", payload=payload, claim_context=claim_context
+            )
+
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.AUTH_EXPIRED
+    finally:
+        transport.close()
+
+
+def test_calendar_delete_claim_reused_is_rejected_with_zero_google_calls(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-calendar-delete")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        execution_arguments = {"calendar_id": "primary", "event_id": "event-1"}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-calendar-delete-1"
+            ),
+            tool_name="calendar_delete_event",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+
+        # No OAuth credential is configured, so the first attempt fails with
+        # AUTH_EXPIRED after passing claim validation and consuming the nonce.
+        with pytest.raises(GoogleWorkspaceGatewayError) as first_error:
+            gateway.delete_calendar_event(
+                calendar_id="primary", event_id="event-1", claim_context=claim_context
+            )
+        assert first_error.value.code is GoogleWorkspaceErrorCode.AUTH_EXPIRED
+
+        # Replaying the same claim context must be rejected before any
+        # further Google dispatch, proving the nonce cannot be reused.
+        with pytest.raises(GoogleWorkspaceGatewayError) as second_error:
+            gateway.delete_calendar_event(
+                calendar_id="primary", event_id="event-1", claim_context=claim_context
+            )
+        assert second_error.value.delivery_certainty is DeliveryCertainty.NOT_SENT
+        assert second_error.value.code is GoogleWorkspaceErrorCode.PERMISSION_DENIED
+    finally:
+        transport.close()
+
+
+def test_wrong_execution_arguments_are_rejected_with_zero_google_calls(tmp_path: Path) -> None:
+    transport = _start_transport(tmp_path, service_instance_id="svc-claim-mismatch")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        approved_payload: dict[str, object] = {
+            "to": ["a@example.com"],
+            "subject": "Hi",
+            "body": "Approved body",
+        }
+        execution_arguments = {"payload": approved_payload}
+        claim_context = gateway.prepare_claim_context(
+            claim_payload=_claim_payload(
+                service_instance_id=transport.service_instance_id, nonce="nonce-mismatch-1"
+            ),
+            tool_name="gmail_create_draft",
+            approval_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+            execution_arguments_hash=calculate_canonical_json_hash(execution_arguments),
+        )
+        tampered_payload = dict(approved_payload)
+        tampered_payload["body"] = "A body nobody approved"
+
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.create_gmail_draft(payload=tampered_payload, claim_context=claim_context)
+
+        assert exc_info.value.delivery_certainty is DeliveryCertainty.NOT_SENT
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.PERMISSION_DENIED
+    finally:
+        transport.close()
+
+
+def test_recovery_search_reaches_the_real_google_dispatch_gate(tmp_path: Path) -> None:
+    """search_by_recovery_fingerprint carries no claim -- it's read-only -- so
+    it should reach the same real Google-dispatch gate as any other read
+    tool (proving it is no longer TOOL_NOT_AVAILABLE)."""
+
+    transport = _start_transport(tmp_path, service_instance_id="svc-recovery-search")
+    gateway = MCPGoogleWorkspaceGateway(transport=transport)
+    try:
+        with pytest.raises(GoogleWorkspaceGatewayError) as exc_info:
+            gateway.search_by_recovery_fingerprint(
+                resource_type=ResourceType.TASK, recovery_fingerprint="fp-contract-1"
+            )
+        assert exc_info.value.code is GoogleWorkspaceErrorCode.AUTH_EXPIRED
+    finally:
+        transport.close()

--- a/tests/contract/oauth/test_mcp_oauth.py
+++ b/tests/contract/oauth/test_mcp_oauth.py
@@ -29,6 +29,8 @@ def test_mcp_oauth_flow_uses_google_loopback_authorization_and_no_token_leakage(
     assert query["scope"] == [
         " ".join(
             [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email",
                 "https://www.googleapis.com/auth/gmail.readonly",
                 "https://www.googleapis.com/auth/gmail.compose",
                 "https://www.googleapis.com/auth/tasks",

--- a/tests/integration/persistence/test_google_account_provisioning.py
+++ b/tests/integration/persistence/test_google_account_provisioning.py
@@ -1,0 +1,105 @@
+"""Integration tests for provisioning the google_accounts identity row."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from google_work_agent.adapters.persistence import apply_migrations, connect_sqlite
+from google_work_agent.application.queries import QueryService
+
+
+def _fresh_query_service(tmp_path: Path) -> tuple[QueryService, Path]:
+    database_path = tmp_path / "provisioning.db"
+    connection = connect_sqlite(database_path)
+    try:
+        apply_migrations(connection)
+    finally:
+        connection.close()
+    return (
+        QueryService(
+            database_path=database_path, runtime_status_provider=_UnusedRuntimeStatusProvider()
+        ),
+        database_path,
+    )
+
+
+class _UnusedRuntimeStatusProvider:
+    def get_summary(self) -> object:
+        raise NotImplementedError
+
+
+def test_ensure_google_account_connected_creates_a_new_row(tmp_path: Path) -> None:
+    query_service, _ = _fresh_query_service(tmp_path)
+
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="User Name", now_ms=1_000
+    )
+
+    account = query_service.get_current_google_account()
+    assert account is not None
+    assert account.email == "user@example.com"
+    assert account.display_name == "User Name"
+
+
+def test_ensure_google_account_connected_is_idempotent_and_keeps_the_same_id(
+    tmp_path: Path,
+) -> None:
+    query_service, _ = _fresh_query_service(tmp_path)
+
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="User Name", now_ms=1_000
+    )
+    first = query_service.get_current_google_account()
+    assert first is not None
+
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="User Name", now_ms=2_000
+    )
+    second = query_service.get_current_google_account()
+
+    assert second is not None
+    assert second.account_id == first.account_id
+
+
+def test_ensure_google_account_connected_reactivates_a_disconnected_account(
+    tmp_path: Path,
+) -> None:
+    query_service, database_path = _fresh_query_service(tmp_path)
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="User Name", now_ms=1_000
+    )
+    original = query_service.get_current_google_account()
+    assert original is not None
+
+    connection = connect_sqlite(database_path)
+    try:
+        connection.execute(
+            "UPDATE google_accounts SET disconnected_at_ms = 1500 WHERE id = ?;",
+            (original.account_id,),
+        )
+    finally:
+        connection.close()
+    assert query_service.get_current_google_account() is None
+
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="User Name", now_ms=2_000
+    )
+
+    reconnected = query_service.get_current_google_account()
+    assert reconnected is not None
+    assert reconnected.account_id == original.account_id
+
+
+def test_ensure_google_account_connected_updates_display_name(tmp_path: Path) -> None:
+    query_service, _ = _fresh_query_service(tmp_path)
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="Old Name", now_ms=1_000
+    )
+
+    query_service.ensure_google_account_connected(
+        email="user@example.com", display_name="New Name", now_ms=2_000
+    )
+
+    account = query_service.get_current_google_account()
+    assert account is not None
+    assert account.display_name == "New Name"

--- a/tests/unit/adapters/runtime/test_attachment_staging.py
+++ b/tests/unit/adapters/runtime/test_attachment_staging.py
@@ -1,0 +1,165 @@
+"""Unit tests for the local Gmail attachment staging service (WP4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from google_work_agent.adapters.runtime.attachment_staging import (
+    AttachmentDescriptor,
+    AttachmentStagingError,
+    LocalAttachmentStaging,
+)
+
+
+def _staging(tmp_path: Path, *, now_ms: int = 1_000_000) -> LocalAttachmentStaging:
+    return LocalAttachmentStaging(staging_dir=tmp_path / "attachments", now_ms=lambda: now_ms)
+
+
+def test_stage_then_read_verified_round_trips_bytes(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    descriptor = staging.stage(
+        data=b"file bytes", filename="report.pdf", mime_type="application/pdf"
+    )
+
+    assert descriptor.filename == "report.pdf"
+    assert descriptor.mime_type == "application/pdf"
+    assert descriptor.size_bytes == len(b"file bytes")
+    assert len(descriptor.sha256) == 64
+
+    assert staging.read_verified(descriptor) == b"file bytes"
+
+
+def test_stage_rejects_empty_bytes(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.stage(data=b"", filename="empty.txt", mime_type="text/plain")
+    assert exc_info.value.safe_code == "ATTACHMENT_EMPTY"
+
+
+def test_stage_rejects_oversized_bytes(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    from google_work_agent.adapters.runtime.attachment_staging import MAX_STAGED_FILE_BYTES
+
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.stage(
+            data=b"x" * (MAX_STAGED_FILE_BYTES + 1),
+            filename="big.bin",
+            mime_type="application/octet-stream",
+        )
+    assert exc_info.value.safe_code == "ATTACHMENT_TOO_LARGE"
+
+
+def test_stage_rejects_path_like_filenames(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.stage(data=b"data", filename="../../etc/passwd", mime_type="text/plain")
+    assert exc_info.value.safe_code == "ATTACHMENT_FILENAME_INVALID"
+
+
+def test_read_verified_rejects_unknown_staging_id(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    fake = AttachmentDescriptor(
+        staged_attachment_id="does-not-exist",
+        filename="a.txt",
+        mime_type="text/plain",
+        size_bytes=1,
+        sha256="0" * 64,
+    )
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(fake)
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_MISSING"
+
+
+def test_read_verified_rejects_expired_staging(tmp_path: Path) -> None:
+    clock = {"now": 1_000_000}
+    staging = LocalAttachmentStaging(
+        staging_dir=tmp_path / "attachments", now_ms=lambda: clock["now"]
+    )
+    descriptor = staging.stage(data=b"bytes", filename="a.txt", mime_type="text/plain")
+    clock["now"] += 20 * 60 * 1000  # advance past the 15 minute TTL
+
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(descriptor)
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_EXPIRED"
+
+
+def test_read_verified_rejects_size_mismatch(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    descriptor = staging.stage(data=b"bytes", filename="a.txt", mime_type="text/plain")
+    tampered = AttachmentDescriptor(
+        staged_attachment_id=descriptor.staged_attachment_id,
+        filename=descriptor.filename,
+        mime_type=descriptor.mime_type,
+        size_bytes=descriptor.size_bytes + 1,
+        sha256=descriptor.sha256,
+    )
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(tampered)
+    assert exc_info.value.safe_code == "ATTACHMENT_SIZE_MISMATCH"
+
+
+def test_read_verified_rejects_hash_mismatch(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    descriptor = staging.stage(data=b"bytes", filename="a.txt", mime_type="text/plain")
+    tampered = AttachmentDescriptor(
+        staged_attachment_id=descriptor.staged_attachment_id,
+        filename=descriptor.filename,
+        mime_type=descriptor.mime_type,
+        size_bytes=descriptor.size_bytes,
+        sha256="f" * 64,
+    )
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(tampered)
+    assert exc_info.value.safe_code == "ATTACHMENT_HASH_MISMATCH"
+
+
+def test_read_verified_rejects_descriptor_mismatch_on_filename(tmp_path: Path) -> None:
+    staging = _staging(tmp_path)
+    descriptor = staging.stage(data=b"bytes", filename="a.txt", mime_type="text/plain")
+    tampered = AttachmentDescriptor(
+        staged_attachment_id=descriptor.staged_attachment_id,
+        filename="different.txt",
+        mime_type=descriptor.mime_type,
+        size_bytes=descriptor.size_bytes,
+        sha256=descriptor.sha256,
+    )
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(tampered)
+    assert exc_info.value.safe_code == "ATTACHMENT_DESCRIPTOR_MISMATCH"
+
+
+def test_cleanup_expired_removes_only_expired_entries(tmp_path: Path) -> None:
+    clock = {"now": 1_000_000}
+    staging = LocalAttachmentStaging(
+        staging_dir=tmp_path / "attachments", now_ms=lambda: clock["now"]
+    )
+    stale = staging.stage(data=b"stale", filename="stale.txt", mime_type="text/plain")
+    clock["now"] += 20 * 60 * 1000
+    fresh = staging.stage(data=b"fresh", filename="fresh.txt", mime_type="text/plain")
+
+    staging.cleanup_expired()
+
+    assert staging.read_verified(fresh) == b"fresh"
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        staging.read_verified(stale)
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_MISSING"
+
+
+def test_descriptor_json_round_trip() -> None:
+    descriptor = AttachmentDescriptor(
+        staged_attachment_id="id-1",
+        filename="a.txt",
+        mime_type="text/plain",
+        size_bytes=5,
+        sha256="a" * 64,
+    )
+    restored = AttachmentDescriptor.from_json(descriptor.to_json())
+    assert restored == descriptor
+
+
+def test_descriptor_from_json_rejects_malformed_payload() -> None:
+    with pytest.raises(AttachmentStagingError) as exc_info:
+        AttachmentDescriptor.from_json({"filename": "a.txt"})
+    assert exc_info.value.safe_code == "ATTACHMENT_DESCRIPTOR_MALFORMED"

--- a/tests/unit/application/test_google_connection.py
+++ b/tests/unit/application/test_google_connection.py
@@ -1,0 +1,99 @@
+"""Unit tests for Google connection identity provisioning wiring."""
+
+from __future__ import annotations
+
+from google_work_agent.application.google_connection import GetGoogleConnectionService
+from google_work_agent.ports import CredentialState, GoogleConnectionStatus, OAuthEnvironment
+
+
+class _FakeProvider:
+    def __init__(self, status: GoogleConnectionStatus) -> None:
+        self._status = status
+
+    def start_oauth(self) -> object:
+        raise NotImplementedError
+
+    def get_connection_status(self) -> GoogleConnectionStatus:
+        return self._status
+
+    def disconnect(self) -> object:
+        raise NotImplementedError
+
+
+class _RecordingProvisioner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None, int]] = []
+
+    def ensure_google_account_connected(
+        self, *, email: str, display_name: str | None, now_ms: int
+    ) -> None:
+        self.calls.append((email, display_name, now_ms))
+
+
+def _status(*, connected: bool, account_email: str | None) -> GoogleConnectionStatus:
+    return GoogleConnectionStatus(
+        connected=connected,
+        credential_state=CredentialState.CONNECTED if connected else CredentialState.NOT_CONNECTED,
+        account_email=account_email,
+        display_name="Display Name",
+        granted_scopes=(),
+        missing_scopes=(),
+        reauth_required=False,
+        oauth_environment=OAuthEnvironment.DEVELOPMENT,
+        last_checked_at_ms=1_000,
+    )
+
+
+def test_provisions_account_when_connected_with_resolved_email() -> None:
+    provisioner = _RecordingProvisioner()
+    service = GetGoogleConnectionService(
+        provider=_FakeProvider(_status(connected=True, account_email="user@example.com")),
+        account_provisioner=provisioner,
+        now_ms=lambda: 5_000,
+    )
+
+    status = service()
+
+    assert status.connected is True
+    assert provisioner.calls == [("user@example.com", "Display Name", 5_000)]
+
+
+def test_does_not_provision_when_not_connected() -> None:
+    provisioner = _RecordingProvisioner()
+    service = GetGoogleConnectionService(
+        provider=_FakeProvider(_status(connected=False, account_email=None)),
+        account_provisioner=provisioner,
+        now_ms=lambda: 5_000,
+    )
+
+    service()
+
+    assert provisioner.calls == []
+
+
+def test_does_not_provision_when_connected_but_email_unresolved() -> None:
+    """A pre-fix (or pre-reconnect) session can be connected without the
+    email scope having ever been granted; provisioning must not run on a
+    guess and must not crash on the missing email."""
+
+    provisioner = _RecordingProvisioner()
+    service = GetGoogleConnectionService(
+        provider=_FakeProvider(_status(connected=True, account_email=None)),
+        account_provisioner=provisioner,
+        now_ms=lambda: 5_000,
+    )
+
+    status = service()
+
+    assert status.connected is True
+    assert provisioner.calls == []
+
+
+def test_works_without_a_provisioner_configured() -> None:
+    service = GetGoogleConnectionService(
+        provider=_FakeProvider(_status(connected=True, account_email="user@example.com"))
+    )
+
+    status = service()
+
+    assert status.connected is True

--- a/tests/unit/mcp/test_attachment_tools.py
+++ b/tests/unit/mcp/test_attachment_tools.py
@@ -1,0 +1,357 @@
+"""Unit tests for WP4 Gmail attachment READ and Draft/SEND attachment wiring."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from google_work_agent.adapters.runtime.attachment_staging import (
+    AttachmentDescriptor,
+    LocalAttachmentStaging,
+)
+from google_work_agent.mcp import server
+from google_work_agent.mcp.settings import GoogleOAuthSettings
+
+SESSION_KEY = "33" * 32
+SERVICE_INSTANCE_ID = "svc-attachment-1"
+
+
+def _state() -> server._WorkspaceState:
+    state = server._WorkspaceState(keyring=_MemorySecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    state.session_key = SESSION_KEY
+    state.service_instance_id = SERVICE_INSTANCE_ID
+    return state
+
+
+class _MemorySecretStore:
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        del service, account, secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        del service, account
+        return None
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        del service, account
+        return True
+
+
+def _build_claim(
+    *, state: server._WorkspaceState, tool_name: str, execution_arguments: dict[str, object]
+) -> dict[str, object]:
+    issued_at_ms = server._now_ms()
+    claim: dict[str, object] = {
+        "claim_version": 2,
+        "action_id": "action-1",
+        "approval_id": "approval-1",
+        "execution_attempt_id": "attempt-1",
+        "tool_name": tool_name,
+        "approval_arguments_hash": server._canonical_json_hash(execution_arguments),
+        "execution_arguments_hash": server._canonical_json_hash(execution_arguments),
+        "service_instance_id": state.service_instance_id,
+        "mcp_process_instance_id": state.process_instance_id,
+        "issued_at_ms": issued_at_ms,
+        "expires_at_ms": issued_at_ms + 30_000,
+        "nonce": "nonce-attachment-1",
+    }
+    claim["signature"] = server._sign_claim_context(state.session_key, claim)
+    return claim
+
+
+def _reject_google_calls(*_args: object, **_kwargs: object) -> dict[str, object]:
+    pytest.fail("Google API must not be called")
+
+
+# --------------------------------------------------------------------------
+# gmail_get_attachment (READ)
+# --------------------------------------------------------------------------
+
+
+def test_gmail_get_attachment_returns_bytes_and_hash(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    raw = b"file content bytes"
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        assert "messages/msg-1/attachments/att-1" in url
+        return {"size": len(raw), "data": server._b64url_encode(raw)}
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(),
+        tool_name="gmail_get_attachment",
+        arguments={"message_id": "msg-1", "attachment_id": "att-1"},
+    )
+
+    assert result["size_bytes"] == len(raw)
+    assert result["sha256"] == server.hashlib.sha256(raw).hexdigest()
+    assert server._b64url_decode(cast(str, result["data_base64url"])) == raw
+
+
+def test_gmail_get_attachment_rejects_oversized_payload(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    oversized = b"x" * (server.MAX_ATTACHMENT_READ_BYTES + 1)
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        return {"size": len(oversized), "data": server._b64url_encode(oversized)}
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            _state(),
+            tool_name="gmail_get_attachment",
+            arguments={"message_id": "msg-1", "attachment_id": "att-1"},
+        )
+    assert exc_info.value.safe_code == "ATTACHMENT_TOO_LARGE"
+
+
+def test_gmail_get_attachment_never_leaves_the_read_tool_boundary(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The attachment READ tool itself performs no claim/persistence/trace side
+    effects -- it is a pure request/response mapping, matching the contract
+    that only the calling FastAPI route (not this process) streams bytes to
+    the browser and never touches SQLite or the LLM with them."""
+
+    raw = b"pdf-bytes"
+    monkeypatch.setattr(
+        server,
+        "_google_api",
+        lambda *a, **k: {"size": len(raw), "data": server._b64url_encode(raw)},
+    )
+    result = server._tool_call(
+        _state(),
+        tool_name="gmail_get_attachment",
+        arguments={"message_id": "msg-1", "attachment_id": "att-1"},
+    )
+    assert set(result) == {"message_id", "attachment_id", "size_bytes", "sha256", "data_base64url"}
+
+
+# --------------------------------------------------------------------------
+# Draft CREATE/UPDATE with staged attachments
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def staging(tmp_path: Path, monkeypatch) -> LocalAttachmentStaging:  # type: ignore[no-untyped-def]
+    staging_dir = tmp_path / "attachments"
+    monkeypatch.setenv(server.ATTACHMENT_STAGING_DIR_ENV, str(staging_dir))
+    return LocalAttachmentStaging(staging_dir=staging_dir)
+
+
+def test_gmail_create_draft_embeds_a_verified_staged_attachment(
+    monkeypatch,
+    staging: LocalAttachmentStaging,  # type: ignore[no-untyped-def]
+) -> None:
+    descriptor = staging.stage(
+        data=b"report bytes", filename="report.pdf", mime_type="application/pdf"
+    )
+    captured: dict[str, object] = {}
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        captured["body"] = body
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Report",
+        "body": "See attached",
+        "attachments": [descriptor.to_json()],
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    server._tool_call(
+        state,
+        tool_name="gmail_create_draft",
+        arguments={"payload": payload, "claim_context": claim},
+    )
+
+    body = cast(dict[str, object], captured["body"])
+    message = cast(dict[str, object], body["message"])
+    raw_bytes = server._b64url_decode(cast(str, message["raw"]))
+    assert base64.b64encode(b"report bytes") in raw_bytes
+    assert b"report.pdf" in raw_bytes
+    assert b"application/pdf" in raw_bytes
+
+
+def test_gmail_create_draft_rejects_missing_staged_attachment(
+    monkeypatch,
+    staging: LocalAttachmentStaging,  # type: ignore[no-untyped-def]
+) -> None:
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    fake_descriptor = AttachmentDescriptor(
+        staged_attachment_id="never-staged",
+        filename="a.txt",
+        mime_type="text/plain",
+        size_bytes=1,
+        sha256="0" * 64,
+    )
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Hi",
+        "body": "Body",
+        "attachments": [fake_descriptor.to_json()],
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_MISSING"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_gmail_create_draft_rejects_hash_mismatched_staged_attachment(
+    monkeypatch,
+    staging: LocalAttachmentStaging,  # type: ignore[no-untyped-def]
+) -> None:
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    real_descriptor = staging.stage(data=b"real bytes", filename="a.txt", mime_type="text/plain")
+    tampered_descriptor = AttachmentDescriptor(
+        staged_attachment_id=real_descriptor.staged_attachment_id,
+        filename=real_descriptor.filename,
+        mime_type=real_descriptor.mime_type,
+        size_bytes=real_descriptor.size_bytes,
+        sha256="f" * 64,
+    )
+    state = _state()
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Hi",
+        "body": "Body",
+        "attachments": [tampered_descriptor.to_json()],
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "ATTACHMENT_HASH_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_gmail_create_draft_rejects_expired_staged_attachment(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    clock = {"now": 1_000_000}
+    staging_dir = tmp_path / "attachments"
+    monkeypatch.setenv(server.ATTACHMENT_STAGING_DIR_ENV, str(staging_dir))
+    expiring_staging = LocalAttachmentStaging(staging_dir=staging_dir, now_ms=lambda: clock["now"])
+    descriptor = expiring_staging.stage(data=b"bytes", filename="a.txt", mime_type="text/plain")
+    clock["now"] += 20 * 60 * 1000  # advance past the 15 minute TTL
+
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Hi",
+        "body": "Body",
+        "attachments": [descriptor.to_json()],
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_EXPIRED"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_gmail_create_draft_without_staging_env_rejects_attachment_use(
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    monkeypatch.delenv(server.ATTACHMENT_STAGING_DIR_ENV, raising=False)
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Hi",
+        "body": "Body",
+        "attachments": [
+            {
+                "staged_attachment_id": "x",
+                "filename": "a.txt",
+                "mime_type": "text/plain",
+                "size_bytes": 1,
+                "sha256": "0" * 64,
+            }
+        ],
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "ATTACHMENT_STAGING_UNAVAILABLE"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_gmail_create_draft_without_attachments_key_never_touches_staging(
+    monkeypatch,  # type: ignore[no-untyped-def]
+) -> None:
+    monkeypatch.delenv(server.ATTACHMENT_STAGING_DIR_ENV, raising=False)
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_create_draft",
+        arguments={"payload": payload, "claim_context": claim},
+    )
+
+    assert cast(dict[str, object], result["item"])["resource_id"] == "draft-1"

--- a/tests/unit/mcp/test_oauth_server.py
+++ b/tests/unit/mcp/test_oauth_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 from email.message import Message
 from io import BytesIO
@@ -14,9 +15,41 @@ from google_work_agent.mcp.settings import GoogleOAuthSettings
 from google_work_agent.ports import CredentialState
 
 
+def _fake_id_token(claims: dict[str, object]) -> str:
+    header = server._b64url_encode(b'{"alg":"RS256","typ":"JWT"}')
+    payload = server._b64url_encode(json.dumps(claims).encode("utf-8"))
+    return f"{header}.{payload}.unverified-signature"
+
+
 def test_pkce_s256_matches_rfc_7636_vector() -> None:
     verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     assert server._pkce_s256(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+def test_required_scopes_include_openid_and_email() -> None:
+    assert "openid" in server.REQUIRED_SCOPES
+    assert "https://www.googleapis.com/auth/userinfo.email" in server.REQUIRED_SCOPES
+
+
+def test_verified_email_from_id_token_extracts_verified_email() -> None:
+    token = _fake_id_token({"email": "user@example.com", "email_verified": True})
+    assert server._verified_email_from_id_token(token) == "user@example.com"
+
+
+def test_verified_email_from_id_token_rejects_unverified_email() -> None:
+    token = _fake_id_token({"email": "user@example.com", "email_verified": False})
+    assert server._verified_email_from_id_token(token) is None
+
+
+def test_verified_email_from_id_token_rejects_missing_email_verified_claim() -> None:
+    token = _fake_id_token({"email": "user@example.com"})
+    assert server._verified_email_from_id_token(token) is None
+
+
+def test_verified_email_from_id_token_rejects_malformed_token() -> None:
+    assert server._verified_email_from_id_token("not-a-jwt") is None
+    assert server._verified_email_from_id_token("a.b") is None
+    assert server._verified_email_from_id_token("a.!!!not-base64!!!.c") is None
 
 
 def test_authorization_code_grant_binds_the_callback_uri_and_reports_only_redacted_errors(
@@ -109,7 +142,7 @@ def test_callback_consumes_a_flow_before_token_exchange_to_block_code_reuse(
         bound_flow: server._OAuthFlow,
         code: str,
         client_secret: str | None,
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, str | None]:
         nonlocal exchanges
         exchanges += 1
         assert bound_flow.callback_url == flow.callback_url
@@ -117,7 +150,7 @@ def test_callback_consumes_a_flow_before_token_exchange_to_block_code_reuse(
         assert client_secret == "compatibility-client-secret"
         exchange_started.set()
         assert release_exchange.wait(timeout=2)
-        return "refresh-value", "access-value"
+        return "refresh-value", "access-value", None
 
     monkeypatch.setattr(server, "_exchange_authorization_code", exchange)
     callback_url = (
@@ -190,9 +223,9 @@ def test_refresh_grant_rotates_keyring_and_keeps_access_token_in_mcp_memory(
 
     def refresh(
         value: str, client_id: str | None, client_secret: str | None
-    ) -> tuple[str, int, str | None]:
+    ) -> tuple[str, int, str | None, str | None]:
         calls.append((value, client_id, client_secret))
-        return "access-value", server._now_ms() + 10_000, "rotated-value"
+        return "access-value", server._now_ms() + 10_000, "rotated-value", None
 
     monkeypatch.setattr(server, "_refresh_access_token", refresh)
     state.ensure_access_token()
@@ -204,6 +237,71 @@ def test_refresh_grant_rotates_keyring_and_keeps_access_token_in_mcp_memory(
     assert store.values["refresh"] == "rotated-value"
     assert "access-value" not in repr(state.connection_payload())
     assert "compatibility-client-secret" not in repr(state.connection_payload())
+
+
+def test_ensure_access_token_self_heals_account_email_from_refresh_id_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Access tokens (and any id_token that arrives with them) are process-
+    memory-only, so a restarted MCP process must re-derive account_email on
+    its next refresh rather than requiring the user to reconnect."""
+
+    store = _MemorySecretStore({"refresh": "stored-value"})
+    state = _state(store)
+    assert state.account_email is None
+
+    def refresh(
+        value: str, client_id: str | None, client_secret: str | None
+    ) -> tuple[str, int, str | None, str | None]:
+        del value, client_id, client_secret
+        return "access-value", server._now_ms() + 10_000, None, "user@example.com"
+
+    monkeypatch.setattr(server, "_refresh_access_token", refresh)
+    state.ensure_access_token()
+
+    assert state.account_email == "user@example.com"
+
+
+def test_refresh_access_token_decodes_email_from_id_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = _fake_id_token({"email": "user@example.com", "email_verified": True})
+    body = json.dumps(
+        {"access_token": "access-value", "expires_in": 3600, "id_token": token}
+    ).encode("utf-8")
+    monkeypatch.setattr(server, "urlopen", lambda request, *, timeout: _HTTPResponse(body))
+
+    access_token, _, rotated_refresh_token, email = server._refresh_access_token(
+        "stored-refresh-token", "desktop-client", "compatibility-client-secret"
+    )
+
+    assert access_token == "access-value"
+    assert rotated_refresh_token is None
+    assert email == "user@example.com"
+
+
+def test_exchange_authorization_code_decodes_email_from_id_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flow = server._OAuthFlow(
+        flow_id="flow-1",
+        state="state-value",
+        verifier="verifier-value",
+        callback_url="http://127.0.0.1:43123/oauth/callback",
+        expires_at_ms=server._now_ms() + 60_000,
+        client_id="desktop-client",
+    )
+    token = _fake_id_token({"email": "user@example.com", "email_verified": True})
+    body = json.dumps(
+        {"refresh_token": "refresh-value", "access_token": "access-value", "id_token": token}
+    ).encode("utf-8")
+    monkeypatch.setattr(server, "urlopen", lambda request, *, timeout: _HTTPResponse(body))
+
+    refresh_token, access_token, email = server._exchange_authorization_code(
+        flow, "authorization-code", "compatibility-client-secret"
+    )
+
+    assert refresh_token == "refresh-value"
+    assert access_token == "access-value"
+    assert email == "user@example.com"
 
 
 def test_refresh_grant_uses_form_encoded_mcp_only_client_credentials(
@@ -219,7 +317,7 @@ def test_refresh_grant_uses_form_encoded_mcp_only_client_credentials(
 
     monkeypatch.setattr(server, "urlopen", accept)
 
-    access_token, _, rotated_refresh_token = server._refresh_access_token(
+    access_token, _, rotated_refresh_token, _ = server._refresh_access_token(
         "stored-refresh-token",
         "desktop-client",
         "compatibility-client-secret",
@@ -263,12 +361,12 @@ def test_concurrent_expired_access_token_refreshes_once(monkeypatch: pytest.Monk
 
     def refresh(
         value: str, client_id: str | None, client_secret: str | None
-    ) -> tuple[str, int, str | None]:
+    ) -> tuple[str, int, str | None, str | None]:
         nonlocal calls
         del value, client_id, client_secret
         with call_lock:
             calls += 1
-        return "access-value", server._now_ms() + 10_000, None
+        return "access-value", server._now_ms() + 10_000, None, None
 
     monkeypatch.setattr(server, "_refresh_access_token", refresh)
 

--- a/tests/unit/mcp/test_recovery_search.py
+++ b/tests/unit/mcp/test_recovery_search.py
@@ -1,0 +1,455 @@
+"""Unit tests for WP3 UNKNOWN_RESULT recovery: fingerprint embedding + search."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from google_work_agent.mcp import server
+from google_work_agent.mcp.settings import GoogleOAuthSettings
+
+SESSION_KEY = "22" * 32
+SERVICE_INSTANCE_ID = "svc-recovery-1"
+
+
+def _state() -> server._WorkspaceState:
+    state = server._WorkspaceState(keyring=_MemorySecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    state.session_key = SESSION_KEY
+    state.service_instance_id = SERVICE_INSTANCE_ID
+    return state
+
+
+class _MemorySecretStore:
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        del service, account, secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        del service, account
+        return None
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        del service, account
+        return True
+
+
+def _build_claim(
+    *, state: server._WorkspaceState, tool_name: str, execution_arguments: dict[str, object]
+) -> dict[str, object]:
+    issued_at_ms = server._now_ms()
+    claim: dict[str, object] = {
+        "claim_version": 2,
+        "action_id": "action-1",
+        "approval_id": "approval-1",
+        "execution_attempt_id": "attempt-1",
+        "tool_name": tool_name,
+        "approval_arguments_hash": server._canonical_json_hash(execution_arguments),
+        "execution_arguments_hash": server._canonical_json_hash(execution_arguments),
+        "service_instance_id": state.service_instance_id,
+        "mcp_process_instance_id": state.process_instance_id,
+        "issued_at_ms": issued_at_ms,
+        "expires_at_ms": issued_at_ms + 30_000,
+        "nonce": "nonce-recovery-1",
+    }
+    claim["signature"] = server._sign_claim_context(state.session_key, claim)
+    return claim
+
+
+# --------------------------------------------------------------------------
+# Marker embedding at CREATE / SEND time
+# --------------------------------------------------------------------------
+
+
+def test_gmail_create_draft_embeds_recovery_marker_in_body(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        captured["body"] = body
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {
+        "to": ["a@example.com"],
+        "subject": "Hi",
+        "body": "Body text",
+        "recovery_fingerprint": "fp-create-1",
+    }
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    server._tool_call(
+        state,
+        tool_name="gmail_create_draft",
+        arguments={"payload": payload, "claim_context": claim},
+    )
+
+    body = cast(dict[str, object], captured["body"])
+    message = cast(dict[str, object], body["message"])
+    raw_bytes = server._b64url_decode(cast(str, message["raw"]))
+    assert server._recovery_marker("fp-create-1").encode("utf-8") in raw_bytes
+
+
+def test_gmail_update_draft_never_embeds_a_marker(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        captured["body"] = body
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body text"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_update_draft",
+        execution_arguments={"draft_id": "draft-1", "payload": payload},
+    )
+
+    server._tool_call(
+        state,
+        tool_name="gmail_update_draft",
+        arguments={"draft_id": "draft-1", "payload": payload, "claim_context": claim},
+    )
+
+    body = cast(dict[str, object], captured["body"])
+    message = cast(dict[str, object], body["message"])
+    raw_bytes = server._b64url_decode(cast(str, message["raw"]))
+    assert server.RECOVERY_MARKER_PREFIX.encode("utf-8") not in raw_bytes
+
+
+def test_tasks_create_task_embeds_recovery_marker_in_notes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        captured["body"] = body
+        return {"id": "task-1", "title": "Follow up"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {
+        "title": "Follow up",
+        "notes": "Call customer",
+        "recovery_fingerprint": "fp-task-1",
+    }
+    claim = _build_claim(
+        state=state,
+        tool_name="tasks_create_task",
+        execution_arguments={"task_list_id": "list-1", "payload": payload},
+    )
+
+    server._tool_call(
+        state,
+        tool_name="tasks_create_task",
+        arguments={"task_list_id": "list-1", "payload": payload, "claim_context": claim},
+    )
+
+    body = cast(dict[str, object], captured["body"])
+    notes = cast(str, body["notes"])
+    assert notes.startswith("Call customer")
+    assert server._recovery_marker("fp-task-1") in notes
+
+
+def test_calendar_create_event_embeds_recovery_marker_in_description(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        captured["body"] = body
+        return {"id": "event-1", "summary": "Review"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {
+        "title": "Review",
+        "start": "2026-08-10T09:00:00+09:00",
+        "end": "2026-08-10T10:00:00+09:00",
+        "recovery_fingerprint": "fp-event-1",
+    }
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_create_event",
+        execution_arguments={"calendar_id": "primary", "payload": payload},
+    )
+
+    server._tool_call(
+        state,
+        tool_name="calendar_create_event",
+        arguments={"calendar_id": "primary", "payload": payload, "claim_context": claim},
+    )
+
+    body = cast(dict[str, object], captured["body"])
+    assert server._recovery_marker("fp-event-1") in cast(str, body["description"])
+
+
+def test_gmail_send_rewrites_draft_with_marker_before_sending(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, str]] = []
+    original_mime = server.EmailMessage()
+    original_mime["To"] = "a@example.com"
+    original_mime["Subject"] = "Hi"
+    original_mime.set_content("Original body")
+    encoded_raw = server._b64url_encode(original_mime.as_bytes())
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, url))
+        if method == "GET":
+            return {"message": {"raw": encoded_raw}}
+        assert method == "PUT"
+        message = cast(dict[str, object], cast(dict[str, object], body)["message"])
+        raw_bytes = server._b64url_decode(cast(str, message["raw"]))
+        assert b"Original body" in raw_bytes
+        assert server._recovery_marker("fp-send-1").encode("utf-8") in raw_bytes
+        return {"id": "draft-1", "message": {"id": "msg-1"}}
+
+    def google_api_post(
+        _state: server._WorkspaceState, url: str, body: dict[str, object]
+    ) -> dict[str, object]:
+        calls.append(("POST", url))
+        assert body == {"id": "draft-1"}
+        return {"id": "msg-sent-1", "threadId": "thread-1"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    monkeypatch.setattr(server, "_google_api_post", google_api_post)
+    state = _state()
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_send",
+        execution_arguments={"draft_id": "draft-1", "recovery_fingerprint": "fp-send-1"},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_send",
+        arguments={
+            "draft_id": "draft-1",
+            "recovery_fingerprint": "fp-send-1",
+            "claim_context": claim,
+        },
+    )
+
+    assert cast(dict[str, object], result["item"])["resource_id"] == "msg-sent-1"
+    assert [call[0] for call in calls] == ["GET", "PUT", "POST"]
+
+
+def test_gmail_send_without_fingerprint_never_touches_the_draft(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fail_on_any_call(*_args: object, **_kwargs: object) -> dict[str, object]:
+        pytest.fail("draft must not be re-read or rewritten when no fingerprint is supplied")
+
+    def google_api_post(
+        _state: server._WorkspaceState, url: str, body: dict[str, object]
+    ) -> dict[str, object]:
+        assert body == {"id": "draft-1"}
+        return {"id": "msg-sent-1", "threadId": "thread-1"}
+
+    monkeypatch.setattr(server, "_google_api_call", fail_on_any_call)
+    monkeypatch.setattr(server, "_google_api_post", google_api_post)
+    state = _state()
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_send",
+        execution_arguments={"draft_id": "draft-1", "recovery_fingerprint": None},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_send",
+        arguments={"draft_id": "draft-1", "recovery_fingerprint": None, "claim_context": claim},
+    )
+
+    assert cast(dict[str, object], result["item"])["resource_id"] == "msg-sent-1"
+
+
+# --------------------------------------------------------------------------
+# search_by_recovery_fingerprint
+# --------------------------------------------------------------------------
+
+
+def test_search_gmail_draft_returns_full_snapshot_for_a_single_match(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    responses = [
+        {"drafts": [{"id": "draft-1"}]},
+        {
+            "id": "draft-1",
+            "message": {
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "payload": {"headers": [{"name": "Subject", "value": "Hi"}]},
+            },
+        },
+    ]
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        return cast(dict[str, object], responses.pop(0))
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "gmail_draft", "recovery_fingerprint": "fp-1"},
+    )
+    items = cast(list[dict[str, object]], result["items"])
+    assert len(items) == 1
+    assert items[0]["resource_id"] == "draft-1"
+
+
+def test_search_gmail_draft_returns_no_candidates_when_zero_matches(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api", lambda *a, **k: {"drafts": []})
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "gmail_draft", "recovery_fingerprint": "fp-missing"},
+    )
+    assert result["items"] == []
+
+
+def test_search_gmail_draft_returns_all_candidates_when_ambiguous(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        server, "_google_api", lambda *a, **k: {"drafts": [{"id": "d1"}, {"id": "d2"}]}
+    )
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "gmail_draft", "recovery_fingerprint": "fp-dup"},
+    )
+    items = cast(list[dict[str, object]], result["items"])
+    assert {item["resource_id"] for item in items} == {"d1", "d2"}
+
+
+def test_search_gmail_message_returns_full_snapshot_for_a_single_match(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    responses = [
+        {"messages": [{"id": "msg-1"}]},
+        {
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "historyId": "5",
+            "payload": {"headers": [{"name": "Subject", "value": "Sent"}]},
+        },
+    ]
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        return cast(dict[str, object], responses.pop(0))
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "gmail_message", "recovery_fingerprint": "fp-send-1"},
+    )
+    items = cast(list[dict[str, object]], result["items"])
+    assert items[0]["resource_id"] == "msg-1"
+    assert items[0]["payload"] == {"subject": "Sent", "sent": True}
+
+
+def test_search_tasks_scans_all_task_lists_and_filters_by_marker(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    marker = server._recovery_marker("fp-task-1")
+    responses = {
+        "https://tasks.googleapis.com/tasks/v1/users/@me/lists": {
+            "items": [{"id": "list-1"}, {"id": "list-2"}]
+        },
+        "https://tasks.googleapis.com/tasks/v1/lists/list-1/tasks": {
+            "items": [
+                {"id": "task-1", "title": "Match", "notes": f"context\n\n{marker}"},
+                {"id": "task-2", "title": "No match", "notes": "unrelated"},
+            ]
+        },
+        "https://tasks.googleapis.com/tasks/v1/lists/list-2/tasks": {"items": []},
+    }
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        return responses[url]
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "task", "recovery_fingerprint": "fp-task-1"},
+    )
+    items = cast(list[dict[str, object]], result["items"])
+    assert len(items) == 1
+    assert items[0]["resource_id"] == "task-1"
+    assert items[0]["parent_id"] == "list-1"
+
+
+def test_search_calendar_events_scans_all_calendars_with_query(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    responses = {
+        "https://www.googleapis.com/calendar/v3/users/me/calendarList": {
+            "items": [{"id": "primary"}, {"id": "team"}]
+        },
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events": {
+            "items": [{"id": "event-1", "summary": "Review"}]
+        },
+        "https://www.googleapis.com/calendar/v3/calendars/team/events": {"items": []},
+    }
+
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        if url.endswith("/events"):
+            assert params is not None and "q" in params
+        return responses[url]
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(),
+        tool_name="search_by_recovery_fingerprint",
+        arguments={"resource_type": "calendar_event", "recovery_fingerprint": "fp-event-1"},
+    )
+    items = cast(list[dict[str, object]], result["items"])
+    assert len(items) == 1
+    assert items[0]["resource_id"] == "event-1"
+    assert items[0]["parent_id"] == "primary"
+
+
+def test_search_by_recovery_fingerprint_rejects_unknown_resource_type(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api", lambda *a, **k: pytest.fail("must not call Google"))
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            _state(),
+            tool_name="search_by_recovery_fingerprint",
+            arguments={"resource_type": "task_list", "recovery_fingerprint": "fp-1"},
+        )
+    assert exc_info.value.safe_code == "INVALID_ARGUMENT"

--- a/tests/unit/mcp/test_workspace_write_tools.py
+++ b/tests/unit/mcp/test_workspace_write_tools.py
@@ -1,0 +1,815 @@
+"""Unit tests for R8.4 ClaimContextV2 validation and Gmail write/read tools."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from google_work_agent.domain import calculate_canonical_json_hash
+from google_work_agent.mcp import server
+from google_work_agent.mcp.settings import GoogleOAuthSettings
+
+SESSION_KEY = "11" * 32
+SERVICE_INSTANCE_ID = "svc-test-1"
+
+
+def _state() -> server._WorkspaceState:
+    state = server._WorkspaceState(keyring=_MemorySecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    state.session_key = SESSION_KEY
+    state.service_instance_id = SERVICE_INSTANCE_ID
+    return state
+
+
+class _MemorySecretStore:
+    def set_secret(self, *, service: str, account: str, secret: str) -> None:
+        del service, account, secret
+
+    def get_secret(self, *, service: str, account: str) -> str | None:
+        del service, account
+        return None
+
+    def delete_secret(self, *, service: str, account: str) -> bool:
+        del service, account
+        return True
+
+
+def _build_claim(
+    *,
+    state: server._WorkspaceState,
+    tool_name: str,
+    execution_arguments: dict[str, object],
+    action_id: str = "action-1",
+    approval_id: str = "approval-1",
+    execution_attempt_id: str = "attempt-1",
+    service_instance_id: str | None = None,
+    mcp_process_instance_id: str | None = None,
+    nonce: str = "nonce-1",
+    ttl_ms: int = 30_000,
+    issued_offset_ms: int = 0,
+    execution_arguments_hash: str | None = None,
+) -> dict[str, object]:
+    issued_at_ms = server._now_ms() + issued_offset_ms
+    claim: dict[str, object] = {
+        "claim_version": 2,
+        "action_id": action_id,
+        "approval_id": approval_id,
+        "execution_attempt_id": execution_attempt_id,
+        "tool_name": tool_name,
+        "approval_arguments_hash": calculate_canonical_json_hash(execution_arguments),
+        "execution_arguments_hash": (
+            execution_arguments_hash
+            if execution_arguments_hash is not None
+            else calculate_canonical_json_hash(execution_arguments)
+        ),
+        "service_instance_id": service_instance_id or state.service_instance_id,
+        "mcp_process_instance_id": mcp_process_instance_id or state.process_instance_id,
+        "issued_at_ms": issued_at_ms,
+        "expires_at_ms": issued_at_ms + ttl_ms,
+        "nonce": nonce,
+    }
+    claim["signature"] = server._sign_claim_context(state.session_key, claim)
+    return claim
+
+
+def _reject_google_calls(*_args: object, **_kwargs: object) -> dict[str, object]:
+    pytest.fail("Google API must not be called")
+
+
+# --------------------------------------------------------------------------
+# Happy-path dispatch
+# --------------------------------------------------------------------------
+
+
+def test_gmail_create_draft_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, url, body))
+        return {
+            "id": "draft-1",
+            "message": {
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "historyId": "10",
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "Hi"},
+                        {"name": "To", "value": "a@example.com"},
+                    ]
+                },
+            },
+        }
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body text"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_create_draft",
+        arguments={"payload": payload, "claim_context": claim},
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["resource_id"] == "draft-1"
+    assert item["resource_type"] == "gmail_draft"
+    assert len(calls) == 1
+    assert calls[0][0] == "POST"
+    assert calls[0][1] == "https://gmail.googleapis.com/gmail/v1/users/me/drafts"
+    body = cast(dict[str, object], calls[0][2])
+    message = cast(dict[str, object], body["message"])
+    assert "raw" in message
+
+
+def test_gmail_update_draft_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(method)
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Updated", "body": "New body"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_update_draft",
+        execution_arguments={"draft_id": "draft-1", "payload": payload},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_update_draft",
+        arguments={"draft_id": "draft-1", "payload": payload, "claim_context": claim},
+    )
+
+    assert cast(dict[str, object], result["item"])["resource_id"] == "draft-1"
+    assert calls == ["PUT"]
+
+
+def test_gmail_send_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def google_api_post(
+        _state: server._WorkspaceState, url: str, body: dict[str, object]
+    ) -> dict[str, object]:
+        calls.append((url, body))
+        return {
+            "id": "msg-sent-1",
+            "threadId": "thread-1",
+            "historyId": "20",
+            "payload": {"headers": [{"name": "Subject", "value": "Hi"}]},
+        }
+
+    monkeypatch.setattr(server, "_google_api_post", google_api_post)
+    state = _state()
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_send",
+        execution_arguments={"draft_id": "draft-1", "recovery_fingerprint": None},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="gmail_send",
+        arguments={"draft_id": "draft-1", "recovery_fingerprint": None, "claim_context": claim},
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["resource_id"] == "msg-sent-1"
+    assert item["resource_type"] == "gmail_message"
+    assert len(calls) == 1
+    assert calls[0][0] == "https://gmail.googleapis.com/gmail/v1/users/me/drafts/send"
+    assert calls[0][1] == {"id": "draft-1"}
+
+
+def test_gmail_get_draft_reads_without_a_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def google_api(
+        _state: server._WorkspaceState, url: str, params: dict[str, str] | None = None
+    ) -> dict[str, object]:
+        assert url.endswith("/drafts/draft-1")
+        return {
+            "id": "draft-1",
+            "message": {
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "payload": {"headers": [{"name": "Subject", "value": "Hi"}]},
+            },
+        }
+
+    monkeypatch.setattr(server, "_google_api", google_api)
+    result = server._tool_call(
+        _state(), tool_name="gmail_get_draft", arguments={"draft_id": "draft-1"}
+    )
+    assert cast(dict[str, object], result["item"])["resource_id"] == "draft-1"
+
+
+# --------------------------------------------------------------------------
+# ClaimContextV2 rejection: every case must dispatch zero Google API calls.
+# --------------------------------------------------------------------------
+
+
+def test_missing_claim_context_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(state, tool_name="gmail_create_draft", arguments={"payload": payload})
+
+    assert exc_info.value.safe_code == "CLAIM_MISSING"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_malformed_claim_context_missing_field_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+    del claim["nonce"]
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_MISSING"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_invalid_signature_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+    claim["nonce"] = "tampered-nonce"  # signature no longer matches the payload
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_INVALID_SIGNATURE"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_expired_claim_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_create_draft",
+        execution_arguments={"payload": payload},
+        issued_offset_ms=-60_000,
+        ttl_ms=30_000,
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_EXPIRED"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_ttl_exceeding_maximum_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_create_draft",
+        execution_arguments={"payload": payload},
+        ttl_ms=120_000,
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_TTL_EXCEEDED"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_wrong_service_instance_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_create_draft",
+        execution_arguments={"payload": payload},
+        service_instance_id="svc-other",
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_SERVICE_INSTANCE_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_wrong_mcp_process_instance_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state,
+        tool_name="gmail_create_draft",
+        execution_arguments={"payload": payload},
+        mcp_process_instance_id="mcp-other",
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_PROCESS_INSTANCE_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_wrong_tool_binding_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_update_draft", execution_arguments={"payload": payload}
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_TOOL_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_wrong_execution_arguments_hash_is_rejected(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+    # Tamper the payload actually sent without re-issuing a matching claim.
+    tampered_payload = dict(payload)
+    tampered_payload["body"] = "A different body approved elsewhere"
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": tampered_payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_ARGUMENTS_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_nonce_reuse_is_rejected_and_google_is_called_at_most_once(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(method)
+        return {"id": "draft-1", "message": {"id": "msg-1", "threadId": "thread-1"}}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+    claim = _build_claim(
+        state=state, tool_name="gmail_create_draft", execution_arguments={"payload": payload}
+    )
+
+    first = server._tool_call(
+        state,
+        tool_name="gmail_create_draft",
+        arguments={"payload": payload, "claim_context": claim},
+    )
+    assert cast(dict[str, object], first["item"])["resource_id"] == "draft-1"
+    assert len(calls) == 1
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={"payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_TOKEN_REUSED"
+    assert exc_info.value.dispatch_started is False
+    assert len(calls) == 1
+
+
+def test_tool_not_available_without_claim_infrastructure(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = server._WorkspaceState(keyring=_MemorySecretStore())
+    state.oauth_settings = GoogleOAuthSettings(
+        google_oauth_client_id="desktop-client",
+        google_oauth_client_secret="compatibility-client-secret",
+    )
+    # session_key/process binding never established (no handshake performed).
+    payload: dict[str, object] = {"to": ["a@example.com"], "subject": "Hi", "body": "Body"}
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="gmail_create_draft",
+            arguments={
+                "payload": payload,
+                "claim_context": {
+                    "claim_version": 2,
+                    "action_id": "a",
+                    "approval_id": "b",
+                    "execution_attempt_id": "c",
+                    "tool_name": "gmail_create_draft",
+                    "approval_arguments_hash": "x",
+                    "execution_arguments_hash": "x",
+                    "service_instance_id": "svc",
+                    "mcp_process_instance_id": "mcp",
+                    "issued_at_ms": 0,
+                    "expires_at_ms": 1,
+                    "nonce": "n",
+                    "signature": "s",
+                },
+            },
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_SERVICE_UNAVAILABLE"
+    assert exc_info.value.dispatch_started is False
+
+
+# --------------------------------------------------------------------------
+# Tasks write tools (WP1)
+# --------------------------------------------------------------------------
+
+
+def test_tasks_create_task_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, url, body))
+        return {"id": "task-1", "title": "Follow up", "status": "needsAction"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"title": "Follow up", "notes": "Call customer"}
+    claim = _build_claim(
+        state=state,
+        tool_name="tasks_create_task",
+        execution_arguments={"task_list_id": "list-1", "payload": payload},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="tasks_create_task",
+        arguments={"task_list_id": "list-1", "payload": payload, "claim_context": claim},
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["resource_id"] == "task-1"
+    assert item["parent_id"] == "list-1"
+    assert len(calls) == 1
+    assert calls[0][0] == "POST"
+    assert calls[0][1] == "https://tasks.googleapis.com/tasks/v1/lists/list-1/tasks"
+    assert calls[0][2] == {"title": "Follow up", "notes": "Call customer"}
+
+
+def test_tasks_update_task_supports_completion(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, dict[str, object] | None]] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, body))
+        return {"id": "task-1", "title": "Follow up", "status": "completed"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"status": "completed"}
+    claim = _build_claim(
+        state=state,
+        tool_name="tasks_update_task",
+        execution_arguments={"task_list_id": "list-1", "task_id": "task-1", "payload": payload},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="tasks_update_task",
+        arguments={
+            "task_list_id": "list-1",
+            "task_id": "task-1",
+            "payload": payload,
+            "claim_context": claim,
+        },
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["payload"] == {"title": "Follow up", "status": "completed"}
+    assert calls == [("PATCH", {"status": "completed"})]
+
+
+def test_tasks_create_task_claim_rejection_dispatches_zero_calls(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {"title": "Follow up"}
+    claim = _build_claim(
+        state=state,
+        tool_name="tasks_create_task",
+        execution_arguments={"task_list_id": "list-1", "payload": payload},
+    )
+    tampered_payload = dict(payload)
+    tampered_payload["title"] = "A different title"
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="tasks_create_task",
+            arguments={
+                "task_list_id": "list-1",
+                "payload": tampered_payload,
+                "claim_context": claim,
+            },
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_ARGUMENTS_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_tasks_update_task_missing_claim_dispatches_zero_calls(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="tasks_update_task",
+            arguments={
+                "task_list_id": "list-1",
+                "task_id": "task-1",
+                "payload": {"status": "completed"},
+            },
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_MISSING"
+    assert exc_info.value.dispatch_started is False
+
+
+# --------------------------------------------------------------------------
+# Calendar write tools (WP2)
+# --------------------------------------------------------------------------
+
+
+def test_calendar_create_event_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, url, body))
+        return {
+            "id": "event-1",
+            "summary": "Review",
+            "status": "confirmed",
+            "start": {"dateTime": "2026-08-10T09:00:00+09:00"},
+            "end": {"dateTime": "2026-08-10T10:00:00+09:00"},
+        }
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {
+        "title": "Review",
+        "start": "2026-08-10T09:00:00+09:00",
+        "end": "2026-08-10T10:00:00+09:00",
+        "attendees": ["a@example.com", "b@example.com"],
+    }
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_create_event",
+        execution_arguments={"calendar_id": "primary", "payload": payload},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="calendar_create_event",
+        arguments={"calendar_id": "primary", "payload": payload, "claim_context": claim},
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["resource_id"] == "event-1"
+    assert item["parent_id"] == "primary"
+    assert len(calls) == 1
+    assert calls[0][0] == "POST"
+    body = cast(dict[str, object], calls[0][2])
+    assert body["summary"] == "Review"
+    assert body["attendees"] == [{"email": "a@example.com"}, {"email": "b@example.com"}]
+
+
+def test_calendar_update_event_supports_attendee_change(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[dict[str, object] | None] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        assert method == "PATCH"
+        calls.append(body)
+        return {"id": "event-1", "summary": "Review", "status": "confirmed"}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    payload: dict[str, object] = {"attendees": ["c@example.com"]}
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_update_event",
+        execution_arguments={"calendar_id": "primary", "event_id": "event-1", "payload": payload},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="calendar_update_event",
+        arguments={
+            "calendar_id": "primary",
+            "event_id": "event-1",
+            "payload": payload,
+            "claim_context": claim,
+        },
+    )
+
+    assert cast(dict[str, object], result["item"])["resource_id"] == "event-1"
+    assert calls == [{"attendees": [{"email": "c@example.com"}]}]
+
+
+def test_calendar_delete_event_dispatches_with_valid_claim(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(method)
+        assert body is None
+        return {}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_delete_event",
+        execution_arguments={"calendar_id": "primary", "event_id": "event-1"},
+    )
+
+    result = server._tool_call(
+        state,
+        tool_name="calendar_delete_event",
+        arguments={"calendar_id": "primary", "event_id": "event-1", "claim_context": claim},
+    )
+
+    item = cast(dict[str, object], result["item"])
+    assert item["resource_id"] == "event-1"
+    assert item["payload"] == {"status": "cancelled"}
+    assert calls == ["DELETE"]
+
+
+def test_calendar_create_event_claim_rejection_dispatches_zero_calls(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(server, "_google_api_call", _reject_google_calls)
+    state = _state()
+    payload: dict[str, object] = {
+        "title": "Review",
+        "start": "2026-08-10T09:00:00+09:00",
+        "end": "2026-08-10T10:00:00+09:00",
+    }
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_update_event",  # wrong tool binding on purpose
+        execution_arguments={"calendar_id": "primary", "payload": payload},
+    )
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="calendar_create_event",
+            arguments={"calendar_id": "primary", "payload": payload, "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_TOOL_MISMATCH"
+    assert exc_info.value.dispatch_started is False
+
+
+def test_calendar_delete_event_nonce_reuse_dispatches_at_most_once(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    def google_api_call(
+        _state: server._WorkspaceState,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, str] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(method)
+        return {}
+
+    monkeypatch.setattr(server, "_google_api_call", google_api_call)
+    state = _state()
+    claim = _build_claim(
+        state=state,
+        tool_name="calendar_delete_event",
+        execution_arguments={"calendar_id": "primary", "event_id": "event-1"},
+    )
+
+    first = server._tool_call(
+        state,
+        tool_name="calendar_delete_event",
+        arguments={"calendar_id": "primary", "event_id": "event-1", "claim_context": claim},
+    )
+    assert cast(dict[str, object], first["item"])["resource_id"] == "event-1"
+    assert len(calls) == 1
+
+    with pytest.raises(server._WorkspaceToolError) as exc_info:
+        server._tool_call(
+            state,
+            tool_name="calendar_delete_event",
+            arguments={"calendar_id": "primary", "event_id": "event-1", "claim_context": claim},
+        )
+
+    assert exc_info.value.safe_code == "CLAIM_TOKEN_REUSED"
+    assert len(calls) == 1


### PR DESCRIPTION
…y gaps## 작업 개요

R8.4 Canonical 기준으로 남아 있던 Google Workspace 실제 Write Runtime과
Google 계정 Identity Provisioning 경로를 구현했습니다.

주요 작업 범위는 다음과 같습니다.

- ClaimContextV2 계약 구현
- Gmail / Tasks / Calendar 실제 MCP Write 연결
- UNKNOWN_RESULT Recovery 실제화
- Gmail Attachment READ / Staging / Draft Attachment 지원
- Google OAuth 계정 이메일 확보 및 `google_accounts` 프로비저닝
- MCP Write 오류의 delivery certainty 전달 보강

프론트엔드 UI/UX는 변경하지 않았습니다.

---

## 주요 변경 사항

### 1. ClaimContextV2

- `approval_arguments_hash`와 `execution_arguments_hash` 분리
- 실제 MCP Dispatch Arguments 기준으로 execution hash 계산
- MCP에서 다음 항목을 독립 검증
  - HMAC 서명
  - TTL
  - Service Instance
  - MCP Process Instance
  - Action / Approval / ExecutionAttempt / Tool Binding
  - nonce
  - 실제 수신 Arguments 재해시
- Claim 검증 실패 시 Google Write가 실행되지 않도록 보장
- nonce 경쟁 조건 보완
- pre-dispatch 검증 실패 시 기존 retry semantics 유지

---

### 2. Gmail Write

실제 Gmail API 호출 구현:

- Draft CREATE
- Draft UPDATE
- SEND
- Draft GET

Verification에 필요한 실제 Draft 조회 경로까지 연결했습니다.

---

### 3. Tasks Write

실제 Google Tasks API 호출 구현:

- Task CREATE
- Task UPDATE
- Task COMPLETE

Task COMPLETE는 별도 Effect를 추가하지 않고
기존 계약대로 `status` 변경을 통해 처리합니다.

Task DELETE는 구현하지 않았습니다.

---

### 4. Calendar Write

실제 Google Calendar API 호출 구현:

- Event CREATE
- Event UPDATE
- Event DELETE
- Attendee 추가/수정

반복 일정 전체 일괄 수정 기능은 추가하지 않았습니다.

---

### 5. UNKNOWN_RESULT Recovery

실제 Google 조회 기반 Recovery를 구현했습니다.

- CREATE
  - recovery fingerprint 기반 resource search
- SEND
  - 발송 시 recovery marker 삽입 및 sent message search
- UPDATE
  - target GET
- DELETE
  - target GET / absence 확인

기존 계약대로 다음은 허용하지 않습니다.

- UNKNOWN_RESULT에서 blind resend
- 새로운 ExecutionAttempt 자동 생성
- 기존 Approval 재사용 기반 자동 재실행

---

### 6. Gmail Attachment

구현 범위:

- Gmail Attachment READ MCP Tool
- Attachment Download API
- Local Attachment Staging
- Descriptor / SHA-256 / Size 재검증
- Gmail Draft CREATE / UPDATE MIME Attachment 연결

Attachment raw bytes는 다음 영역에 저장하거나 전달하지 않습니다.

- LLM Context
- Agent State
- SQLite
- Trace
- Audit Log

---

### 7. Google Account Identity Provisioning

실제 브라우저 E2E 확인 중
`/api/v1/identity/google-account`가 항상 `account: null`을 반환하는 문제를 발견했습니다.

원인은 실제 OAuth 연결 흐름에서
`google_accounts` 테이블을 생성/갱신하는 경로가 없었던 것이었습니다.

수정 내용:

- Google OAuth에 계정 Identity용 Scope 추가
- Google Account Email 확보
- `google_accounts` deterministic upsert 구현
- Google Connection 확인 시 Account Provisioning 연결

사용자가 Google 계정을 재연결하고 새 Scope에 동의한 뒤 실제로 확인했습니다.

```text
GET /api/v1/identity/google-account
→ 200 OK
→ account_id 정상 반환
→ email 정상 반환