### PR TITLE
[docs] Google Tasks 예정일·업무 마감·상태 계약 정리

### DIFF
--- a/docs/00-google-work-agent-overview.md
+++ b/docs/00-google-work-agent-overview.md
@@ -1,6 +1,6 @@
 # Google Work Agent — 5분 개요
 
-> **기준일:** 2026-08-09 · **R8.4 Claim V2·Attachment Canonical** · **공식 원본:** Notion · **이 파일:** Repository Export Snapshot
+> **기준일:** 2026-08-10 · **R8.4 Claim V2·Attachment·Task 시간 의미 Canonical** · **공식 원본:** Notion · **이 파일:** Repository Export Snapshot
 
 ## 제품 흐름
 
@@ -41,21 +41,21 @@
 
 | 문서 | 버전 |
 |---|---:|
-| PRD | v2.7 |
-| Functional | v2.6 |
-| Policy | v2.7 |
-| UI·UX | v2.4 |
+| PRD | v2.8 |
+| Functional | v2.9 |
+| Policy | v2.8 |
+| UI·UX | v2.8 |
 | Architecture | v3.0 |
 | Domain·DB | v1.12 |
-| Retrieval | v2.5 |
-| Workflow | v6.0 |
-| Interface | v2.8 |
-| Sequence | v3.1 |
+| Retrieval | v2.6 |
+| Workflow | v6.1 |
+| Interface | v2.10 |
+| Sequence | v3.2 |
 | Security | v2.5 |
 | Infrastructure | v2.7 |
 | Observability | v2.9 |
-| Test | v3.1 |
-| Evaluation | v3.1 |
+| Test | v3.5 |
+| Evaluation | v3.2 |
 | Operations | v2.5 |
 | Agent Capability·Failure·Prompt | v1.5 |
 | Domain DB Schema | v1.4 |

--- a/docs/01-a-functional-definition.md
+++ b/docs/01-a-functional-definition.md
@@ -1,6 +1,6 @@
 # 01-A. Google Work Agent 기능 정의서
 
-> **상태:** Draft v2.8 · **기준일:** 2026-08-10
+> **상태:** Draft v2.9 · **기준일:** 2026-08-10
 
 ## 1. 문서 목적
 
@@ -147,7 +147,7 @@
 - **사용자 목적:** Gmail·Tasks·Calendar의 현재 항목을 목록으로 탐색한다.
 - **입력:** Source, 검색·필터 조건, Page Token.
 - **처리:** 페이지당 10~20개를 Google API에서 조회하며 P0 기본값은 20개로 한다.
-- **정렬:** Gmail 최근 수신 순, Tasks 미완료·기한 임박 우선, Calendar 가까운 예정 일정 순.
+- **정렬:** Gmail 최근 수신 순, Tasks 미완료·예정일 임박 우선, Calendar 가까운 예정 일정 순.
 - **출력:** 목록 Metadata, 다음 Page Token, 마지막 조회 시각.
 - **완료 조건:** 사용자가 원본 전체를 로컬 DB에 저장하지 않고 최신 목록을 탐색할 수 있다.
 
@@ -205,7 +205,7 @@
 ### FN-022 Tasks 검색·조회
 
 - **상태:** P0
-- **입력:** Task List, 상태, 기한, Keyword.
+- **입력:** Task List, 상태, 예정일, Keyword.
 - **처리:** 기본·선택 List의 미완료 Task를 조회하고 정규화한다.
 - **출력:** Task WorkItem.
 
@@ -257,7 +257,7 @@
 ### FN-031 Task 중복 검사
 
 - **상태:** P0
-- **처리:** 제목·사람·Thread·기한·상태를 비교한다.
+- **처리:** 제목·사람·Thread·예정일·상태를 비교한다. 실제 업무 마감은 관련 Evidence에 있을 때만 별도 비교한다.
 - **출력:** 중복 차단, 중복 경고, 신규 허용.
 
 ### FN-032 Calendar 충돌 검사
@@ -269,7 +269,7 @@
 ### FN-033 업무 가능성 판단
 
 - **상태:** P0
-- **입력:** 마감, 예상 소요시간, 가용 Slot, 사용자 업무 시간.
+- **입력:** Evidence 또는 사용자 요청에서 확인한 업무 마감, 예상 소요시간, 가용 Slot, 사용자 업무 시간.
 - **출력:** 가능, 위험, 불가능 및 근거.
 - **예외:** 예상 시간이 없으면 Event를 자동 제안하지 않고 확인 질문을 한다.
 
@@ -297,7 +297,7 @@
 ### FN-043 Task 제안
 
 - **상태:** P0
-- **출력:** 제목, 메모, 기한, Task List.
+- **출력:** 제목, 메모, 예정일(`scheduled_date`), Task List. 실제 업무 마감(`business_deadline`)은 Google Task 예정일로 자동 변환하지 않으며, 필요한 경우 notes와 Evidence·Approval Summary에 업무 마감 의미로 보존한다.
 - **제한:** 정확한 Task 완료 상태 변경과 Task 삭제는 사용자 승인 후 허용한다. Task 삭제는 `DELETE`로 처리하고 실행 후 대상 부재를 검증한다.
 
 ### FN-044 작업 Event 제안
@@ -321,7 +321,7 @@
 ### FN-052 Action 수정
 
 - **상태:** P0
-- **수정 가능:** Draft 수신자·CC·제목·본문, Task 제목·메모·기한, Event 제목·시간·설명.
+- **수정 가능:** Draft 수신자·CC·제목·본문, Task 제목·메모·예정일, Event 제목·시간·설명.
 - **처리:** 수정 후 Schema·Policy·중복·충돌을 다시 검사한다.
 
 ### FN-053 Action 거절
@@ -595,7 +595,7 @@ Supervisor는 Phase, Agent Result, Domain Result와 Budget으로만 Routing한�
 
 ### Source별 Sidebar 목록
 
-- Tasks는 실제 Google Workspace Source다. 지원 Projection은 제목, 메모, 기한, Task List, 완료 상태이며, 기본 compact row는 **Task 제목 → 기한** 순서로 표시한다. Task List는 실제 반환된 값만 보조 정보로 사용할 수 있다. 정렬은 미완료·기한 임박 우선 의미를 유지한다.
+- Tasks는 실제 Google Workspace Source다. 지원 Projection은 제목, 메모, 예정일, Task List, 완료 상태이며, 기본 compact row는 **Task 제목 → 예정일** 순서로 표시한다. Task List는 실제 반환된 값만 보조 정보로 사용할 수 있다. 정렬은 미완료·예정일 임박 우선 의미를 유지한다.
 - Tasks와 Calendar row에는 priority, 임의 category·Task List 이름, 임의 색상 dot·marker·status badge, 내부 Google ID, Page Token을 생성하거나 표시하지 않는다.
 - Calendar Event compact row는 **Event 제목 → 시간 범위** 순서다. 같은 날 시간 Event는 `YYYY년 M월 D일 (요일) 오전/오후 h:mm - 오전/오후 h:mm` 형식으로 연·월·일·요일·시작 시간·종료 시간을 표시하고 날짜는 한 번만 표시한다. 날짜가 다르면 시작일과 종료일을 각각 식별 가능하게 표시한다. All-day Event는 `YYYY년 M월 D일 (요일) · 하루 종일` 형식이다.
 - Calendar Sidebar에는 `시작`, `종료` label을 표시하지 않는다. 중앙 Viewer의 Event 상세는 제공된 `시작`, `종료` 필드를 유지한다. 선택 상태는 기존 Source row와 같은 background/focus styling으로만 나타낸다.
@@ -605,6 +605,25 @@ Supervisor는 Phase, Agent Result, Domain Result와 Budget으로만 Routing한�
 
 - 중앙 Viewer 제목은 모든 Source에서 `자료 상세`다. Focus가 없을 때 Gmail은 `왼쪽 목록에서 메일을 선택하면 상세 내용을 확인할 수 있습니다.`, Tasks는 `왼쪽 목록에서 태스크를 선택하면 상세 내용을 확인할 수 있습니다.`, Calendar는 `왼쪽 목록에서 일정을 선택하면 상세 내용을 확인할 수 있습니다.`를 표시한다.
 - Source 전환은 이전 Source의 Focus와 상세 표시를 제거한 뒤 새 Source의 Empty State 또는 새 Focus 상세를 표시한다.
+
+## v2.9 Google Tasks 날짜·상태 의미
+
+이 절은 Google Tasks의 제품 의미를 소유한다. 기존 Task의 `기한` 또는 `due`가 실제 업무 마감과 동일하다고 해석한 표현과 상충하면 이 절을 우선한다. Google Write 승인·Claim·Verification과 Domain 상태 권위는 변경하지 않는다.
+
+### 예정일과 업무 마감
+
+- `scheduled_date`는 사용자가 Task를 수행할 예정인 날짜다. Google Tasks API Adapter의 `due`와 대응하며 READ/WRITE 가능하다. 시간 정보를 생성·추론하지 않는다.
+- `business_deadline`은 업무 자체가 완료되어야 하는 실제 마감이다. Gmail 본문, 사용자 요청, Evidence에서 인식할 수 있으나 Google Tasks API의 `due`와 동일시하지 않는다.
+- 업무 마감만 있는 요청은 `scheduled_date`를 만들거나 Google `due`를 채우지 않는다. 필요한 경우 `notes`에 `업무 마감: YYYY년 M월 D일`처럼 의미를 보존하고 Evidence·Approval Summary에도 근거를 남긴다.
+- 수행 예정일과 업무 마감이 모두 명시되면 각각 보존한다. 예를 들어 11일 수행·12일 제출은 `scheduled_date=11일`, `business_deadline=12일`이며 Google `due`에는 11일만 사용한다.
+- 시간대가 지정된 Task 요청은 현재 Google Tasks API가 정확한 시간 구간을 구조화해 설정했다고 성공 처리하지 않는다. 날짜 예정일만 제안하거나, 정확한 시간 예약이 필요하면 승인형 Calendar Event 대안을 사용자에게 제시한다. 사용자 동의 없이 Event를 추가하지 않는다.
+
+### 상태와 사용자 Projection
+
+- Provider raw `needsAction`은 제품 상태 `NEEDS_ACTION`, UI 문구 `미완료`로 정규화한다. raw `completed`는 `COMPLETED`, UI 문구 `완료`로 정규화한다.
+- 예정일 경과는 상태 전이가 아니다. `scheduled_date`가 지났고 상태가 미완료이면 UI 보조 문구 `예정일 지남`만 사용할 수 있으며, `기한 초과`·`마감 초과` 또는 자동 완료로 표현하지 않는다.
+- 완료는 Google Task 실제 status가 `completed`일 때만 표시한다. Provider가 완료 날짜를 제공하면 사용자 친화적인 `완료일`로 표시할 수 있다.
+- 목록·상세에는 raw enum, RFC3339 raw `due`, 내부 `due` 필드명, API에 없는 작업 시간·업무 마감을 표시하지 않는다. React는 사용자용 Local API Projection을 소비하며 Provider 의미의 최종 정규화를 담당하지 않는다.
 
 ## R8.4 Gmail 첨부파일 기능
 

--- a/docs/01-b-policy-definition-v2.7.md
+++ b/docs/01-b-policy-definition-v2.7.md
@@ -1,6 +1,6 @@
 # 01-B. Google Work Agent 정책 정의서
 
-> **상태:** Draft v2.7 · **기준일:** 2026-08-09
+> **상태:** Draft v2.8 · **기준일:** 2026-08-10
 
 ## 0. 사람이 먼저 볼 핵심 정책
 
@@ -86,7 +86,7 @@
 - 변경 전·후 값
 - 대상 Google Resource
 - 근거 Evidence
-- 중복·충돌·마감 위험
+- 중복·충돌·Evidence 기반 업무 마감 위험
 - 예상 실행 결과
 
 ### POL-APP-004 승인 무결성
@@ -171,10 +171,17 @@ Task 생성 전에 기존 미완료 Task를 검사한다.
 
 - 제목
 - 메모
-- 기한
+- 예정일
 - 대상 Task List
 
 Task 완료 상태 변경과 Task 삭제는 정확한 Task 대상과 사용자 승인 후 허용한다. Task 삭제는 `DELETE` Effect로 처리하고 실행 후 대상 부재를 재조회해 검증한다.
+
+### POL-TSK-004 날짜·상태 의미와 금지
+
+- Google Task `due`는 제품 내부 `scheduled_date`에만 대응하는 예정일이다. 이를 실제 업무 `business_deadline`으로 표현·판단·검증하지 않는다.
+- Gmail·사용자 요청·Evidence에서 확인한 `business_deadline`을 `scheduled_date` 또는 Google `due`로 자동 변환하지 않는다. Task 생성에서 의미 보존이 필요하면 승인된 notes와 Evidence·Approval Summary를 사용한다.
+- API에 없는 deadline 또는 작업 시간을 추정해 Task Write Argument에 만들지 않는다. 정확한 시간 예약은 승인형 Calendar Event 대안을 사용자에게 제시할 수 있으나 자동 생성하지 않는다.
+- Provider raw status는 UI에 직접 노출하지 않는다. 예정일 경과는 실제 완료 상태를 변경하지 않으며, Task 완료는 정확한 대상·사용자 승인형 `UPDATE`만 허용한다.
 
 ## 9. Calendar 정책
 
@@ -183,7 +190,7 @@ Task 완료 상태 변경과 Task 삭제는 정확한 Task 대상과 사용자 �
 작업 Event 생성에는 다음이 필요하다.
 
 - 예상 소요시간
-- 기한 또는 배치 기준
+- 업무 마감 또는 배치 기준
 - 대상 Calendar
 - 충돌 검사 결과
 
@@ -386,7 +393,7 @@ System Policy, 사용자 요청, Source Context를 Prompt에서 명확히 분리
 
 - expected와 actual을 필드별 비교
 - 공백·줄바꿈·Timezone·초 단위는 정규화 가능
-- 대상, 제목, 본문 의미, 기한, 시작·종료 시간 등 핵심 값 차이는 MISMATCH
+- 대상, 제목, 본문 의미, Task 예정일, Event 시작·종료 시간 등 핵심 값 차이는 MISMATCH다. 실제 업무 마감은 Google Task `due` 비교값으로 대체하지 않는다.
 
 ### POL-VER-003 불일치 처리
 
@@ -520,7 +527,7 @@ Google Workspace API는 사용자 PC의 로컬 MCP Server가 사용자 OAuth Cre
 ### POL-SRC-003 사이드바 목록
 
 - Gmail은 최근 수신 순으로 표시한다.
-- Tasks는 미완료와 기한 임박 항목을 우선 표시한다.
+- Tasks는 미완료와 예정일 임박 항목을 우선 표시한다.
 - Calendar는 현재 이후의 가까운 예정 일정부터 표시한다.
 - 페이지당 10~20개를 조회하며 P0 기본값은 20개다.
 - 다음 페이지 이동 시 새 Page Token으로 Google API를 호출한다.

--- a/docs/01-requirements-prd.md
+++ b/docs/01-requirements-prd.md
@@ -1,8 +1,8 @@
 # 01. Google Work Agent 요구사항 정의서 · PRD
 
-> **문서 기준:** 2026-08-09 R8.4 Claim V2·Attachment 설계 결정을 제품 목표·범위의 기준으로 한다. 문서 간 충돌은 §1.1의 권위·책임 소유 규칙으로 판정하며, PRD가 다른 Concern의 전문 권위 계약을 임의로 덮어쓰지 않는다.
+> **문서 기준:** 2026-08-10 R8.4 Claim V2·Attachment·Task 시간 의미 설계 결정을 제품 목표·범위의 기준으로 한다. 문서 간 충돌은 §1.1의 권위·책임 소유 규칙으로 판정하며, PRD가 다른 Concern의 전문 권위 계약을 임의로 덮어쓰지 않는다.
 >
-> **상태:** Draft v2.7 · **기준일:** 2026-08-09 · **대상:** P0 MVP
+> **상태:** Draft v2.8 · **기준일:** 2026-08-10 · **대상:** P0 MVP
 
 ## 0. 한눈에 보기
 
@@ -79,7 +79,7 @@ Graph Profile의 독립변수는 **Agent Subgraph 분해 수준**이다. `SINGLE
 ## 4. 해결할 문제
 
 1. 메일 요청이 Task로 전환되지 않아 업무가 누락된다.
-2. Task 마감과 Calendar 가용 시간이 별도로 관리되어 실제 수행 가능성을 판단하기 어렵다.
+2. Task 예정일, Gmail·사용자 요청의 업무 마감, Calendar 가용 시간이 분리되어 실제 수행 가능성을 판단하기 어렵다.
 3. 같은 업무가 메일, Task, 일정에 중복 생성된다.
 4. 일정 충돌을 확인하지 않고 회신 Draft나 작업 Event를 만들 수 있다.
 5. 일반 LLM은 사용자가 승인하지 않은 쓰기 동작을 수행하거나 근거 없이 계획을 만들 수 있다.
@@ -90,7 +90,7 @@ Graph Profile의 독립변수는 **Agent Subgraph 분해 수준**이다. `SINGLE
 - 자연어 요청에서 목표와 완료 조건을 추출한다.
 - 요청에 필요한 Gmail·Tasks·Calendar Source를 동적으로 선택한다.
 - Source-native 검색으로 근거를 수집하고 Evidence를 구성한다.
-- 업무 간 관계, 중복, 충돌, 마감 위험을 판단한다.
+- 업무 간 관계, 중복, 충돌, Evidence 기반 업무 마감 위험을 판단한다.
 - 사용자가 검토할 수 있는 Action Plan을 생성한다.
 - 승인된 Action만 MCP Tool로 실행한다.
 - 모든 쓰기 결과를 재조회하여 검증한다.
@@ -142,9 +142,9 @@ Graph Profile의 독립변수는 **Agent Subgraph 분해 수준**이다. `SINGLE
 
 사용자가 회의 또는 후속 메일을 기준으로 해야 할 일을 요청하면 Agent가 관련 Event와 Thread를 연결하고 누락된 Task와 후속 Draft를 제안한다.
 
-### UC-03 이번 주 마감 위험 분석
+### UC-03 이번 주 업무 마감 위험 분석
 
-Agent가 미완료 Task, 관련 메일, Calendar 가용 시간을 분석해 수행 가능·위험·불가능으로 구분하고 재배치 또는 조정 Draft를 제안한다.
+Agent가 미완료 Task의 예정일, 관련 메일·사용자 요청의 실제 업무 마감, Calendar 가용 시간을 구분해 수행 가능·위험·불가능으로 분석하고 재배치 또는 조정 Draft를 제안한다. Google Task의 예정일만으로 실제 업무 마감을 추정하지 않는다.
 
 ### UC-04 읽기 전용 탐색
 
@@ -199,7 +199,7 @@ Agent가 미완료 Task, 관련 메일, Calendar 가용 시간을 분석해 수�
 |---|---|---|
 | FR-030 | Agent는 메일·Task·Event의 관계를 Evidence 기반으로 연결해야 한다. | 각 연결에 근거 Resource가 포함된다. |
 | FR-031 | Agent는 Task 중복과 Calendar 충돌을 검사해야 한다. | 차단 또는 경고 사유가 사용자에게 표시된다. |
-| FR-032 | Agent는 업무 가능성을 가능·위험·불가능으로 분류해야 한다. | 마감, 예상 시간, 가용 Slot 근거를 제시한다. |
+| FR-032 | Agent는 업무 가능성을 가능·위험·불가능으로 분류해야 한다. | 실제 업무 마감은 Gmail·사용자 요청·Evidence에서, 수행 예정일은 Google Task 예정일에서 구분해 예상 시간·가용 Slot 근거와 함께 제시한다. |
 | FR-033 | Agent는 Action을 DAG로 생성해야 한다. | 종속·독립 Action이 구분된다. |
 | FR-034 | Action은 Tool, Arguments, Evidence, Risk, Expected Result를 포함해야 한다. | 승인 화면에서 모든 필드를 검토할 수 있다. |
 
@@ -468,7 +468,7 @@ Domain 상태 전이·SQLite·Command Receipt
 
 ### 19.2 사이드바 목록
 
-- Gmail은 최근 수신 순, Tasks는 미완료·기한 임박 우선, Calendar는 가까운 예정 일정 순으로 표시한다.
+- Gmail은 최근 수신 순, Tasks는 미완료·예정일 임박 우선, Calendar는 가까운 예정 일정 순으로 표시한다.
 - 목록은 페이지당 10~20개를 조회하며 P0 기본값은 20개로 한다.
 - 다음 페이지 이동 시 Google API에서 새 목록을 조회한다.
 - 이미 조회한 페이지는 React Client Session Cache에서 재사용하고 SQLite에는 영구 저장하지 않는다.

--- a/docs/02-ui-ux-design.md
+++ b/docs/02-ui-ux-design.md
@@ -1,6 +1,6 @@
 # 02. Google Work Agent UI · UX 설계서
 
-> **상태:** Draft v2.7 · **기준일:** 2026-08-10 · **대상:** P0 MVP
+> **상태:** Draft v2.8 · **기준일:** 2026-08-10 · **대상:** P0 MVP
 
 > **핵심 UX 원칙:** 사용자는 최소한의 행동으로 최대한의 결과를 얻어야 한다. 사용자가 이미 보고 있는 항목과 작업 흐름 안에서 다음 행동을 수행할 수 있어야 하며, 불필요한 화면 이동·재입력·반복 승인은 UX 실패로 본다.
 
@@ -254,7 +254,7 @@ Gmail·Tasks·Calendar를 확인하는 동시에 현재 항목에서 바로 Agen
 
 - `일정 제안`
 - `관련 메일 찾기`
-- `마감 위험 확인`
+- `관련 마감 확인`
 - `채팅에 추가`
 
 #### Calendar Card Action
@@ -278,7 +278,7 @@ Gmail·Tasks·Calendar를 확인하는 동시에 현재 항목에서 바로 Agen
 ### 9.5 Source별 기본 정렬
 
 - Gmail: 최근 수신 메일부터 표시
-- Tasks: 미완료 우선, 기한 임박 순, 기한 없는 Task 순
+- Tasks: 미완료 우선, 예정일 임박 순, 예정일 없는 Task 순
 - Calendar: 현재 이후의 가장 가까운 일정부터 표시
 - 과거 Calendar 조회에서는 최근 과거 일정부터 표시
 
@@ -517,7 +517,7 @@ Gmail 2개 · Tasks 1개 · Calendar 3개
 수정 가능한 필드:
 
 - Gmail Draft: 수신자, CC, 제목, 본문
-- Task: 제목, 메모, 기한, Task List
+- Task: 제목, 메모, 예정일, Task List
 - Calendar Event: 제목, 시작, 종료, 설명, Calendar
 
 ## 16. 실행과 검증 UX
@@ -806,7 +806,7 @@ Right:  Conversation (새 대화·검색·목록) → Recent Execution
 - 탭은 메일, Tasks, Calendar이며 검색/필터와 수동 새로고침을 제공한다. 목록은 compact row, selected/hover/focus/disabled 상태와 키보드 탐색을 제공한다.
 - 기본 UI page size는 10이다. Page Token 기반 API를 React Session Memory의 page number mapping으로 연결해 숫자 페이지를 제공한다. Agent Retrieval 20과 혼용하지 않는다.
 - count badge는 서버 Projection이 실제 count를 제공할 때만 표시한다. Frontend 전체 페이지 순회·hard code count는 금지한다.
-- 행을 선택하면 Center 상단 Viewer에 제공 가능한 Resource 상세를 표시한다. Gmail sender/recipient/subject/received time/body/attachment metadata, Task title/status/due/list/notes, Calendar title/start/end/attendees/location/description/calendar는 제공된 필드만 표시한다. 누락값의 추정·생성은 금지한다.
+- 행을 선택하면 Center 상단 Viewer에 제공 가능한 Resource 상세를 표시한다. Gmail sender/recipient/subject/received time/body/attachment metadata, Task title/task_status/scheduled_date/list/notes, Calendar title/start/end/attendees/location/description/calendar는 제공된 필드만 표시한다. 누락값의 추정·생성은 금지한다.
 - Focus Resource와 다중 선택 Resource 집합을 분리한다. Focus는 Viewer용이며 다중 선택은 기존 Agent Context 기능을 보존한다.
 
 ### 29.3 Center Conversation과 Approval
@@ -843,9 +843,12 @@ Right:  Conversation (새 대화·검색·목록) → Recent Execution
 
 ### 30.2 Tasks Sidebar
 
-- Tasks는 실제 Google Workspace Source이며 기본 compact row는 **Task 제목 → 기한** 순서다. 제목, 메모, 기한, Task List, 완료 상태 중 실제 Projection이 제공한 값만 사용한다.
+- Tasks는 실제 Google Workspace Source이며 기본 compact row는 **Task 제목 → 예정일** 순서다. 제목, 메모, 예정일, Task List, 완료 상태 중 실제 Projection이 제공한 값만 사용한다.
 - Task List는 실제 반환 값일 때만 보조로 표시할 수 있으며, priority, 가짜 category·Task List 이름·색상 dot는 표시하지 않는다.
-- 목록 정렬은 미완료·기한 임박 우선의 기존 계약을 유지한다.
+- 목록 정렬은 미완료·예정일 임박 우선의 기존 계약을 유지한다.
+- Local API Projection은 Provider `needsAction`을 `미완료`, `completed`를 `완료`로 정규화한다. raw enum과 RFC3339 raw `due`는 UI에 노출하지 않는다.
+- Google `due`는 UI에서 `예정일`로만 표시한다. 예정일이 없으면 날짜 영역을 비우거나 생략하며, API에 없는 작업 시간·업무 마감일을 생성하지 않는다.
+- 미완료 Task의 예정일이 지났을 때만 보조 문구 `예정일 지남`을 표시할 수 있다. 이는 상태를 완료로 바꾸지 않으며 `기한 초과`·`마감 초과`로 표현하지 않는다. Provider가 제공한 완료 날짜는 `완료일`로 표시할 수 있다.
 
 ### 30.3 Resource Viewer Empty State
 

--- a/docs/05-context-retrieval.md
+++ b/docs/05-context-retrieval.md
@@ -1,6 +1,6 @@
 # 05. Google Work Agent · Context · Retrieval 설계서
 
-> **상태:** Draft v2.5 · **기준일:** 2026-08-09 · **대상:** P0 MVP
+> **상태:** Draft v2.6 · **기준일:** 2026-08-10 · **대상:** P0 MVP
 >
 > API 탐색·수집 Agent와 Context Retriever Agent를 분리한다. Google 원본을 요청 시점에 검색하고 Metadata로 후보를 줄인 뒤 필요한 상세만 읽는다.
 
@@ -129,8 +129,14 @@ class ContextRetrievalResult:
 ## 8. Source 전략
 
 - Gmail: Thread 검색 → 참여자·제목·시각·Snippet 필터 → 상위 Thread 상세 → Message 시간순 정리
-- Tasks: Task List 결정 → 미완료 목록 → 기한·상태·Keyword 필터 → 필요한 상세
+- Tasks: Task List 결정 → 미완료 목록 → 예정일·상태·Keyword 필터 → 필요한 상세
 - Calendar: Calendar 결정 → 기간 Event 목록 → 필요한 상세 → 필요할 때 FreeBusy 1회
+
+### Tasks 시간 의미
+
+- Google Task `due`는 Retrieval·WorkItem에서 `scheduled_date`로 정규화한다. 날짜만 후보·정렬·필터에 사용하며 시간 정보를 추론하지 않는다.
+- 실제 업무 `business_deadline`은 Gmail·사용자 요청·Evidence에서 확인한 경우에만 별도 Evidence로 사용한다. Task `due`를 업무 마감 Evidence로 승격하거나 둘을 자동 동일시하지 않는다.
+- 예정일 경과는 Provider 완료 상태의 근거가 아니다. 완료 여부는 실제 Task status에서만 가져온다.
 
 ## 9. 후보 점수 초기값
 

--- a/docs/06-agent-workflow.md
+++ b/docs/06-agent-workflow.md
@@ -1,8 +1,8 @@
 # 06. Google Work Agent · Agent · Workflow 설계서
 
-> **문서 기준:** `01 PRD v2.7`, `01-A v2.6`, `01-B v2.7`, `02 UI·UX v2.4`, `03 Architecture v3.0`, `04 Database v1.12`, `05 Retrieval v2.5`, `07 Interface v2.8`, Domain 상태 전이 계약 v1.4와 테스트 매트릭스 v1.4을 기준으로 한다.
+> **문서 기준:** `01 PRD v2.8`, `01-A v2.9`, `01-B v2.8`, `02 UI·UX v2.8`, `03 Architecture v3.0`, `04 Database v1.12`, `05 Retrieval v2.6`, `07 Interface v3.0`, Domain 상태 전이 계약 v1.4와 테스트 매트릭스 v1.4을 기준으로 한다.
 >
-> **상태:** Draft v6.0 · **DB Schema:** v1.4 · **대상:** P0 MVP
+> **상태:** Draft v6.1 · **DB Schema:** v1.4 · **대상:** P0 MVP
 >
 > 결정적 Supervisor + 최대 6개 전문 Agent Subgraph Baseline + 결정적 실행·검증 Engine을 사용한다. 각 Agent Subgraph는 invocation 범위 Local State와 bounded validation·repair/revision loop를 가지며 Typed Result만 Main Graph에 반환한다. Agent별 장기 Memory는 없고 승인·실행·검증 사실은 SQLite Domain Store가 소유한다.
 
@@ -132,7 +132,14 @@ class AgentLocalState:
 | 실행 Engine | 승인 인자 Claim·MCP Write | LLM 재계획 |
 | 검증·복구 | Google GET·Comparator·Recovery | LLM 성공 판정 |
 
-## 2.1 전문 Agent Subgraph 설계
+### 2.1 Tasks 시간 의미
+
+- Request Understanding은 `~까지`를 실제 업무 `business_deadline` 후보로, `~에 하다`를 Task `scheduled_date` 후보로 구분해 구조화한다. 이는 문자열 규칙을 하드코딩하는 요구가 아니라 RequestIntent·Analysis·Planning의 의미 계약이다.
+- 두 값이 함께 있으면 자동으로 같게 만들지 않는다. 업무 마감만 확인되면 Task 예정일이나 Google `due`를 생성하지 않으며, 필요한 의미 보존은 notes·Evidence·Approval Summary에 제안한다.
+- 정확한 시간 구간이 필요한 요청은 Tasks API가 시간을 설정했다고 성공 선언하지 않는다. Planning은 날짜 예정일 또는 승인형 Calendar Event 대안을 제시하고, Event 생성은 별도 Action·Approval을 따른다.
+- Work Analysis는 예정일 경과를 완료로 해석하지 않는다. 완료 상태는 실제 Provider status이며 Policy·Domain·Verification이 최종 판정한다.
+
+## 2.2 전문 Agent Subgraph 설계
 
 | Agent Subgraph | 핵심 내부 Node | Local Loop | Parent 반환 |
 |---|---|---|---|

--- a/docs/07-tool-mcp-internal-interface.md
+++ b/docs/07-tool-mcp-internal-interface.md
@@ -1,10 +1,10 @@
 # 07. Google Work Agent · Tool · MCP · 내부 인터페이스 명세서
 
-> **문서 기준:** `01`~`06`의 React + FastAPI Local Agent Service 구조와 `06. Agent·Workflow 설계서 Draft v6.0`을 기준으로 한다. 외부 공개 API가 아니라 설치된 앱 내부의 Local API, MCP Tool, Python 내부 인터페이스 계약을 정의한다.
+> **문서 기준:** `01`~`06`의 React + FastAPI Local Agent Service 구조와 `06. Agent·Workflow 설계서 Draft v6.1`을 기준으로 한다. 외부 공개 API가 아니라 설치된 앱 내부의 Local API, MCP Tool, Python 내부 인터페이스 계약을 정의한다.
 
 ## 0. 문서 정보
 
-- **상태:** Draft v2.9
+- **상태:** Draft v2.10
 - **기준일:** 2026-08-10
 - **대상:** P0 MVP
 - **배포 형태:** Windows 설치 파일 기반 로컬 애플리케이션
@@ -259,6 +259,8 @@ tasks_delete_task
 ```
 
 `tasks_update_task`는 승인된 완료 상태 변경을 지원한다. `tasks_delete_task`는 정확한 Task ID를 대상으로 하는 승인형 `DELETE`이며 Claim V2 검증 후 실행하고 `GET_ABSENT`로 대상 부재를 검증한다.
+
+Google Tasks Adapter의 raw `due`는 제품 내부 `scheduled_date`의 Provider 매핑값이다. 현재 Tool Schema의 `due?` 표기는 Google API 경계의 raw argument이며, Local API·Application·UI Projection은 `scheduled_date`와 정규화된 `task_status`를 소비하도록 후속 구현에서 정합해야 한다. `business_deadline`은 Google Task Write의 구조화 Argument가 아니며 `due`로 자동 매핑하지 않는다. Task 시간 구간도 현재 Tool 계약의 필드가 아니다.
 
 ## 9. Calendar Tool
 
@@ -708,6 +710,7 @@ metadata
 - 모든 ID·Page Token은 길이 1..2048, 제어문자 금지.
 - 날짜·시간은 RFC3339와 명시 Timezone을 사용한다.
 - Write Tool의 `claim context`는 Action·Approval·Attempt·Hash·Token을 포함한다.
+- `tasks_create_task`의 raw `due?`는 Google Adapter 경계에서만 `scheduled_date`와 대응한다. `business_deadline`·작업 시간은 새 Task Tool Argument로 추가하지 않으며, 업무 마감 의미 보존은 승인된 `notes`와 Evidence·Approval Projection을 따른다.
 
 ## 28. Verification·Recovery 계약
 - CREATE·UPDATE: GET_COMPARE.

--- a/docs/08-sequence-design.md
+++ b/docs/08-sequence-design.md
@@ -1,8 +1,8 @@
 # 08. Google Work Agent · 시퀀스 설계서
 
-> **문서 기준:** `01. 요구사항 정의서·PRD v2.7`, `01-A. 기능 정의서 v2.7`, `01-B. 정책 정의서 v2.7`, `02. UI·UX 설계서 v2.5`, `03. 시스템 아키텍처 설계서 v3.0`, `04. 도메인·데이터베이스 설계서 Draft v1.12`, `05. Context·Retrieval 설계서 Draft v2.5`, `06. Agent·Workflow 설계서 Draft v6.0`, `07. Tool·MCP·내부 인터페이스 명세서 Draft v2.8`, Domain 상태 전이 계약 v1.4를 기준으로 한다. `09~14`는 본 문서의 시퀀스를 보안·인프라·관측·테스트·평가·운영 절차로 구체화한다.
+> **문서 기준:** `01. 요구사항 정의서·PRD v2.8`, `01-A. 기능 정의서 v2.9`, `01-B. 정책 정의서 v2.8`, `02. UI·UX 설계서 v2.8`, `03. 시스템 아키텍처 설계서 v3.0`, `04. 도메인·데이터베이스 설계서 Draft v1.12`, `05. Context·Retrieval 설계서 Draft v2.6`, `06. Agent·Workflow 설계서 Draft v6.1`, `07. Tool·MCP·내부 인터페이스 명세서 Draft v3.0`, Domain 상태 전이 계약 v1.4를 기준으로 한다. `09~14`는 본 문서의 시퀀스를 보안·인프라·관측·테스트·평가·운영 절차로 구체화한다.
 
-> **상태:** Draft v3.1 · **기준일:** 2026-08-09  
+> **상태:** Draft v3.2 · **기준일:** 2026-08-10
 > **대상:** P0 MVP  
 > **구조:** 결정적 Supervisor + 1/3/6 Agent Subgraph Profile + 결정적 실행·검증 Engine  
 > **상태 기준:** SQLite Domain Store가 승인·실행·검증 사실의 기준점이며 LangGraph Checkpoint는 재개 위치, SSE는 UI Projection이다.
@@ -464,6 +464,29 @@ sequenceDiagram
 ```
 
 외부 Write와 GET 수행 중 DB Transaction을 유지하지 않는다.
+
+### 11.1 Google Task 날짜·시간 의미
+
+```text
+Gmail·사용자 요청에서 업무 마감만 확인
+→ Request Understanding: business_deadline 후보
+→ Task scheduled_date 없음
+→ Plan: notes·Evidence·Approval Summary에 업무 마감 보존 제안
+→ 사용자 Approval
+→ tasks_create_task(due 없음)
+→ GET Verification: 제목·notes·예정일 부재 비교
+
+사용자가 수행 예정일도 명시
+→ Request Understanding: scheduled_date 후보
+→ 승인된 tasks_create_task(due = scheduled_date)
+→ GET Verification: 예정일 비교
+
+정확한 시간 구간 요청
+→ Tasks 시간 설정 성공 선언 금지
+→ 날짜 예정일 또는 별도 승인형 Calendar Event 대안 제시
+```
+
+Provider `needsAction`·`completed`는 Local API Projection에서 사용자 상태 `미완료`·`완료`로 정규화한다. 예정일 경과는 상태 전이나 자동 완료 시퀀스를 만들지 않는다.
 
 ## 12. 일부 승인과 Action DAG
 

--- a/docs/12-test-design.md
+++ b/docs/12-test-design.md
@@ -1,8 +1,8 @@
 # 12. Google Work Agent · 테스트 설계서
 
-> **문서 기준:** `01 PRD v2.7`, `01-A v2.8`, `01-B v2.7`, `02 UI·UX v2.7`, `03 Architecture v3.0`, `04 Database v1.12`, `05 Retrieval v2.5`, `06 Workflow v6.0`, `07 Interface v2.9`, `08 Sequence v3.1`, `09 Security v2.5`, `10 Infrastructure v2.7`, `11 Observability v2.9`, `15 Agent Capability·Failure·Prompt v1.5`, Domain 상태 전이 계약 v1.4와 테스트 매트릭스 v1.4을 기준으로 한다.
+> **문서 기준:** `01 PRD v2.8`, `01-A v2.9`, `01-B v2.8`, `02 UI·UX v2.8`, `03 Architecture v3.0`, `04 Database v1.12`, `05 Retrieval v2.6`, `06 Workflow v6.1`, `07 Interface v3.0`, `08 Sequence v3.2`, `09 Security v2.5`, `10 Infrastructure v2.7`, `11 Observability v2.9`, `15 Agent Capability·Failure·Prompt v1.5`, Domain 상태 전이 계약 v1.4와 테스트 매트릭스 v1.4을 기준으로 한다.
 >
-> **상태:** Draft v3.4 · **기준일:** 2026-08-10 · **OS:** Windows 11 x64 · **Browser:** Chrome·Edge
+> **상태:** Draft v3.5 · **기준일:** 2026-08-10 · **OS:** Windows 11 x64 · **Browser:** Chrome·Edge
 
 ## 1. 목적과 계층
 
@@ -85,7 +85,7 @@ DeterministicGrader
 필수 경계:
 
 - Gmail 긴 Thread·외부 주소·Prompt Injection
-- Task 중복·유사·기한 없음·기한 임박
+- Task 중복·유사·예정일 없음·예정일 임박·업무 마감 분리
 - Calendar Busy·Tentative·Free·OOO·Focus·DST
 - Write 정상·정규화 차이·Mismatch
 - 401·403·404·409·429·5xx·Timeout·응답 유실
@@ -457,8 +457,18 @@ REVIEW_RECHECK_PER_PLANNING_REVISION=1
 
 - Calendar Sidebar는 실제 Event 제목과 같은 날/날짜가 다른 시간 범위, All-day 형식을 검증한다. 같은 날 시간 Event에는 연도·월·일·요일·시작/종료 시간이 있고 `시작`·`종료` label은 없으며, All-day Event에는 연도·월·일·요일과 `하루 종일`이 있다.
 - Calendar 중앙 Viewer에는 실제 Projection의 `시작`, `종료` 필드가 남아 있음을 검증한다.
-- Tasks Sidebar는 실제 Google Task Projection의 제목·기한을 렌더링하고, Projection에 없는 priority·category·가짜 Task List를 표시하지 않음을 검증한다.
+- Tasks Sidebar는 실제 Google Task Projection의 제목·예정일을 렌더링하고, Projection에 없는 priority·category·가짜 Task List를 표시하지 않음을 검증한다.
 - Viewer Empty State는 Gmail·Tasks·Calendar 각각의 안내 문구를 검증하며, Source 전환 뒤 이전 Source 상세가 남지 않음을 검증한다.
+
+### Google Tasks 날짜·상태 의미 회귀
+
+1. Provider `needsAction`은 UI `미완료`, `completed`는 UI `완료`이며 raw enum 노출은 0이다.
+2. `due=2026-08-11T00:00:00Z`는 `scheduled_date=2026-08-11` 및 사용자 UI `예정일`로 정규화한다. raw timestamp와 `마감일` 표현은 0이다.
+3. 미완료 Task의 예정일이 지나도 Provider·Domain 완료 상태는 변하지 않으며 UI 보조 문구 `예정일 지남`만 허용한다.
+4. 메일의 `8월 12일까지 제출` + Task 생성 요청은 `business_deadline=8/12`, `scheduled_date` 없음, Google `due` 자동 생성 0을 검증한다. 업무 마감 보존이 필요하면 승인된 notes·Evidence·Approval Projection을 검증한다.
+5. `8월 11일에 처리`는 `scheduled_date=8/11`, Google `due=8/11`을 검증한다. `11일에 처리하고 12일까지 제출`은 두 값을 분리해 검증한다.
+6. 시간대 지정 요청에서 Tasks API가 정확한 시간 구간을 설정했다고 성공 선언하는 경우는 0이다. Calendar Event 대안은 별도 승인형 Write인지 검증한다.
+7. Task 완료 상태 변경은 정확한 대상·승인형 `UPDATE`이며 예정일 경과로 자동 완료되지 않음을 검증한다.
 
 ### UI Fixture 원칙
 

--- a/docs/13-evaluation-experiment.md
+++ b/docs/13-evaluation-experiment.md
@@ -1,8 +1,8 @@
 # 13. Google Work Agent · 평가 · 실험 설계서
 
-> **문서 기준:** `01 PRD v2.7`, `01-A v2.6`, `01-B v2.7`, `03 Architecture v3.0`, `05 Retrieval v2.5`, `06 Workflow v6.0`, `07 Interface v2.8`, `10 Infrastructure v2.7`, `11 Observability v2.9`, `12 Test v3.1`, `15 Agent Capability·Failure·Prompt v1.5`를 기준으로 한다.
+> **문서 기준:** `01 PRD v2.8`, `01-A v2.9`, `01-B v2.8`, `03 Architecture v3.0`, `05 Retrieval v2.6`, `06 Workflow v6.1`, `07 Interface v3.0`, `10 Infrastructure v2.7`, `11 Observability v2.9`, `12 Test v3.5`, `15 Agent Capability·Failure·Prompt v1.5`를 기준으로 한다.
 >
-> **상태:** Draft v3.1 · **기준일:** 2026-08-09 · **선행 Gate:** Dataset·Grader Integrity + 12 Safety Regression 100%
+> **상태:** Draft v3.2 · **기준일:** 2026-08-10 · **선행 Gate:** Dataset·Grader Integrity + 12 Safety Regression 100%
 
 ## 먼저 읽기 — 이 문서가 결정하는 것
 
@@ -620,6 +620,7 @@ DELETE -> GET_ABSENT  / GET_TARGET
 - Required와 Forbidden·Hard Negative가 겹치지 않게 자동 검사한다.
 - Source 본문에는 평가 라벨·정답 유도 문구·정책 설명을 넣지 않는다.
 - 실제 업무 요청에서 사용자가 명시한 값과 Fixture에서 확인해야 할 값을 구분한다. 사용자 명시값을 다시 “확인받아야 할 모호성”으로 만들지 않는다.
+- Google Task 평가에서 `scheduled_date`와 `business_deadline`을 분리한다. 기존 Dataset·Gold가 Task `due`를 deadline으로 표기·채점한다면 즉시 수정하지 않고 Dataset Issue로 기록해 Migration/Gold regeneration 후 새 Dataset Version으로 승격한다. 올바르게 예정일로 판단한 후보를 기존 deadline Gold로 실패 처리하지 않는다.
 
 ## 9. G00 Dataset·Grader Integrity
 


### PR DESCRIPTION
## 변경 목적

Google Tasks API의 `due`를 기존 문서 일부에서 `기한/마감일`처럼
해석하던 계약을 실제 Provider 의미에 맞게 정리합니다.

## 주요 변경

- `due` → `scheduled_date(예정일)` 의미로 정리
- `business_deadline`과 `scheduled_date` 분리
- `business_deadline → due` 자동 변환 금지
- `needsAction → 미완료`
- `completed → 완료`
- 예정일 경과는 상태 변경이 아니라 `예정일 지남` 보조 표시
- API가 제공하지 않는 Task 시간/deadline 추론 금지
- UI / Retrieval / Workflow / MCP / Sequence / Test / Evaluation 계약 동기화
- Interface v2.10 / Workflow v6.1 참조 정합성 수정

## 범위

문서 계약만 수정했습니다.

이번 PR에 포함하지 않음:
- Backend/MCP 구현
- Frontend 구현
- 테스트 코드
- Evaluation Dataset/Gold
- DB Migration

## 검증

- `git diff --check` PASS
- `origin/main...HEAD` 기준 docs 11개만 포함