### PR TITLE
Wave 1C: canonical FailureRecord and provider dispatch accounting

### DIFF
--- a/src/google_work_agent/adapters/langgraph/agent_kernel.py
+++ b/src/google_work_agent/adapters/langgraph/agent_kernel.py
@@ -11,7 +11,10 @@ from google_work_agent.application.workflows import (
     PromptRef,
     RunBudgetV1,
     check_llm_call_budget,
-    consume_llm_provider_calls,
+)
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    bind_provider_dispatch_budget,
+    merge_provider_dispatch_usage,
 )
 from google_work_agent.ports import (
     LLMErrorCode,
@@ -124,16 +127,13 @@ def ensure_llm_call_budget(
     *,
     provider_calls_requested: int = 1,
 ) -> None:
-    """Deterministic Run-level LLM budget gate (RunBudgetV1), checked
-    immediately before every real Provider call that any native subgraph
-    node issues -- INITIAL, SCHEMA_REPAIR (bundled into one node call's
-    attempt count), SEMANTIC_REVISION, retrieval follow-up, planning
-    revision, review recheck.
+    """Preflight the RunBudget and bind it to the real dispatch boundary.
 
-    Denial raises before the node calls its Agent, so zero Provider calls
-    happen: the same terminal-failure path
-    (``application/coordinator.py``'s catch-all -> ``RunStatus.FAILED``)
-    already used for any other real ``LLMInvocationError``.
+    ``provider_calls_requested`` remains a conservative node-level precheck
+    (useful for multi-route Planning), but actual consumption is performed by
+    ``PromptInputGuardedProvider`` immediately before every real provider
+    dispatch. This binding is ContextVar-scoped, so concurrent graph tasks do
+    not share budget authorities.
     """
     retry_budget = cast(RunBudgetV1, state["retry_budget"])
     decision = check_llm_call_budget(
@@ -145,6 +145,7 @@ def ensure_llm_call_budget(
             f"run LLM call budget exhausted: {decision['budget_reason_code']}",
             retryable=False,
         )
+    bind_provider_dispatch_budget(retry_budget)
 
 
 def consume_llm_call_budget(
@@ -152,17 +153,16 @@ def consume_llm_call_budget(
     *,
     provider_calls_consumed: int = 1,
 ) -> RunBudgetV1:
-    """Authoritative post-call accounting: increments ``retry_budget``'s
-    ``llm_calls_used`` by the number of real Provider calls the just-completed
-    node invocation actually made (``StructuredLLMResult.provider_calls_consumed``
-    for that invocation -- 1 normally, 2 when a SCHEMA_REPAIR attempt fired).
-    Callers must fold the returned ``RunBudgetV1`` into their node's
-    ``retry_budget`` state update so it survives the LangGraph checkpoint.
+    """Checkpoint the usage already consumed at provider dispatch.
+
+    ``provider_calls_consumed`` is retained only for source compatibility with
+    older node callers and is intentionally *not* an accounting authority.
+    Successful ``StructuredLLMResult`` metadata can no longer increment the
+    durable budget; it merely remains available for trace/latency reporting.
     """
+    del provider_calls_consumed
     retry_budget = cast(RunBudgetV1, state["retry_budget"])
-    return consume_llm_provider_calls(
-        retry_budget, provider_calls_consumed=provider_calls_consumed
-    )
+    return merge_provider_dispatch_usage(retry_budget)
 
 
 def _counter_value(item: dict[str, object], field: str) -> int:

--- a/src/google_work_agent/adapters/langgraph/invocation.py
+++ b/src/google_work_agent/adapters/langgraph/invocation.py
@@ -9,6 +9,9 @@ from langgraph.types import Command
 
 from google_work_agent.adapters.langgraph.graph_state import GraphState
 from google_work_agent.adapters.langgraph.profiles import GraphProfile
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    provider_dispatch_execution_scope,
+)
 from google_work_agent.domain import RunStatus
 from google_work_agent.ports import (
     WorkflowCancelRequest,
@@ -53,60 +56,62 @@ class WorkflowInvocationCoordinator:
         self._cancel_signals = cancel_signals
 
     def start(self, request: WorkflowStartRequest) -> WorkflowInvocationResult:
-        config = self.config_for_thread(request.workflow_key)
-        self._graph.invoke(self._initial_state(request), config=config)
-        return self.result_from_thread(
-            workflow_key=request.workflow_key,
-            run_id=request.run_id,
-        )
+        with provider_dispatch_execution_scope():
+            config = self.config_for_thread(request.workflow_key)
+            self._graph.invoke(self._initial_state(request), config=config)
+            return self.result_from_thread(
+                workflow_key=request.workflow_key,
+                run_id=request.run_id,
+            )
 
     def resume(self, request: WorkflowResumeRequest) -> WorkflowInvocationResult:
-        config = self.config_for_thread(request.workflow_key)
-        snapshot = self._graph.get_state(config)
-        if not snapshot.values and not snapshot.next:
-            return WorkflowInvocationResult(
+        with provider_dispatch_execution_scope():
+            config = self.config_for_thread(request.workflow_key)
+            snapshot = self._graph.get_state(config)
+            if not snapshot.values and not snapshot.next:
+                return WorkflowInvocationResult(
+                    run_id=request.run_id,
+                    workflow_key=request.workflow_key,
+                    outcome=WorkflowOutcome.CHECKPOINT_MISSING,
+                    payload={},
+                )
+            if not self.is_profile_compatible(cast(GraphState, snapshot.values)):
+                return WorkflowInvocationResult(
+                    run_id=request.run_id,
+                    workflow_key=request.workflow_key,
+                    outcome=WorkflowOutcome.DOMAIN_CHECKPOINT_CONFLICT,
+                    payload={"graph_profile": self._graph_profile.value},
+                )
+            if snapshot.next:
+                # A real interrupt() is pending (e.g. WAITING_CONFIRMATION,
+                # PREFLIGHT_REAPPROVAL_REQUIRED) -- Command(resume=...) is the
+                # correct way to feed the user's response back into it.
+                self._graph.invoke(Command(resume=request.resume_payload), config=config)
+                return self.result_from_thread(
+                    workflow_key=request.workflow_key,
+                    run_id=request.run_id,
+                )
+            # No pending interrupt: the prior invocation already reached END via
+            # a normal conditional edge (e.g. REAUTH_REQUIRED, RECOVERY_REQUIRED
+            # ending the graph without ever calling interrupt()).
+            # Command(resume=...) is a no-op against a thread with no pending
+            # task, so this resume must instead continue from persisted Domain
+            # facts -- the same mechanism recover_open_run already uses.
+            state = self._continue_from_domain_facts(
+                values=cast(GraphState, snapshot.values),
                 run_id=request.run_id,
-                workflow_key=request.workflow_key,
-                outcome=WorkflowOutcome.CHECKPOINT_MISSING,
-                payload={},
+                allow_reauth_resume=request.resume_kind == "REAUTH_COMPLETED",
             )
-        if not self.is_profile_compatible(cast(GraphState, snapshot.values)):
-            return WorkflowInvocationResult(
-                run_id=request.run_id,
-                workflow_key=request.workflow_key,
-                outcome=WorkflowOutcome.DOMAIN_CHECKPOINT_CONFLICT,
-                payload={"graph_profile": self._graph_profile.value},
-            )
-        if snapshot.next:
-            # A real interrupt() is pending (e.g. WAITING_CONFIRMATION,
-            # PREFLIGHT_REAPPROVAL_REQUIRED) -- Command(resume=...) is the
-            # correct way to feed the user's response back into it.
-            self._graph.invoke(Command(resume=request.resume_payload), config=config)
-            return self.result_from_thread(
+            if state is None:
+                return self.result_from_thread(
+                    workflow_key=request.workflow_key,
+                    run_id=request.run_id,
+                )
+            return self.workflow_result_from_state(
+                state=state,
                 workflow_key=request.workflow_key,
                 run_id=request.run_id,
             )
-        # No pending interrupt: the prior invocation already reached END via
-        # a normal conditional edge (e.g. REAUTH_REQUIRED, RECOVERY_REQUIRED
-        # ending the graph without ever calling interrupt()).
-        # Command(resume=...) is a no-op against a thread with no pending
-        # task, so this resume must instead continue from persisted Domain
-        # facts -- the same mechanism recover_open_run already uses.
-        state = self._continue_from_domain_facts(
-            values=cast(GraphState, snapshot.values),
-            run_id=request.run_id,
-            allow_reauth_resume=request.resume_kind == "REAUTH_COMPLETED",
-        )
-        if state is None:
-            return self.result_from_thread(
-                workflow_key=request.workflow_key,
-                run_id=request.run_id,
-            )
-        return self.workflow_result_from_state(
-            state=state,
-            workflow_key=request.workflow_key,
-            run_id=request.run_id,
-        )
 
     def request_cancel(self, request: WorkflowCancelRequest) -> WorkflowInvocationResult:
         with self._cancel_signal_lock:
@@ -119,37 +124,38 @@ class WorkflowInvocationCoordinator:
         )
 
     def recover_open_run(self, request: WorkflowRecoveryRequest) -> WorkflowInvocationResult:
-        config = self.config_for_thread(request.workflow_key)
-        snapshot = self._graph.get_state(config)
-        if not snapshot.values and not snapshot.next:
-            return WorkflowInvocationResult(
+        with provider_dispatch_execution_scope():
+            config = self.config_for_thread(request.workflow_key)
+            snapshot = self._graph.get_state(config)
+            if not snapshot.values and not snapshot.next:
+                return WorkflowInvocationResult(
+                    run_id=request.run_id,
+                    workflow_key=request.workflow_key,
+                    outcome=WorkflowOutcome.CHECKPOINT_MISSING,
+                    payload={},
+                )
+            if not self.is_profile_compatible(cast(GraphState, snapshot.values)):
+                return WorkflowInvocationResult(
+                    run_id=request.run_id,
+                    workflow_key=request.workflow_key,
+                    outcome=WorkflowOutcome.DOMAIN_CHECKPOINT_CONFLICT,
+                    payload={"graph_profile": self._graph_profile.value},
+                )
+            state = self._continue_from_domain_facts(
+                values=cast(GraphState, snapshot.values),
                 run_id=request.run_id,
-                workflow_key=request.workflow_key,
-                outcome=WorkflowOutcome.CHECKPOINT_MISSING,
-                payload={},
+                allow_reauth_resume=False,
             )
-        if not self.is_profile_compatible(cast(GraphState, snapshot.values)):
-            return WorkflowInvocationResult(
-                run_id=request.run_id,
-                workflow_key=request.workflow_key,
-                outcome=WorkflowOutcome.DOMAIN_CHECKPOINT_CONFLICT,
-                payload={"graph_profile": self._graph_profile.value},
-            )
-        state = self._continue_from_domain_facts(
-            values=cast(GraphState, snapshot.values),
-            run_id=request.run_id,
-            allow_reauth_resume=False,
-        )
-        if state is None:
-            return self.result_from_thread(
+            if state is None:
+                return self.result_from_thread(
+                    workflow_key=request.workflow_key,
+                    run_id=request.run_id,
+                )
+            return self.workflow_result_from_state(
+                state=state,
                 workflow_key=request.workflow_key,
                 run_id=request.run_id,
             )
-        return self.workflow_result_from_state(
-            state=state,
-            workflow_key=request.workflow_key,
-            run_id=request.run_id,
-        )
 
     def _continue_from_domain_facts(
         self,

--- a/src/google_work_agent/adapters/llm/prompt_input_guard.py
+++ b/src/google_work_agent/adapters/llm/prompt_input_guard.py
@@ -6,9 +6,16 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+from google_work_agent.application.workflows.failure_record import (
+    FAILURE_RECORD_FIELDS,
+    build_failure_record_v1,
+)
 from google_work_agent.application.workflows.prompt_input_contract import (
     PromptInputContractError,
     PromptRuntimeInputContractValidator,
+)
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    account_provider_dispatch,
 )
 from google_work_agent.ports import (
     ActualRuntime,
@@ -62,11 +69,13 @@ class _RuntimeToolCallingProvider(_ToolCallingProvider, Protocol):
 
 @dataclass(frozen=True, slots=True)
 class PromptInputGuardedProvider:
-    """Validate the exact projection immediately before every provider call.
+    """Validate exact Product Prompt input and account the real dispatch.
 
-    The same decorated provider instance is passed to schema-repair code, so
-    repair/revision calls are checked against their own registered PromptRef
-    as well; there is no alternate unvalidated repair dispatch path.
+    The same decorated provider instance is passed to schema/tool-call repair
+    code, so primary, fallback, repair, tool-call, and tool-call-repair all
+    cross this one boundary. ``account_provider_dispatch`` runs after local
+    validation but immediately before the delegate invocation; a provider
+    timeout/error therefore still consumes exactly one RunBudget call.
     """
 
     delegate: _StructuredProvider
@@ -89,10 +98,12 @@ class PromptInputGuardedProvider:
         runtime_policy: RuntimePolicy,
         api_key: str | None,
     ) -> ProviderResponsePayload:
-        self._validate(prompt_ref=prompt_ref, prompt_input=prompt_input)
+        normalized_input = _canonical_prompt_input(prompt_input)
+        self._validate(prompt_ref=prompt_ref, prompt_input=normalized_input)
+        account_provider_dispatch()
         return self.delegate.invoke_structured(
             prompt_ref=prompt_ref,
-            prompt_input=prompt_input,
+            prompt_input=normalized_input,
             output_schema=output_schema,
             runtime_policy=runtime_policy,
             api_key=api_key,
@@ -107,16 +118,18 @@ class PromptInputGuardedProvider:
         runtime_policy: RuntimePolicy,
         api_key: str | None,
     ) -> ToolCallProviderResponse:
-        self._validate(prompt_ref=prompt_ref, prompt_input=prompt_input)
+        normalized_input = _canonical_prompt_input(prompt_input)
+        self._validate(prompt_ref=prompt_ref, prompt_input=normalized_input)
         delegate = self.delegate
         if not isinstance(delegate, _RuntimeToolCallingProvider):
             raise LLMInvocationError(
                 LLMErrorCode.RUNTIME_MODE_BLOCKED,
                 "selected provider does not support native tool calling",
             )
+        account_provider_dispatch()
         return delegate.invoke_tool_call(
             prompt_ref=prompt_ref,
-            prompt_input=prompt_input,
+            prompt_input=normalized_input,
             tools=tools,
             runtime_policy=runtime_policy,
             api_key=api_key,
@@ -128,14 +141,53 @@ class PromptInputGuardedProvider:
         try:
             self.validator.validate(prompt_id=prompt_ref.prompt_id, prompt_input=prompt_input)
         except PromptInputContractError as error:
-            # No dedicated public LLM error code exists for input-contract
-            # violations. RUNTIME_VERSION_MISMATCH is the closest existing
-            # fail-closed runtime-contract classification and avoids falsely
-            # labelling this as a provider response failure.
             raise LLMInvocationError(
                 LLMErrorCode.RUNTIME_VERSION_MISMATCH,
                 f"prompt runtime input contract violation: {error}",
             ) from error
+
+
+def _canonical_prompt_input(prompt_input: Mapping[str, object]) -> Mapping[str, object]:
+    """Normalize the already-3-root Generic Repair envelope to FailureRecordV1.
+
+    IMP-138's outer contract is unchanged. Historical Generic Schema Repair
+    already emitted the exact nine FailureRecord field names but used two
+    pre-v1.26 enum spellings (``RUNTIME`` and
+    ``STRUCTURED_OUTPUT_VALIDATOR``). Only that exact legacy shape is
+    normalized. Bespoke semantic-revision shapes are not accepted here and
+    are rejected by the nested Prompt Input Guard instead.
+    """
+
+    raw = prompt_input.get("failure_record")
+    if not isinstance(raw, Mapping) or set(raw) != FAILURE_RECORD_FIELDS:
+        return prompt_input
+    if raw.get("failure_origin") != "RUNTIME" or raw.get("detected_by") != (
+        "STRUCTURED_OUTPUT_VALIDATOR"
+    ):
+        return prompt_input
+    failure_id = raw.get("failure_id")
+    reason_code = raw.get("failure_reason_code")
+    runtime_disposition = raw.get("runtime_disposition")
+    experiment_disposition = raw.get("experiment_disposition")
+    affected_paths = raw.get("affected_field_paths")
+    evidence_refs = raw.get("evidence_refs")
+    if not isinstance(failure_id, str) or not isinstance(reason_code, str):
+        return prompt_input
+    if runtime_disposition != "RETRYABLE" or experiment_disposition != "RUN_REPAIR":
+        return prompt_input
+    if not isinstance(affected_paths, list) or not isinstance(evidence_refs, list):
+        return prompt_input
+    canonical = build_failure_record_v1(
+        failure_id=failure_id,
+        failure_reason_code=reason_code,
+        failure_origin="LLM_OUTPUT",
+        detected_by="RUNTIME_SCHEMA_VALIDATOR",
+        runtime_disposition="RETRYABLE",
+        experiment_disposition="RUN_REPAIR",
+        affected_field_paths=affected_paths,
+        evidence_refs=evidence_refs,
+    )
+    return {**prompt_input, "failure_record": canonical}
 
 
 __all__ = ["PromptInputGuardedProvider"]

--- a/src/google_work_agent/adapters/llm/prompt_input_guard.py
+++ b/src/google_work_agent/adapters/llm/prompt_input_guard.py
@@ -141,6 +141,10 @@ class PromptInputGuardedProvider:
         try:
             self.validator.validate(prompt_id=prompt_ref.prompt_id, prompt_input=prompt_input)
         except PromptInputContractError as error:
+            # No dedicated public LLM error code exists for input-contract
+            # violations. RUNTIME_VERSION_MISMATCH is the closest existing
+            # fail-closed runtime-contract classification and avoids falsely
+            # labelling this as a provider response failure.
             raise LLMInvocationError(
                 LLMErrorCode.RUNTIME_VERSION_MISMATCH,
                 f"prompt runtime input contract violation: {error}",

--- a/src/google_work_agent/application/workflows/context_retrieval.py
+++ b/src/google_work_agent/application/workflows/context_retrieval.py
@@ -45,6 +45,7 @@ from google_work_agent.application.workflows.contracts import (
     build_semantic_failure_signature_v1,
     validate_additional_acquisition_request_v1,
 )
+from google_work_agent.application.workflows.failure_record import build_failure_record_v1
 from google_work_agent.application.workflows.handoff_contracts import (
     AcquisitionResultV1,
     ClarificationQuestionV1,
@@ -184,9 +185,6 @@ class ContextRetrievalAgent:
         *,
         request_intent: RequestIntentV2,
     ) -> list[RagCandidateV1]:
-        """retrieval.rag_retrieve (docs/05-context-retrieval.md SS5.5): rank
-        already-normalized Segments and bound them to the Context Budget.
-        Retrieval Local State only -- see rank_segments docstring."""
         return rank_segments(
             segments,
             request_intent=request_intent,
@@ -310,20 +308,6 @@ class ContextRetrievalAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[EvidenceSelectionResultV2, RunBudgetV1]:
-        """Bounded SEMANTIC_REVISION retry (docs/15 section 8.1: max 1 per Node per
-        Failure Signature). The initial validator already rejected the output as
-        SEMANTIC_INVALID; this never widens what counts as valid, it only gives the
-        model one chance to re-ground its selection in the actually-supplied
-        ranked_segments. If the revision also fails validation, a deterministic empty
-        selection is returned -- the LLM never gets a second judgment call.
-
-        G3: same-Run/same-node dedup via approve_semantic_revision -- once this
-        node has already spent its one revision attempt for the normalized
-        failure signature below (persisted in
-        retry_budget.semantic_revision_signatures_used, so it survives
-        resume/checkpoint restore), a second occurrence is denied before any
-        Provider call and falls back to the same deterministic empty
-        selection a failed revision would produce."""
         signature = build_semantic_failure_signature_v1(
             node_id="context.select_evidence",
             failure_reason_codes=["EVIDENCE_SELECTION_SEMANTIC_INVALID"],
@@ -348,12 +332,15 @@ class ContextRetrievalAgent:
                     "ranked_segments": ranked_segments,
                 },
                 "candidate_output": previous_output,
-                "failure_record": {
-                    "failure_reason_code": "EVIDENCE_SELECTION_SEMANTIC_INVALID",
-                    "affected_fields": affected_fields,
-                    "allowed_change_scope": affected_fields,
-                    "validation_errors": [failure_detail],
-                },
+                "failure_record": build_failure_record_v1(
+                    failure_reason_code="EVIDENCE_SELECTION_SEMANTIC_INVALID",
+                    failure_origin="RETRIEVAL_RESULT",
+                    detected_by="RUNTIME_DOMAIN_VALIDATOR",
+                    runtime_disposition="RETRYABLE",
+                    experiment_disposition="RUN_REVISION",
+                    affected_field_paths=affected_fields,
+                    failure_context_ids=[failure_detail],
+                ),
             },
             output_schema=EVIDENCE_SELECTION_OUTPUT_SCHEMA,
             trace_context=ObservabilityContext(
@@ -387,14 +374,6 @@ class ContextRetrievalAgent:
         retry_budget: RunBudgetV1,
         confirmation_response: ConfirmationResponseV1 | None = None,
     ) -> tuple[SufficiencyResultV2, dict[str, object]]:
-        """retrieval.assess_sufficiency (docs/05-context-retrieval.md SS5.7):
-        request_intent + top rag candidates' materialized evidence. Never
-        re-sends the full context_bundle/acquisition_status opaque blob --
-        only the Candidate-pinned selected_evidence/source_statuses/
-        budget_state typed projections. ``confirmation_response`` is only
-        present on a same-owner nested-checkpoint resume (C3) -- this is the
-        one Product Prompt NEEDS_CONFIRMATION actually originates from, so
-        it is the only one that needs to see the bounded answer."""
         prompt_input: dict[str, object] = {
             "request_intent": request_intent,
             "selected_evidence": selected_evidence_prompt_projection(evidence_drafts),
@@ -507,10 +486,6 @@ class ContextRetrievalAgent:
         selection_result: EvidenceSelectionResultV2,
         acquisition_result: AcquisitionResultV1,
     ) -> tuple[ContextBundleV1, list[EvidenceDraftV1]]:
-        """Pre-sufficiency draft: assess_sufficiency has not run yet at this
-        point in the pipeline, so missing_information/ambiguity are not yet
-        known -- that judgment is entirely assess_sufficiency's (docs/05
-        section 5.7), not select_evidence's."""
         segments = cast(
             list[_SourceSegment],
             self.build_segments_from_acquisition(acquisition_result),
@@ -537,15 +512,6 @@ class ContextRetrievalAgent:
 
 
 def _blocked_empty_selection() -> EvidenceSelectionResultV2:
-    """Deterministic fallback once the bounded SEMANTIC_REVISION retry is exhausted.
-
-    Trivially schema- and semantically-valid (empty lists are always a valid
-    subset of the supplied ranked_segments), so it never re-enters LLM
-    judgment -- downstream sufficiency/supervisor routing treats it as
-    insufficient context and proceeds through the normal
-    RETRIEVE_MORE/BLOCKED guard instead of the node crashing.
-    """
-
     return {
         "schema_version": 2,
         "evidence_drafts": [],
@@ -560,12 +526,6 @@ def validate_evidence_selection_result_v2(
     candidate_segment_ids: set[str],
     context_budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
 ) -> EvidenceSelectionResultV2:
-    """evidence-selection-result-v2.schema.json. ``candidate_segment_ids`` is
-    the bounded RAG top-K set actually sent as ``ranked_segments`` (docs/05
-    section 5.6/5.5) -- selected/excluded ids outside it, or evidence
-    referencing an unselected segment, are rejected rather than silently
-    accepted, so select_evidence can never introduce a Segment/Resource RAG
-    never surfaced."""
     root = _require_mapping(value, "$")
     _require_exact_keys(
         root,
@@ -718,46 +678,6 @@ def load_context_select_evidence_semantic_revision_prompt_reference(
     )
 
 
-# Common quoted-reply and signature markers across Gmail clients (English and
-# Korean). Best-effort/heuristic by nature -- docs/05 section 6 requires
-# "Gmail HTML 안전 텍스트 변환, 인용·서명 제거" as a Context Retriever
-# responsibility, but does not pin an exhaustive pattern list.
-
-
-# Retrieval Chunk Token is a Provider-independent deterministic estimated
-# token unit, not a claim of exact parity with any real Provider's
-# tokenizer/billing count (see docs/05-context-retrieval.md section 10).
-# It is measured as UTF-8 byte length: for byte-level BPE tokenizers (the
-# family essentially every current LLM provider uses, including this
-# project's active Ollama/Qwen and Gemini providers), a single token is
-# always built from one or more whole input bytes -- a tokenizer merges
-# bytes together, it never splits one byte into multiple tokens. That
-# makes "1 estimated unit per UTF-8 byte" a theoretically sound upper
-# bound on real token count for any such tokenizer, not merely a guess:
-# real_tokens <= utf8_byte_length always holds.
-#
-# This was calibrated against a locally running Ollama qwen2.5:3b
-# (/api/generate with raw=true, reading prompt_eval_count) across English,
-# Korean, Korean/English-mixed, URL/email/number, and Gmail-reply-shaped
-# samples. Natural-language text (English, Korean, mixed) measured well
-# under 1 real token per byte, but digit/punctuation-dense text (order
-# numbers, IDs, timestamps -- realistic in Gmail bodies) measured as high
-# as 1.0 real tokens per byte (pure digit sequences: qwen2.5 tokenizes
-# purely digit-by-digit). No sample exceeded 1 real token per byte, which
-# matches the byte-level-BPE argument above. Earlier chars/4 undercounted
-# Korean by up to ~2.5x and digit-heavy text by up to ~3.4x against this
-# same real measurement -- both silently violated the "no chunk exceeds
-# chunk_max_tokens" contract for an actual provider call.
-#
-# Trade-off: this is intentionally conservative, so ordinary English/Korean
-# prose chunks end up smaller in characters than the old chars/4 estimate
-# allowed (chunks are sized for the digit-dense worst case even when actual
-# content is natural language). That is the accepted cost of an honest
-# never-exceeds guarantee without adding a tokenizer dependency; it is not
-# a per-script/per-language heuristic -- the same byte-count formula runs
-# unconditionally for every Unicode input.
-
-
 def _selected_segments(
     selected_ids: list[str],
     *,
@@ -772,12 +692,6 @@ def _ranked_segments_prompt_projection(
     *,
     segments_by_id: dict[str, _SourceSegment],
 ) -> list[dict[str, object]]:
-    """retrieval-evidence-selection-input-v1.schema.json ``ranked_segments``.
-
-    Joins each RagCandidateV1 back to its normalized SourceSegment by
-    segment_id -- docs/05 section 5.6/Q2-RAG boundary: RagCandidateV1 never
-    carries body text itself, and this never re-scores or re-orders what
-    Q2-RAG already ranked."""
     projections: list[dict[str, object]] = []
     for candidate in rag_candidates:
         segment = segments_by_id.get(candidate["segment_id"])
@@ -805,11 +719,6 @@ def _materialize_evidence_drafts(
     segments: list[_SourceSegment],
     context_budget: ContextBudget,
 ) -> list[EvidenceDraftV1]:
-    """Join the LLM's thin role/segment reference back to its normalized
-    SourceSegment -- docs/05-context-retrieval.md section 5.6 forbids the
-    LLM from copying Connector body text into its own output, so
-    resource_handle/excerpt/locator always come from the Segment, never
-    from the LLM."""
     segments_by_id = {segment.segment_id: segment for segment in segments}
     drafts: list[EvidenceDraftV1] = []
     for role_draft in role_drafts:
@@ -972,7 +881,6 @@ def _segment_ref(segment: _SourceSegment) -> dict[str, object]:
     }
 
 
-# Shared with the other agent workflow modules; see _schema_support module docstring.
 _require_mapping = partial(_schema.require_mapping, error_cls=ContextRetrievalValidationError)
 _nullable_mapping = partial(_schema.nullable_mapping, error_cls=ContextRetrievalValidationError)
 _require_exact_keys = partial(_schema.require_exact_keys, error_cls=ContextRetrievalValidationError)

--- a/src/google_work_agent/application/workflows/context_retrieval.py
+++ b/src/google_work_agent/application/workflows/context_retrieval.py
@@ -185,6 +185,9 @@ class ContextRetrievalAgent:
         *,
         request_intent: RequestIntentV2,
     ) -> list[RagCandidateV1]:
+        """retrieval.rag_retrieve (docs/05-context-retrieval.md SS5.5): rank
+        already-normalized Segments and bound them to the Context Budget.
+        Retrieval Local State only -- see rank_segments docstring."""
         return rank_segments(
             segments,
             request_intent=request_intent,
@@ -308,6 +311,20 @@ class ContextRetrievalAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[EvidenceSelectionResultV2, RunBudgetV1]:
+        """Bounded SEMANTIC_REVISION retry (docs/15 section 8.1: max 1 per Node per
+        Failure Signature). The initial validator already rejected the output as
+        SEMANTIC_INVALID; this never widens what counts as valid, it only gives the
+        model one chance to re-ground its selection in the actually-supplied
+        ranked_segments. If the revision also fails validation, a deterministic empty
+        selection is returned -- the LLM never gets a second judgment call.
+
+        G3: same-Run/same-node dedup via approve_semantic_revision -- once this
+        node has already spent its one revision attempt for the normalized
+        failure signature below (persisted in
+        retry_budget.semantic_revision_signatures_used, so it survives
+        resume/checkpoint restore), a second occurrence is denied before any
+        Provider call and falls back to the same deterministic empty
+        selection a failed revision would produce."""
         signature = build_semantic_failure_signature_v1(
             node_id="context.select_evidence",
             failure_reason_codes=["EVIDENCE_SELECTION_SEMANTIC_INVALID"],
@@ -374,6 +391,14 @@ class ContextRetrievalAgent:
         retry_budget: RunBudgetV1,
         confirmation_response: ConfirmationResponseV1 | None = None,
     ) -> tuple[SufficiencyResultV2, dict[str, object]]:
+        """retrieval.assess_sufficiency (docs/05-context-retrieval.md SS5.7):
+        request_intent + top rag candidates' materialized evidence. Never
+        re-sends the full context_bundle/acquisition_status opaque blob --
+        only the Candidate-pinned selected_evidence/source_statuses/
+        budget_state typed projections. ``confirmation_response`` is only
+        present on a same-owner nested-checkpoint resume (C3) -- this is the
+        one Product Prompt NEEDS_CONFIRMATION actually originates from, so
+        it is the only one that needs to see the bounded answer."""
         prompt_input: dict[str, object] = {
             "request_intent": request_intent,
             "selected_evidence": selected_evidence_prompt_projection(evidence_drafts),
@@ -486,6 +511,10 @@ class ContextRetrievalAgent:
         selection_result: EvidenceSelectionResultV2,
         acquisition_result: AcquisitionResultV1,
     ) -> tuple[ContextBundleV1, list[EvidenceDraftV1]]:
+        """Pre-sufficiency draft: assess_sufficiency has not run yet at this
+        point in the pipeline, so missing_information/ambiguity are not yet
+        known -- that judgment is entirely assess_sufficiency's (docs/05
+        section 5.7), not select_evidence's."""
         segments = cast(
             list[_SourceSegment],
             self.build_segments_from_acquisition(acquisition_result),
@@ -512,6 +541,15 @@ class ContextRetrievalAgent:
 
 
 def _blocked_empty_selection() -> EvidenceSelectionResultV2:
+    """Deterministic fallback once the bounded SEMANTIC_REVISION retry is exhausted.
+
+    Trivially schema- and semantically-valid (empty lists are always a valid
+    subset of the supplied ranked_segments), so it never re-enters LLM
+    judgment -- downstream sufficiency/supervisor routing treats it as
+    insufficient context and proceeds through the normal
+    RETRIEVE_MORE/BLOCKED guard instead of the node crashing.
+    """
+
     return {
         "schema_version": 2,
         "evidence_drafts": [],
@@ -526,6 +564,12 @@ def validate_evidence_selection_result_v2(
     candidate_segment_ids: set[str],
     context_budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
 ) -> EvidenceSelectionResultV2:
+    """evidence-selection-result-v2.schema.json. ``candidate_segment_ids`` is
+    the bounded RAG top-K set actually sent as ``ranked_segments`` (docs/05
+    section 5.6/5.5) -- selected/excluded ids outside it, or evidence
+    referencing an unselected segment, are rejected rather than silently
+    accepted, so select_evidence can never introduce a Segment/Resource RAG
+    never surfaced."""
     root = _require_mapping(value, "$")
     _require_exact_keys(
         root,
@@ -678,6 +722,46 @@ def load_context_select_evidence_semantic_revision_prompt_reference(
     )
 
 
+# Common quoted-reply and signature markers across Gmail clients (English and
+# Korean). Best-effort/heuristic by nature -- docs/05 section 6 requires
+# "Gmail HTML 안전 텍스트 변환, 인용·서명 제거" as a Context Retriever
+# responsibility, but does not pin an exhaustive pattern list.
+
+
+# Retrieval Chunk Token is a Provider-independent deterministic estimated
+# token unit, not a claim of exact parity with any real Provider's
+# tokenizer/billing count (see docs/05-context-retrieval.md section 10).
+# It is measured as UTF-8 byte length: for byte-level BPE tokenizers (the
+# family essentially every current LLM provider uses, including this
+# project's active Ollama/Qwen and Gemini providers), a single token is
+# always built from one or more whole input bytes -- a tokenizer merges
+# bytes together, it never splits one byte into multiple tokens. That
+# makes "1 estimated unit per UTF-8 byte" a theoretically sound upper
+# bound on real token count for any such tokenizer, not merely a guess:
+# real_tokens <= utf8_byte_length always holds.
+#
+# This was calibrated against a locally running Ollama qwen2.5:3b
+# (/api/generate with raw=true, reading prompt_eval_count) across English,
+# Korean, Korean/English-mixed, URL/email/number, and Gmail-reply-shaped
+# samples. Natural-language text (English, Korean, mixed) measured well
+# under 1 real token per byte, but digit/punctuation-dense text (order
+# numbers, IDs, timestamps -- realistic in Gmail bodies) measured as high
+# as 1.0 real tokens per byte (pure digit sequences: qwen2.5 tokenizes
+# purely digit-by-digit). No sample exceeded 1 real token per byte, which
+# matches the byte-level-BPE argument above. Earlier chars/4 undercounted
+# Korean by up to ~2.5x and digit-heavy text by up to ~3.4x against this
+# same real measurement -- both silently violated the "no chunk exceeds
+# chunk_max_tokens" contract for an actual provider call.
+#
+# Trade-off: this is intentionally conservative, so ordinary English/Korean
+# prose chunks end up smaller in characters than the old chars/4 estimate
+# allowed (chunks are sized for the digit-dense worst case even when actual
+# content is natural language). That is the accepted cost of an honest
+# never-exceeds guarantee without adding a tokenizer dependency; it is not
+# a per-script/per-language heuristic -- the same byte-count formula runs
+# unconditionally for every Unicode input.
+
+
 def _selected_segments(
     selected_ids: list[str],
     *,
@@ -692,6 +776,12 @@ def _ranked_segments_prompt_projection(
     *,
     segments_by_id: dict[str, _SourceSegment],
 ) -> list[dict[str, object]]:
+    """retrieval-evidence-selection-input-v1.schema.json ``ranked_segments``.
+
+    Joins each RagCandidateV1 back to its normalized SourceSegment by
+    segment_id -- docs/05 section 5.6/Q2-RAG boundary: RagCandidateV1 never
+    carries body text itself, and this never re-scores or re-orders what
+    Q2-RAG already ranked."""
     projections: list[dict[str, object]] = []
     for candidate in rag_candidates:
         segment = segments_by_id.get(candidate["segment_id"])
@@ -719,6 +809,11 @@ def _materialize_evidence_drafts(
     segments: list[_SourceSegment],
     context_budget: ContextBudget,
 ) -> list[EvidenceDraftV1]:
+    """Join the LLM's thin role/segment reference back to its normalized
+    SourceSegment -- docs/05-context-retrieval.md section 5.6 forbids the
+    LLM from copying Connector body text into its own output, so
+    resource_handle/excerpt/locator always come from the Segment, never
+    from the LLM."""
     segments_by_id = {segment.segment_id: segment for segment in segments}
     drafts: list[EvidenceDraftV1] = []
     for role_draft in role_drafts:
@@ -881,6 +976,7 @@ def _segment_ref(segment: _SourceSegment) -> dict[str, object]:
     }
 
 
+# Shared with the other agent workflow modules; see _schema_support module docstring.
 _require_mapping = partial(_schema.require_mapping, error_cls=ContextRetrievalValidationError)
 _nullable_mapping = partial(_schema.nullable_mapping, error_cls=ContextRetrievalValidationError)
 _require_exact_keys = partial(_schema.require_exact_keys, error_cls=ContextRetrievalValidationError)

--- a/src/google_work_agent/application/workflows/failure_record.py
+++ b/src/google_work_agent/application/workflows/failure_record.py
@@ -1,0 +1,233 @@
+"""Canonical FailureRecordV1 projection and validation.
+
+Product repair/revision prompts receive exactly one normalized failure record.
+This module is the single runtime projector/validator for that nested DTO; node
+callers may supply local diagnostics to choose the canonical fields, but may
+not add bespoke prompt fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import Literal, TypedDict, cast
+
+FailureOriginV1 = Literal[
+    "LLM_OUTPUT",
+    "QUERY_PLANNING",
+    "RETRIEVAL_RESULT",
+    "PROVIDER",
+    "DOMAIN",
+    "POLICY",
+    "EXPERIMENT",
+]
+DetectedByV1 = Literal[
+    "RUNTIME_SCHEMA_VALIDATOR",
+    "RUNTIME_DOMAIN_VALIDATOR",
+    "RUNTIME_POLICY_VALIDATOR",
+    "RUNTIME_REVIEW_AGENT",
+    "RUNTIME_PROVIDER",
+    "EXPERIMENT_DETERMINISTIC_GRADER",
+    "EXPERIMENT_SEMANTIC_GRADER",
+    "HUMAN_REVIEW",
+]
+RuntimeDispositionV1 = Literal[
+    "RETRYABLE",
+    "REDIRECT",
+    "DETERMINISTIC",
+    "TERMINAL",
+    "NOT_AVAILABLE",
+]
+ExperimentDispositionV1 = Literal[
+    "COUNT_FAILURE",
+    "RUN_REPAIR",
+    "RUN_REVISION",
+    "REJECT_CANDIDATE",
+    "HUMAN_REVIEW",
+]
+
+
+class FailureRecordV1(TypedDict):
+    schema_version: Literal[1]
+    failure_id: str
+    failure_reason_code: str
+    failure_origin: FailureOriginV1
+    detected_by: DetectedByV1
+    runtime_disposition: RuntimeDispositionV1
+    experiment_disposition: ExperimentDispositionV1
+    affected_field_paths: list[str]
+    evidence_refs: list[str]
+
+
+FAILURE_RECORD_FIELDS = frozenset(FailureRecordV1.__annotations__)
+_FAILURE_ORIGINS = {
+    "LLM_OUTPUT",
+    "QUERY_PLANNING",
+    "RETRIEVAL_RESULT",
+    "PROVIDER",
+    "DOMAIN",
+    "POLICY",
+    "EXPERIMENT",
+}
+_DETECTED_BY = {
+    "RUNTIME_SCHEMA_VALIDATOR",
+    "RUNTIME_DOMAIN_VALIDATOR",
+    "RUNTIME_POLICY_VALIDATOR",
+    "RUNTIME_REVIEW_AGENT",
+    "RUNTIME_PROVIDER",
+    "EXPERIMENT_DETERMINISTIC_GRADER",
+    "EXPERIMENT_SEMANTIC_GRADER",
+    "HUMAN_REVIEW",
+}
+_RUNTIME_DISPOSITIONS = {
+    "RETRYABLE",
+    "REDIRECT",
+    "DETERMINISTIC",
+    "TERMINAL",
+    "NOT_AVAILABLE",
+}
+_EXPERIMENT_DISPOSITIONS = {
+    "COUNT_FAILURE",
+    "RUN_REPAIR",
+    "RUN_REVISION",
+    "REJECT_CANDIDATE",
+    "HUMAN_REVIEW",
+}
+
+
+class FailureRecordValidationError(ValueError):
+    pass
+
+
+def build_failure_record_v1(
+    *,
+    failure_reason_code: str,
+    failure_origin: FailureOriginV1,
+    detected_by: DetectedByV1,
+    runtime_disposition: RuntimeDispositionV1,
+    experiment_disposition: ExperimentDispositionV1,
+    affected_field_paths: Iterable[str] = (),
+    evidence_refs: Iterable[str] = (),
+    failure_context_ids: Iterable[str] = (),
+    failure_id: str | None = None,
+) -> FailureRecordV1:
+    """Project local failure diagnostics into the canonical prompt DTO.
+
+    ``failure_context_ids`` may bind a deterministic id to local issue ids but
+    is never serialized into the Product Prompt.
+    """
+
+    paths = _dedupe_non_empty(affected_field_paths, "affected_field_paths")
+    refs = _dedupe_non_empty(evidence_refs, "evidence_refs")
+    context_ids = _dedupe_non_empty(failure_context_ids, "failure_context_ids")
+    if failure_id is None:
+        identity = json.dumps(
+            {
+                "failure_reason_code": failure_reason_code,
+                "failure_origin": failure_origin,
+                "detected_by": detected_by,
+                "affected_field_paths": paths,
+                "evidence_refs": refs,
+                "failure_context_ids": context_ids,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        failure_id = f"failure-{hashlib.sha256(identity).hexdigest()[:24]}"
+    record: FailureRecordV1 = {
+        "schema_version": 1,
+        "failure_id": failure_id,
+        "failure_reason_code": failure_reason_code,
+        "failure_origin": failure_origin,
+        "detected_by": detected_by,
+        "runtime_disposition": runtime_disposition,
+        "experiment_disposition": experiment_disposition,
+        "affected_field_paths": paths,
+        "evidence_refs": refs,
+    }
+    return validate_failure_record_v1(record)
+
+
+def validate_failure_record_v1(value: object) -> FailureRecordV1:
+    if not isinstance(value, Mapping):
+        raise FailureRecordValidationError("failure_record must be an object")
+    root = cast(Mapping[str, object], value)
+    keys = set(root)
+    if keys != FAILURE_RECORD_FIELDS:
+        missing = sorted(FAILURE_RECORD_FIELDS - keys)
+        extra = sorted(keys - FAILURE_RECORD_FIELDS)
+        raise FailureRecordValidationError(
+            f"failure_record exact schema mismatch; missing={missing}, extra={extra}"
+        )
+    if root["schema_version"] != 1 or isinstance(root["schema_version"], bool):
+        raise FailureRecordValidationError("failure_record.schema_version must be 1")
+    _non_empty_string(root["failure_id"], "failure_id")
+    _non_empty_string(root["failure_reason_code"], "failure_reason_code")
+    _enum(root["failure_origin"], "failure_origin", _FAILURE_ORIGINS)
+    _enum(root["detected_by"], "detected_by", _DETECTED_BY)
+    _enum(root["runtime_disposition"], "runtime_disposition", _RUNTIME_DISPOSITIONS)
+    _enum(
+        root["experiment_disposition"],
+        "experiment_disposition",
+        _EXPERIMENT_DISPOSITIONS,
+    )
+    paths = _string_list(root["affected_field_paths"], "affected_field_paths")
+    refs = _string_list(root["evidence_refs"], "evidence_refs")
+    return {
+        "schema_version": 1,
+        "failure_id": cast(str, root["failure_id"]),
+        "failure_reason_code": cast(str, root["failure_reason_code"]),
+        "failure_origin": cast(FailureOriginV1, root["failure_origin"]),
+        "detected_by": cast(DetectedByV1, root["detected_by"]),
+        "runtime_disposition": cast(RuntimeDispositionV1, root["runtime_disposition"]),
+        "experiment_disposition": cast(
+            ExperimentDispositionV1, root["experiment_disposition"]
+        ),
+        "affected_field_paths": paths,
+        "evidence_refs": refs,
+    }
+
+
+def _dedupe_non_empty(values: Iterable[str], field: str) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str) or not value:
+            raise FailureRecordValidationError(f"{field} items must be non-empty strings")
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _string_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list):
+        raise FailureRecordValidationError(f"failure_record.{field} must be an array")
+    result = _dedupe_non_empty(value, field)
+    if len(result) != len(value):
+        raise FailureRecordValidationError(f"failure_record.{field} must be unique")
+    return result
+
+
+def _non_empty_string(value: object, field: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise FailureRecordValidationError(
+            f"failure_record.{field} must be a non-empty string"
+        )
+
+
+def _enum(value: object, field: str, allowed: set[str]) -> None:
+    if not isinstance(value, str) or value not in allowed:
+        raise FailureRecordValidationError(f"failure_record.{field} is invalid")
+
+
+__all__ = [
+    "FAILURE_RECORD_FIELDS",
+    "FailureRecordV1",
+    "FailureRecordValidationError",
+    "build_failure_record_v1",
+    "validate_failure_record_v1",
+]

--- a/src/google_work_agent/application/workflows/planning_argument_writer.py
+++ b/src/google_work_agent/application/workflows/planning_argument_writer.py
@@ -13,6 +13,10 @@ from typing import Final
 
 from google_work_agent.application.llm import StructuredLLMRuntime
 from google_work_agent.application.observability import ObservabilityContext
+from google_work_agent.application.workflows.failure_record import (
+    FailureRecordV1,
+    build_failure_record_v1,
+)
 from google_work_agent.application.workflows.handoff_contracts import (
     EvidenceDraftV1,
     ReviewIssueV1,
@@ -214,12 +218,13 @@ def _normalized_failure_record(
     *,
     review_issues: list[ReviewIssueV1],
     review_summary: str | None,
-) -> dict[str, object]:
-    """Project Review issues into the bounded argument-writer revision envelope."""
+) -> FailureRecordV1:
+    """Project Review issues through the single Canonical FailureRecordV1 builder."""
 
     reason_codes: list[str] = []
     affected_fields: list[str] = []
     issue_ids: list[str] = []
+    evidence_refs: list[str] = []
     for issue in review_issues:
         issue_id = issue.get("issue_id")
         if isinstance(issue_id, str) and issue_id and issue_id not in issue_ids:
@@ -231,17 +236,33 @@ def _normalized_failure_record(
             normalized = _candidate_relative_field_path(field_path)
             if normalized is not None and normalized not in affected_fields:
                 affected_fields.append(normalized)
+        for evidence_ref in issue.get("evidence_refs", []):
+            if (
+                isinstance(evidence_ref, str)
+                and evidence_ref
+                and evidence_ref not in evidence_refs
+            ):
+                evidence_refs.append(evidence_ref)
 
     if not affected_fields:
         affected_fields.extend(_ALLOWED_REVISION_SCOPE)
 
-    return {
-        "failure_reason_codes": reason_codes or ["PLAN_REVIEW_REVISE"],
-        "affected_fields": affected_fields,
-        "allowed_change_scope": list(_ALLOWED_REVISION_SCOPE),
-        "review_issue_ids": issue_ids,
-        "summary": review_summary,
-    }
+    context_ids = list(issue_ids)
+    if review_summary:
+        # The summary binds deterministic failure identity only.  It is not a
+        # Product Prompt field because FailureRecordV1 has no free-text slot.
+        context_ids.append(f"summary:{review_summary}")
+
+    return build_failure_record_v1(
+        failure_reason_code=reason_codes[0] if reason_codes else "PLAN_REVIEW_REVISE",
+        failure_origin="LLM_OUTPUT",
+        detected_by="RUNTIME_REVIEW_AGENT",
+        runtime_disposition="RETRYABLE",
+        experiment_disposition="RUN_REVISION",
+        affected_field_paths=affected_fields,
+        evidence_refs=evidence_refs,
+        failure_context_ids=context_ids,
+    )
 
 
 def _candidate_relative_field_path(field_path: object) -> str | None:

--- a/src/google_work_agent/application/workflows/prompt_input_contract.py
+++ b/src/google_work_agent/application/workflows/prompt_input_contract.py
@@ -14,6 +14,11 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
+from google_work_agent.application.workflows.failure_record import (
+    FailureRecordValidationError,
+    validate_failure_record_v1,
+)
+
 
 class PromptInputContractError(ValueError):
     """Raised before provider dispatch when a Product Prompt input is invalid."""
@@ -38,6 +43,17 @@ class PromptRuntimeInputContractValidator:
             raise PromptInputContractError(
                 f"prompt input contains undeclared root fields for {prompt_id}: {undeclared}"
             )
+
+        # Repair/revision roots remain base_projection + candidate_output +
+        # failure_record, while the nested failure_record is itself a closed,
+        # versioned DTO.  Reject bespoke legacy fields before serialization.
+        if "failure_record" in prompt_input:
+            try:
+                validate_failure_record_v1(prompt_input["failure_record"])
+            except FailureRecordValidationError as error:
+                raise PromptInputContractError(
+                    f"prompt input failure_record is invalid for {prompt_id}: {error}"
+                ) from error
 
         forbidden = _require_string_set(
             contract.get("forbidden_runtime_fields"), "$.forbidden_runtime_fields"

--- a/src/google_work_agent/application/workflows/provider_dispatch_budget.py
+++ b/src/google_work_agent/application/workflows/provider_dispatch_budget.py
@@ -21,7 +21,6 @@ from google_work_agent.application.workflows.contracts import (
     BudgetDecision,
     RunBudgetV1,
     check_llm_call_budget,
-    consume_llm_provider_calls,
     validate_run_budget_v1,
 )
 from google_work_agent.ports import LLMErrorCode, LLMInvocationError
@@ -36,10 +35,6 @@ def bind_provider_dispatch_budget(run_budget: RunBudgetV1) -> RunBudgetV1:
     """Bind one mutable RunBudget authority to the current execution context."""
 
     validated = validate_run_budget_v1(run_budget)
-    # Keep the caller-owned object as the authority. Validation above is
-    # fail-closed, while mutation below preserves object identity so a failed
-    # provider dispatch is visible to the owning graph state even though no
-    # StructuredLLMResult is produced.
     run_budget.clear()
     run_budget.update(validated)
     _CURRENT_RUN_BUDGET.set(run_budget)
@@ -60,9 +55,13 @@ def account_provider_dispatch() -> None:
             f"run LLM call budget exhausted: {decision['budget_reason_code']}",
             retryable=False,
         )
-    updated = consume_llm_provider_calls(run_budget, provider_calls_consumed=1)
+    # This is the sole increment for a real provider dispatch. Do not route it
+    # through the historical post-result consumer: calls that raise must count.
+    updated = dict(validate_run_budget_v1(run_budget))
+    updated["llm_calls_used"] = int(updated["llm_calls_used"]) + 1
+    validated = validate_run_budget_v1(updated)
     run_budget.clear()
-    run_budget.update(updated)
+    run_budget.update(validated)
 
 
 def merge_provider_dispatch_usage(run_budget: RunBudgetV1) -> RunBudgetV1:
@@ -85,7 +84,7 @@ def merge_provider_dispatch_usage(run_budget: RunBudgetV1) -> RunBudgetV1:
 
 
 def current_provider_dispatch_budget() -> RunBudgetV1 | None:
-    """Test/adapter inspection helper; returns the RunBudget authority itself."""
+    """Return the bound RunBudget authority itself, never a second counter."""
 
     return _CURRENT_RUN_BUDGET.get()
 

--- a/src/google_work_agent/application/workflows/provider_dispatch_budget.py
+++ b/src/google_work_agent/application/workflows/provider_dispatch_budget.py
@@ -10,10 +10,18 @@ immediately after prompt validation and immediately before the real provider
 method. The budget is therefore consumed even when that provider call raises a
 timeout/error, and primary/fallback/repair/tool-call dispatches are each seen
 independently.
+
+The production graph invocation boundary is wrapped in
+:func:`provider_dispatch_execution_scope`, which guarantees that a budget
+reference bound by one start/resume/recovery invocation cannot leak into a
+later unrelated invocation or diagnostic provider call. Direct callers that
+need a narrower boundary can use :func:`provider_dispatch_budget_scope`.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import cast
 
@@ -32,13 +40,56 @@ _CURRENT_RUN_BUDGET: ContextVar[RunBudgetV1 | None] = ContextVar(
 
 
 def bind_provider_dispatch_budget(run_budget: RunBudgetV1) -> RunBudgetV1:
-    """Bind one mutable RunBudget authority to the current execution context."""
+    """Bind one mutable RunBudget authority to the current execution context.
+
+    This compatibility helper deliberately does not own lifecycle. Production
+    graph execution is bounded by ``provider_dispatch_execution_scope``;
+    direct callers that bind a budget themselves should prefer
+    ``provider_dispatch_budget_scope`` so reset is guaranteed by ``finally``.
+    """
 
     validated = validate_run_budget_v1(run_budget)
     run_budget.clear()
     run_budget.update(validated)
     _CURRENT_RUN_BUDGET.set(run_budget)
     return run_budget
+
+
+@contextmanager
+def provider_dispatch_budget_scope(run_budget: RunBudgetV1) -> Iterator[RunBudgetV1]:
+    """Bind one authoritative RunBudget and always restore the prior context."""
+
+    validated = validate_run_budget_v1(run_budget)
+    run_budget.clear()
+    run_budget.update(validated)
+    token = _CURRENT_RUN_BUDGET.set(run_budget)
+    try:
+        yield run_budget
+    finally:
+        _CURRENT_RUN_BUDGET.reset(token)
+
+
+@contextmanager
+def provider_dispatch_execution_scope() -> Iterator[None]:
+    """Bound the provider-budget ContextVar to one graph invocation.
+
+    ``WorkflowInvocationCoordinator`` is the top-level start/resume/recovery
+    boundary and is not recursively entered. Start from an explicitly clean
+    ContextVar so a stale reference left by older/unscoped code can never be
+    charged by this invocation, then use the ContextVar token lifecycle to
+    guarantee cleanup on success and on any escaping exception.
+    """
+
+    if _CURRENT_RUN_BUDGET.get() is not None:
+        # Compatibility cleanup for a process that entered this code with an
+        # older unbounded binding already present. This is reference cleanup,
+        # not numeric accounting and does not create a second authority.
+        _CURRENT_RUN_BUDGET.set(None)
+    token = _CURRENT_RUN_BUDGET.set(None)
+    try:
+        yield
+    finally:
+        _CURRENT_RUN_BUDGET.reset(token)
 
 
 def account_provider_dispatch() -> None:
@@ -109,4 +160,6 @@ __all__ = [
     "current_provider_dispatch_budget",
     "legacy_post_call_projection",
     "merge_provider_dispatch_usage",
+    "provider_dispatch_budget_scope",
+    "provider_dispatch_execution_scope",
 ]

--- a/src/google_work_agent/application/workflows/provider_dispatch_budget.py
+++ b/src/google_work_agent/application/workflows/provider_dispatch_budget.py
@@ -1,0 +1,98 @@
+"""RunBudgetV1 accounting at the real LLM provider dispatch boundary.
+
+The ContextVar stores only a reference to the currently authoritative
+``RunBudgetV1`` object for this execution context. It is not a second counter:
+``llm_calls_used`` in RunBudgetV1 remains the sole numeric/durable authority.
+
+Native LangGraph nodes bind their current RunBudget before invoking the LLM
+runtime. ``PromptInputGuardedProvider`` calls :func:`account_provider_dispatch`
+immediately after prompt validation and immediately before the real provider
+method. The budget is therefore consumed even when that provider call raises a
+timeout/error, and primary/fallback/repair/tool-call dispatches are each seen
+independently.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import cast
+
+from google_work_agent.application.workflows.contracts import (
+    BudgetDecision,
+    RunBudgetV1,
+    check_llm_call_budget,
+    consume_llm_provider_calls,
+    validate_run_budget_v1,
+)
+from google_work_agent.ports import LLMErrorCode, LLMInvocationError
+
+_CURRENT_RUN_BUDGET: ContextVar[RunBudgetV1 | None] = ContextVar(
+    "google_work_agent_current_provider_dispatch_run_budget",
+    default=None,
+)
+
+
+def bind_provider_dispatch_budget(run_budget: RunBudgetV1) -> RunBudgetV1:
+    """Bind one mutable RunBudget authority to the current execution context."""
+
+    validated = validate_run_budget_v1(run_budget)
+    # Keep the caller-owned object as the authority. Validation above is
+    # fail-closed, while mutation below preserves object identity so a failed
+    # provider dispatch is visible to the owning graph state even though no
+    # StructuredLLMResult is produced.
+    run_budget.clear()
+    run_budget.update(validated)
+    _CURRENT_RUN_BUDGET.set(run_budget)
+    return run_budget
+
+
+def account_provider_dispatch() -> None:
+    """Consume exactly one provider call immediately before external dispatch."""
+
+    run_budget = _CURRENT_RUN_BUDGET.get()
+    if run_budget is None:
+        # Non-Run diagnostic/connection probes intentionally have no RunBudget.
+        return
+    decision = check_llm_call_budget(run_budget, provider_calls_requested=1)
+    if decision["decision"] == BudgetDecision.DENY.value:
+        raise LLMInvocationError(
+            LLMErrorCode.LLM_CALL_BUDGET_EXHAUSTED,
+            f"run LLM call budget exhausted: {decision['budget_reason_code']}",
+            retryable=False,
+        )
+    updated = consume_llm_provider_calls(run_budget, provider_calls_consumed=1)
+    run_budget.clear()
+    run_budget.update(updated)
+
+
+def merge_provider_dispatch_usage(run_budget: RunBudgetV1) -> RunBudgetV1:
+    """Merge actual dispatch usage into a derived RunBudget projection.
+
+    Semantic-revision guards return a copied RunBudget carrying their signature
+    update. The provider boundary may meanwhile have incremented the bound
+    authority. Preserve all fields from the derived projection, replacing only
+    ``llm_calls_used`` with the actual dispatch authority value.
+    """
+
+    derived = validate_run_budget_v1(run_budget)
+    authority = _CURRENT_RUN_BUDGET.get()
+    if authority is None:
+        return derived
+    actual = validate_run_budget_v1(authority)
+    merged = dict(derived)
+    merged["llm_calls_used"] = actual["llm_calls_used"]
+    return cast(RunBudgetV1, validate_run_budget_v1(merged))
+
+
+def current_provider_dispatch_budget() -> RunBudgetV1 | None:
+    """Test/adapter inspection helper; returns the RunBudget authority itself."""
+
+    return _CURRENT_RUN_BUDGET.get()
+
+
+__all__ = [
+    "account_provider_dispatch",
+    "bind_provider_dispatch_budget",
+    "current_provider_dispatch_budget",
+    "merge_provider_dispatch_usage",
+]

--- a/src/google_work_agent/application/workflows/provider_dispatch_budget.py
+++ b/src/google_work_agent/application/workflows/provider_dispatch_budget.py
@@ -65,13 +65,7 @@ def account_provider_dispatch() -> None:
 
 
 def merge_provider_dispatch_usage(run_budget: RunBudgetV1) -> RunBudgetV1:
-    """Merge actual dispatch usage into a derived RunBudget projection.
-
-    Semantic-revision guards return a copied RunBudget carrying their signature
-    update. The provider boundary may meanwhile have incremented the bound
-    authority. Preserve all fields from the derived projection, replacing only
-    ``llm_calls_used`` with the actual dispatch authority value.
-    """
+    """Merge actual dispatch usage into a derived RunBudget projection."""
 
     derived = validate_run_budget_v1(run_budget)
     authority = _CURRENT_RUN_BUDGET.get()
@@ -81,6 +75,26 @@ def merge_provider_dispatch_usage(run_budget: RunBudgetV1) -> RunBudgetV1:
     merged = dict(derived)
     merged["llm_calls_used"] = actual["llm_calls_used"]
     return cast(RunBudgetV1, validate_run_budget_v1(merged))
+
+
+def legacy_post_call_projection(run_budget: RunBudgetV1) -> RunBudgetV1:
+    """Bridge Tool Route's pre-Wave-1C post-call ``+1`` caller.
+
+    Tool Route still calls the historical deterministic consumer once after a
+    semantic-agent call. Until that caller is retired by its own runtime-cutover
+    work, return a projection whose call count is one below the already-counted
+    dispatch total, so the legacy post-call increment preserves -- rather than
+    duplicates -- the dispatch-authoritative total. No separate counter exists;
+    this projection is derived solely from RunBudgetV1.
+    """
+
+    merged = merge_provider_dispatch_usage(run_budget)
+    used = merged["llm_calls_used"]
+    if used <= 0:
+        return merged
+    projected = dict(merged)
+    projected["llm_calls_used"] = used - 1
+    return cast(RunBudgetV1, validate_run_budget_v1(projected))
 
 
 def current_provider_dispatch_budget() -> RunBudgetV1 | None:
@@ -93,5 +107,6 @@ __all__ = [
     "account_provider_dispatch",
     "bind_provider_dispatch_budget",
     "current_provider_dispatch_budget",
+    "legacy_post_call_projection",
     "merge_provider_dispatch_usage",
 ]

--- a/src/google_work_agent/application/workflows/retrieval_query_planner.py
+++ b/src/google_work_agent/application/workflows/retrieval_query_planner.py
@@ -122,7 +122,18 @@ class RetrievalQueryPlannerAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[RetrievalQueryPlanV2, RunBudgetV1]:
-        """Bounded SEMANTIC_REVISION retry (max 1 per Node/Failure Signature)."""
+        """Bounded SEMANTIC_REVISION retry (max 1 per Node/Failure Signature):
+        a schema-shaped plan that fails RetrievalQueryPlanV2's own semantic
+        checks (frozen-route/constraint-policy/validated-ref violations) gets
+        one re-grounding attempt against the dedicated .revise prompt --
+        never the generic SCHEMA_REPAIR path. If the revision also fails,
+        the error propagates to the caller's existing fail-closed handling.
+
+        G3: dedup via approve_semantic_revision -- a second occurrence of the
+        same normalized failure signature for this node, anywhere in the Run
+        (including after resume/checkpoint restore), is denied before any
+        Provider call and raises the same RetrievalV2ValidationError a failed
+        revision attempt would."""
         failure_code = "RETRIEVAL_QUERY_PLAN_SEMANTIC_INVALID"
         signature = build_semantic_failure_signature_v1(
             node_id="retrieval.plan_query",

--- a/src/google_work_agent/application/workflows/retrieval_query_planner.py
+++ b/src/google_work_agent/application/workflows/retrieval_query_planner.py
@@ -13,6 +13,7 @@ from google_work_agent.application.workflows.contracts import (
     approve_semantic_revision,
     build_semantic_failure_signature_v1,
 )
+from google_work_agent.application.workflows.failure_record import build_failure_record_v1
 from google_work_agent.application.workflows.prompt_registry import (
     default_prompt_manifest_path as _registry_default_prompt_manifest_path,
 )
@@ -121,18 +122,7 @@ class RetrievalQueryPlannerAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[RetrievalQueryPlanV2, RunBudgetV1]:
-        """Bounded SEMANTIC_REVISION retry (max 1 per Node/Failure Signature):
-        a schema-shaped plan that fails RetrievalQueryPlanV2's own semantic
-        checks (frozen-route/constraint-policy/validated-ref violations) gets
-        one re-grounding attempt against the dedicated .revise prompt --
-        never the generic SCHEMA_REPAIR path. If the revision also fails,
-        the error propagates to the caller's existing fail-closed handling.
-
-        G3: dedup via approve_semantic_revision -- a second occurrence of the
-        same normalized failure signature for this node, anywhere in the Run
-        (including after resume/checkpoint restore), is denied before any
-        Provider call and raises the same RetrievalV2ValidationError a failed
-        revision attempt would."""
+        """Bounded SEMANTIC_REVISION retry (max 1 per Node/Failure Signature)."""
         failure_code = "RETRIEVAL_QUERY_PLAN_SEMANTIC_INVALID"
         signature = build_semantic_failure_signature_v1(
             node_id="retrieval.plan_query",
@@ -149,12 +139,15 @@ class RetrievalQueryPlannerAgent:
             prompt_input={
                 "base_projection": dict(prompt_input),
                 "candidate_output": previous_output,
-                "failure_record": {
-                    "failure_reason_code": failure_code,
-                    "affected_fields": mutable_fields,
-                    "allowed_change_scope": mutable_fields,
-                    "validation_errors": [failure_detail],
-                },
+                "failure_record": build_failure_record_v1(
+                    failure_reason_code=failure_code,
+                    failure_origin="QUERY_PLANNING",
+                    detected_by="RUNTIME_DOMAIN_VALIDATOR",
+                    runtime_disposition="RETRYABLE",
+                    experiment_disposition="RUN_REVISION",
+                    affected_field_paths=mutable_fields,
+                    failure_context_ids=[failure_detail],
+                ),
             },
             output_schema=self._output_schema,
             trace_context=trace_context,

--- a/src/google_work_agent/application/workflows/tool_route_semantic.py
+++ b/src/google_work_agent/application/workflows/tool_route_semantic.py
@@ -5,9 +5,7 @@ semantic-candidate/tool-selection validation for Tool Route. Never assembles
 a final ``ToolRoutePlanV2`` and never binds a Registry tool on its own
 authority -- ``ToolRouteCoordinator`` (tool_routing.py) keeps sole ownership
 of deterministic registry binding, PolicyPreconditionResolver, validation,
-and freezing. This module supplies that coordinator with a
-``SemanticRouteCandidate`` and, only when the Registry has more than one
-eligible tool for a route, a Registry-validated tool selection.
+and freezing.
 """
 
 from __future__ import annotations
@@ -25,6 +23,7 @@ from google_work_agent.application.workflows.contracts import (
     approve_semantic_revision,
     build_semantic_failure_signature_v1,
 )
+from google_work_agent.application.workflows.failure_record import build_failure_record_v1
 from google_work_agent.application.workflows.handoff_contracts import RequestIntentV2
 from google_work_agent.application.workflows.prompt_registry import (
     default_prompt_manifest_path as _registry_default_prompt_manifest_path,
@@ -133,14 +132,7 @@ TOOL_SELECTION_OUTPUT_SCHEMA = OutputSchemaDefinition(
 
 
 class ToolRouteAgent:
-    """Own the Tool Route semantic candidate LLM stage.
-
-    Registry authority stays with ``ToolRouteCoordinator``: this Agent only
-    produces a semantic resource/effect candidate and, when the Registry
-    has more than one eligible tool for a route, a selection among those
-    Registry-validated candidates. It never assembles a final
-    ``ToolRoutePlanV2``.
-    """
+    """Own the Tool Route semantic candidate LLM stage."""
 
     def __init__(
         self,
@@ -231,7 +223,6 @@ class ToolRouteAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[Mapping[str, object], RunBudgetV1]:
-        """Bounded semantic revision using the frozen runtime envelope."""
         failure_code = "SEMANTIC_CANDIDATE_INVALID"
         signature = build_semantic_failure_signature_v1(
             node_id="tool_route.determine_io_resources",
@@ -254,12 +245,15 @@ class ToolRouteAgent:
             prompt_input={
                 "base_projection": dict(base_projection),
                 "candidate_output": previous_output,
-                "failure_record": {
-                    "failure_reason_code": failure_code,
-                    "affected_fields": mutable_fields,
-                    "allowed_change_scope": mutable_fields,
-                    "validation_errors": [failure_detail],
-                },
+                "failure_record": build_failure_record_v1(
+                    failure_reason_code=failure_code,
+                    failure_origin="LLM_OUTPUT",
+                    detected_by="RUNTIME_DOMAIN_VALIDATOR",
+                    runtime_disposition="RETRYABLE",
+                    experiment_disposition="RUN_REVISION",
+                    affected_field_paths=mutable_fields,
+                    failure_context_ids=[failure_detail],
+                ),
             },
             output_schema=ROUTE_RESOURCE_CANDIDATE_OUTPUT_SCHEMA,
             trace_context=ObservabilityContext(
@@ -328,14 +322,17 @@ class ToolRouteAgent:
             prompt_input={
                 "base_projection": dict(prompt_input),
                 "candidate_output": llm_result.structured_output,
-                "failure_record": {
-                    "failure_reason_code": failure_code,
-                    "affected_fields": mutable_fields,
-                    "allowed_change_scope": mutable_fields,
-                    "validation_errors": [
+                "failure_record": build_failure_record_v1(
+                    failure_reason_code=failure_code,
+                    failure_origin="LLM_OUTPUT",
+                    detected_by="RUNTIME_DOMAIN_VALIDATOR",
+                    runtime_disposition="RETRYABLE",
+                    experiment_disposition="RUN_REVISION",
+                    affected_field_paths=mutable_fields,
+                    failure_context_ids=[
                         "selected_tool_id is not a Registry-eligible candidate"
                     ],
-                },
+                ),
             },
             output_schema=TOOL_SELECTION_OUTPUT_SCHEMA,
             trace_context=ObservabilityContext(
@@ -426,7 +423,6 @@ def _eligible_route_capabilities(
 
 
 def _normalize_output_resource_type(coarse_resource: str, effect: EffectType) -> str:
-    """Expand a coarse output resource type using its paired effect."""
     if coarse_resource == "EMAIL":
         if effect is EffectType.SEND:
             return "GMAIL_MESSAGE"

--- a/src/google_work_agent/application/workflows/tool_route_semantic.py
+++ b/src/google_work_agent/application/workflows/tool_route_semantic.py
@@ -5,7 +5,9 @@ semantic-candidate/tool-selection validation for Tool Route. Never assembles
 a final ``ToolRoutePlanV2`` and never binds a Registry tool on its own
 authority -- ``ToolRouteCoordinator`` (tool_routing.py) keeps sole ownership
 of deterministic registry binding, PolicyPreconditionResolver, validation,
-and freezing.
+and freezing. This module supplies that coordinator with a
+``SemanticRouteCandidate`` and, only when the Registry has more than one
+eligible tool for a route, a Registry-validated tool selection.
 """
 
 from __future__ import annotations
@@ -32,8 +34,8 @@ from google_work_agent.application.workflows.prompt_registry import (
     load_prompt_reference as _load_registry_prompt_reference,
 )
 from google_work_agent.application.workflows.provider_dispatch_budget import (
-    bind_provider_dispatch_budget,
     legacy_post_call_projection,
+    provider_dispatch_budget_scope,
 )
 from google_work_agent.application.workflows.tool_routing import (
     SemanticRouteCandidate,
@@ -136,7 +138,14 @@ TOOL_SELECTION_OUTPUT_SCHEMA = OutputSchemaDefinition(
 
 
 class ToolRouteAgent:
-    """Own the Tool Route semantic candidate LLM stage."""
+    """Own the Tool Route semantic candidate LLM stage.
+
+    Registry authority stays with ``ToolRouteCoordinator``: this Agent only
+    produces a semantic resource/effect candidate and, when the Registry
+    has more than one eligible tool for a route, a selection among those
+    Registry-validated candidates. It never assembles a final
+    ``ToolRoutePlanV2``.
+    """
 
     def __init__(
         self,
@@ -179,7 +188,22 @@ class ToolRouteAgent:
         retry_budget: RunBudgetV1,
         confirmation_response: ConfirmationResponseV1 | None = None,
     ) -> tuple[SemanticRouteCandidate, RunBudgetV1]:
-        bind_provider_dispatch_budget(retry_budget)
+        with provider_dispatch_budget_scope(retry_budget):
+            return self._determine_semantic_candidate_scoped(
+                request_intent=request_intent,
+                request=request,
+                retry_budget=retry_budget,
+                confirmation_response=confirmation_response,
+            )
+
+    def _determine_semantic_candidate_scoped(
+        self,
+        *,
+        request_intent: RequestIntentV2,
+        request: WorkflowStartRequest,
+        retry_budget: RunBudgetV1,
+        confirmation_response: ConfirmationResponseV1 | None,
+    ) -> tuple[SemanticRouteCandidate, RunBudgetV1]:
         eligible_route_capabilities = _eligible_route_capabilities(self._tool_catalog)
         base_projection: dict[str, object] = {
             "request_intent": request_intent,
@@ -228,6 +252,7 @@ class ToolRouteAgent:
         failure_detail: str,
         retry_budget: RunBudgetV1,
     ) -> tuple[Mapping[str, object], RunBudgetV1]:
+        """Bounded semantic revision using the frozen runtime envelope."""
         failure_code = "SEMANTIC_CANDIDATE_INVALID"
         signature = build_semantic_failure_signature_v1(
             node_id="tool_route.determine_io_resources",
@@ -286,7 +311,28 @@ class ToolRouteAgent:
         request: WorkflowStartRequest,
         retry_budget: RunBudgetV1,
     ) -> tuple[str, RunBudgetV1]:
-        bind_provider_dispatch_budget(retry_budget)
+        with provider_dispatch_budget_scope(retry_budget):
+            return self._select_tool_if_needed_scoped(
+                route_id=route_id,
+                connector_id=connector_id,
+                resource_type=resource_type,
+                effect=effect,
+                eligible_tool_ids=eligible_tool_ids,
+                request=request,
+                retry_budget=retry_budget,
+            )
+
+    def _select_tool_if_needed_scoped(
+        self,
+        *,
+        route_id: str,
+        connector_id: str,
+        resource_type: str,
+        effect: str,
+        eligible_tool_ids: tuple[str, ...],
+        request: WorkflowStartRequest,
+        retry_budget: RunBudgetV1,
+    ) -> tuple[str, RunBudgetV1]:
         prompt_input = {
             "route_id": route_id,
             "connector_id": connector_id,
@@ -429,6 +475,7 @@ def _eligible_route_capabilities(
 
 
 def _normalize_output_resource_type(coarse_resource: str, effect: EffectType) -> str:
+    """Expand a coarse output resource type using its paired effect."""
     if coarse_resource == "EMAIL":
         if effect is EffectType.SEND:
             return "GMAIL_MESSAGE"

--- a/src/google_work_agent/application/workflows/tool_route_semantic.py
+++ b/src/google_work_agent/application/workflows/tool_route_semantic.py
@@ -31,6 +31,10 @@ from google_work_agent.application.workflows.prompt_registry import (
 from google_work_agent.application.workflows.prompt_registry import (
     load_prompt_reference as _load_registry_prompt_reference,
 )
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    bind_provider_dispatch_budget,
+    legacy_post_call_projection,
+)
 from google_work_agent.application.workflows.tool_routing import (
     SemanticRouteCandidate,
     ToolRouteValidationError,
@@ -175,6 +179,7 @@ class ToolRouteAgent:
         retry_budget: RunBudgetV1,
         confirmation_response: ConfirmationResponseV1 | None = None,
     ) -> tuple[SemanticRouteCandidate, RunBudgetV1]:
+        bind_provider_dispatch_budget(retry_budget)
         eligible_route_capabilities = _eligible_route_capabilities(self._tool_catalog)
         base_projection: dict[str, object] = {
             "request_intent": request_intent,
@@ -211,7 +216,7 @@ class ToolRouteAgent:
             )
         return (
             _semantic_candidate_from_llm_candidate(candidate, request_intent=request_intent),
-            retry_budget,
+            legacy_post_call_projection(retry_budget),
         )
 
     def _revise_semantic_candidate_once(
@@ -281,6 +286,7 @@ class ToolRouteAgent:
         request: WorkflowStartRequest,
         retry_budget: RunBudgetV1,
     ) -> tuple[str, RunBudgetV1]:
+        bind_provider_dispatch_budget(retry_budget)
         prompt_input = {
             "route_id": route_id,
             "connector_id": connector_id,
@@ -305,7 +311,7 @@ class ToolRouteAgent:
             llm_result.structured_output, eligible_tool_ids=eligible_tool_ids
         )
         if selected_tool_id is not None:
-            return selected_tool_id, retry_budget
+            return selected_tool_id, legacy_post_call_projection(retry_budget)
         failure_code = "TOOL_SELECTION_INVALID"
         signature = build_semantic_failure_signature_v1(
             node_id="tool_route.select_tool_if_needed",
@@ -351,7 +357,7 @@ class ToolRouteAgent:
             raise ToolRouteValidationError(
                 "selected tool is not a Registry-eligible candidate after revision"
             )
-        return revised_tool_id, decision["run_budget"]
+        return revised_tool_id, legacy_post_call_projection(decision["run_budget"])
 
     def _validated_tool_selection(
         self, value: object, *, eligible_tool_ids: tuple[str, ...]

--- a/tests/integration/langgraph/test_provider_dispatch_budget_checkpoint.py
+++ b/tests/integration/langgraph/test_provider_dispatch_budget_checkpoint.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TypedDict
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+from langgraph.graph import END, START, StateGraph
+
+from google_work_agent.adapters.langgraph.agent_kernel import (
+    consume_llm_call_budget,
+    ensure_llm_call_budget,
+)
+from google_work_agent.adapters.llm.prompt_input_guard import PromptInputGuardedProvider
+from google_work_agent.application.workflows.contracts import (
+    RunBudgetV1,
+    build_default_run_budget,
+    consume_llm_provider_calls,
+)
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    provider_dispatch_execution_scope,
+)
+from google_work_agent.ports import (
+    ActualRuntime,
+    OutputSchemaDefinition,
+    PromptReference,
+    ProviderResponsePayload,
+    RuntimePolicy,
+)
+
+
+class _BudgetState(TypedDict):
+    retry_budget: RunBudgetV1
+
+
+class _NoopValidator:
+    def validate(self, *, prompt_id: str, prompt_input: Mapping[str, object]) -> None:
+        del prompt_id, prompt_input
+
+
+class _Provider:
+    provider_name = "checkpoint-test"
+    runtime = ActualRuntime.API_LLM
+
+    def __init__(self, *, timeout: bool = False) -> None:
+        self.timeout = timeout
+        self.dispatches = 0
+
+    def invoke_structured(
+        self,
+        *,
+        prompt_ref: PromptReference,
+        prompt_input: Mapping[str, object],
+        output_schema: OutputSchemaDefinition,
+        runtime_policy: RuntimePolicy,
+        api_key: str | None,
+    ) -> ProviderResponsePayload:
+        del prompt_ref, prompt_input, output_schema, runtime_policy, api_key
+        self.dispatches += 1
+        if self.timeout:
+            raise TimeoutError("primary timeout after transport dispatch")
+        return ProviderResponsePayload(
+            content={"ok": True},
+            model="checkpoint-model",
+            provider_request_id="checkpoint-request",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+        )
+
+
+def _prompt_ref() -> PromptReference:
+    return PromptReference(
+        prompt_bundle_version="test",
+        prompt_id="checkpoint.test",
+        prompt_version="1",
+        content_hash="0" * 64,
+        agent_role="test",
+        subgraph_name="test",
+        node_name="dispatch",
+        node_state="INITIAL",
+        purpose="test",
+        input_schema_version="1",
+        output_schema_version="1",
+    )
+
+
+def _invoke(guarded: PromptInputGuardedProvider) -> None:
+    guarded.invoke_structured(
+        prompt_ref=_prompt_ref(),
+        prompt_input={},
+        output_schema=OutputSchemaDefinition(
+            schema_version="1",
+            json_schema={"type": "object"},
+        ),
+        runtime_policy=RuntimePolicy(),
+        api_key=None,
+    )
+
+
+def _compile_graph(
+    *,
+    checkpointer: SqliteSaver,
+    primary: PromptInputGuardedProvider,
+    fallback: PromptInputGuardedProvider,
+):
+    def dispatch_node(state: _BudgetState) -> _BudgetState:
+        ensure_llm_call_budget(state, provider_calls_requested=2)
+        try:
+            _invoke(primary)
+        except TimeoutError:
+            _invoke(fallback)
+        return {
+            "retry_budget": consume_llm_call_budget(state),
+        }
+
+    graph = StateGraph(_BudgetState)
+    graph.add_node("dispatch", dispatch_node)
+    graph.add_edge(START, "dispatch")
+    graph.add_edge("dispatch", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+def test_handled_primary_timeout_fallback_budget_survives_sqlite_checkpoint_reopen(
+    tmp_path: Path,
+) -> None:
+    checkpoint_path = tmp_path / "provider-budget-checkpoint.db"
+    primary_provider = _Provider(timeout=True)
+    fallback_provider = _Provider()
+    primary = PromptInputGuardedProvider(primary_provider, _NoopValidator())
+    fallback = PromptInputGuardedProvider(fallback_provider, _NoopValidator())
+
+    initial_budget = consume_llm_provider_calls(
+        build_default_run_budget(),
+        provider_calls_consumed=3,
+    )
+    config = {"configurable": {"thread_id": "provider-budget-thread"}}
+
+    connection = sqlite3.connect(checkpoint_path, check_same_thread=False)
+    try:
+        compiled = _compile_graph(
+            checkpointer=SqliteSaver(connection),
+            primary=primary,
+            fallback=fallback,
+        )
+        with provider_dispatch_execution_scope():
+            result = compiled.invoke({"retry_budget": initial_budget}, config=config)
+        assert result["retry_budget"]["llm_calls_used"] == 5
+    finally:
+        connection.close()
+
+    assert primary_provider.dispatches == 1
+    assert fallback_provider.dispatches == 1
+
+    reopened = sqlite3.connect(checkpoint_path, check_same_thread=False)
+    try:
+        restored = _compile_graph(
+            checkpointer=SqliteSaver(reopened),
+            primary=primary,
+            fallback=fallback,
+        ).get_state(config)
+        restored_budget = restored.values["retry_budget"]
+        assert restored_budget["llm_calls_used"] == 5
+    finally:
+        reopened.close()

--- a/tests/unit/test_failure_record_contract.py
+++ b/tests/unit/test_failure_record_contract.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from google_work_agent.application.workflows.failure_record import (
+    FAILURE_RECORD_FIELDS,
+    FailureRecordValidationError,
+    build_failure_record_v1,
+    validate_failure_record_v1,
+)
+from google_work_agent.application.workflows.prompt_input_contract import (
+    PromptInputContractError,
+    PromptRuntimeInputContractValidator,
+)
+
+
+def _record() -> dict[str, object]:
+    return build_failure_record_v1(
+        failure_reason_code="TOOL_SELECTION_INVALID",
+        failure_origin="LLM_OUTPUT",
+        detected_by="RUNTIME_DOMAIN_VALIDATOR",
+        runtime_disposition="RETRYABLE",
+        experiment_disposition="RUN_REVISION",
+        affected_field_paths=["$.selected_tool_id"],
+        evidence_refs=[],
+        failure_context_ids=["issue-1"],
+    )
+
+
+def test_failure_record_builder_emits_exact_canonical_schema() -> None:
+    record = _record()
+    assert set(record) == FAILURE_RECORD_FIELDS
+    assert record["schema_version"] == 1
+    assert record["failure_origin"] == "LLM_OUTPUT"
+    assert record["detected_by"] == "RUNTIME_DOMAIN_VALIDATOR"
+    assert record["affected_field_paths"] == ["$.selected_tool_id"]
+    assert "affected_fields" not in record
+    assert "allowed_change_scope" not in record
+    assert "validation_errors" not in record
+
+
+def test_failure_record_validator_rejects_bespoke_nested_field() -> None:
+    invalid = {**_record(), "validation_errors": ["bad"]}
+    with pytest.raises(FailureRecordValidationError, match="exact schema mismatch"):
+        validate_failure_record_v1(invalid)
+
+
+def test_prompt_input_guard_validates_nested_failure_record_exactly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    prompt_dir = repo / "prompts" / "agent"
+    contract_dir = prompt_dir / "contracts"
+    contract_dir.mkdir(parents=True)
+    manifest_path = prompt_dir / "prompt-manifest-v1.json"
+    contract_path = contract_dir / "runtime-input-v1.json"
+    manifest_path.write_text(
+        json.dumps({"runtime_input_contract": "prompts/agent/contracts/runtime-input-v1.json"}),
+        encoding="utf-8",
+    )
+    contract_path.write_text(
+        json.dumps(
+            {
+                "forbidden_runtime_fields": [],
+                "slots": {
+                    "tool_route.select_tool_if_needed.revise": {
+                        "allowed_root_fields": [
+                            "base_projection",
+                            "candidate_output",
+                            "failure_record",
+                        ]
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    validator = PromptRuntimeInputContractValidator(manifest_path=manifest_path)
+    valid_input = {
+        "base_projection": {},
+        "candidate_output": {},
+        "failure_record": _record(),
+    }
+    validator.validate(
+        prompt_id="tool_route.select_tool_if_needed.revise",
+        prompt_input=valid_input,
+    )
+
+    invalid_input = {
+        **valid_input,
+        "failure_record": {**_record(), "review_issue_ids": ["issue-1"]},
+    }
+    with pytest.raises(PromptInputContractError, match="failure_record is invalid"):
+        validator.validate(
+            prompt_id="tool_route.select_tool_if_needed.revise",
+            prompt_input=invalid_input,
+        )

--- a/tests/unit/test_provider_dispatch_accounting.py
+++ b/tests/unit/test_provider_dispatch_accounting.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+from google_work_agent.adapters.llm.prompt_input_guard import PromptInputGuardedProvider
+from google_work_agent.application.workflows.contracts import build_default_run_budget
+from google_work_agent.application.workflows.provider_dispatch_budget import (
+    bind_provider_dispatch_budget,
+)
+from google_work_agent.ports import (
+    ActualRuntime,
+    LLMToolCall,
+    OutputSchemaDefinition,
+    PromptReference,
+    ProviderResponsePayload,
+    RuntimePolicy,
+    ToolCallProviderResponse,
+    ToolDefinition,
+)
+
+
+class _RecordingValidator:
+    def __init__(self) -> None:
+        self.inputs: list[Mapping[str, object]] = []
+
+    def validate(self, *, prompt_id: str, prompt_input: Mapping[str, object]) -> None:
+        del prompt_id
+        self.inputs.append(prompt_input)
+
+
+class _FakeProvider:
+    provider_name = "fake"
+    runtime = ActualRuntime.API_LLM
+
+    def __init__(self, *, fail_structured: bool = False, fail_tool: bool = False) -> None:
+        self.fail_structured = fail_structured
+        self.fail_tool = fail_tool
+        self.structured_dispatches = 0
+        self.tool_dispatches = 0
+
+    def invoke_structured(
+        self,
+        *,
+        prompt_ref: PromptReference,
+        prompt_input: Mapping[str, object],
+        output_schema: OutputSchemaDefinition,
+        runtime_policy: RuntimePolicy,
+        api_key: str | None,
+    ) -> ProviderResponsePayload:
+        del prompt_ref, prompt_input, output_schema, runtime_policy, api_key
+        self.structured_dispatches += 1
+        if self.fail_structured:
+            raise TimeoutError("provider timeout after dispatch")
+        return ProviderResponsePayload(
+            content={"ok": True},
+            model="fake-model",
+            provider_request_id="request-1",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+        )
+
+    def invoke_tool_call(
+        self,
+        *,
+        prompt_ref: PromptReference,
+        prompt_input: Mapping[str, object],
+        tools: Sequence[ToolDefinition],
+        runtime_policy: RuntimePolicy,
+        api_key: str | None,
+    ) -> ToolCallProviderResponse:
+        del prompt_ref, prompt_input, tools, runtime_policy, api_key
+        self.tool_dispatches += 1
+        if self.fail_tool:
+            raise TimeoutError("tool provider timeout after dispatch")
+        return ToolCallProviderResponse(
+            calls=(LLMToolCall(name="fake_tool", arguments={}),),
+            model="fake-model",
+            provider_request_id="request-tool-1",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+        )
+
+
+def _prompt_ref(prompt_id: str = "test.slot") -> PromptReference:
+    return PromptReference(
+        prompt_bundle_version="test",
+        prompt_id=prompt_id,
+        prompt_version="1",
+        content_hash="0" * 64,
+        agent_role="test",
+        subgraph_name="test",
+        node_name="test",
+        node_state="INITIAL",
+        purpose="test",
+        input_schema_version="1",
+        output_schema_version="1",
+    )
+
+
+def _schema() -> OutputSchemaDefinition:
+    return OutputSchemaDefinition(schema_version="1", json_schema={"type": "object"})
+
+
+def _invoke_structured(guarded: PromptInputGuardedProvider, *, prompt_input=None) -> None:
+    guarded.invoke_structured(
+        prompt_ref=_prompt_ref(),
+        prompt_input={} if prompt_input is None else prompt_input,
+        output_schema=_schema(),
+        runtime_policy=RuntimePolicy(),
+        api_key=None,
+    )
+
+
+def test_failed_primary_dispatch_is_counted_before_timeout() -> None:
+    budget = build_default_run_budget()
+    bind_provider_dispatch_budget(budget)
+    provider = _FakeProvider(fail_structured=True)
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with pytest.raises(TimeoutError, match="provider timeout"):
+        _invoke_structured(guarded)
+
+    assert provider.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 1
+
+
+def test_failed_primary_plus_successful_fallback_counts_two_dispatches() -> None:
+    budget = build_default_run_budget()
+    bind_provider_dispatch_budget(budget)
+    primary = _FakeProvider(fail_structured=True)
+    fallback = _FakeProvider()
+    primary_guard = PromptInputGuardedProvider(primary, _RecordingValidator())
+    fallback_guard = PromptInputGuardedProvider(fallback, _RecordingValidator())
+
+    with pytest.raises(TimeoutError):
+        _invoke_structured(primary_guard)
+    _invoke_structured(fallback_guard)
+
+    assert primary.structured_dispatches == 1
+    assert fallback.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 2
+
+
+def test_failed_schema_repair_dispatch_counts_and_uses_canonical_failure_record() -> None:
+    budget = build_default_run_budget()
+    bind_provider_dispatch_budget(budget)
+    initial = _FakeProvider()
+    repair = _FakeProvider(fail_structured=True)
+    initial_guard = PromptInputGuardedProvider(initial, _RecordingValidator())
+    validator = _RecordingValidator()
+    repair_guard = PromptInputGuardedProvider(repair, validator)
+
+    _invoke_structured(initial_guard)
+    legacy_repair_input = {
+        "base_projection": {"request_intent": {}},
+        "candidate_output": {"bad": True},
+        "failure_record": {
+            "schema_version": 1,
+            "failure_id": "repair-1",
+            "failure_reason_code": "OUTPUT_SCHEMA_INVALID",
+            "failure_origin": "RUNTIME",
+            "detected_by": "STRUCTURED_OUTPUT_VALIDATOR",
+            "runtime_disposition": "RETRYABLE",
+            "experiment_disposition": "RUN_REPAIR",
+            "affected_field_paths": ["$.bad"],
+            "evidence_refs": [],
+        },
+    }
+    with pytest.raises(TimeoutError, match="provider timeout"):
+        _invoke_structured(repair_guard, prompt_input=legacy_repair_input)
+
+    assert initial.structured_dispatches == 1
+    assert repair.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 2
+    normalized = validator.inputs[-1]["failure_record"]
+    assert isinstance(normalized, Mapping)
+    assert normalized["failure_origin"] == "LLM_OUTPUT"
+    assert normalized["detected_by"] == "RUNTIME_SCHEMA_VALIDATOR"
+    assert set(normalized) == {
+        "schema_version",
+        "failure_id",
+        "failure_reason_code",
+        "failure_origin",
+        "detected_by",
+        "runtime_disposition",
+        "experiment_disposition",
+        "affected_field_paths",
+        "evidence_refs",
+    }
+
+
+def test_failed_tool_call_dispatch_is_counted() -> None:
+    budget = build_default_run_budget()
+    bind_provider_dispatch_budget(budget)
+    provider = _FakeProvider(fail_tool=True)
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with pytest.raises(TimeoutError, match="tool provider timeout"):
+        guarded.invoke_tool_call(
+            prompt_ref=_prompt_ref(),
+            prompt_input={},
+            tools=(ToolDefinition(name="fake_tool", description="fake", parameters={}),),
+            runtime_policy=RuntimePolicy(),
+            api_key=None,
+        )
+
+    assert provider.tool_dispatches == 1
+    assert budget["llm_calls_used"] == 1

--- a/tests/unit/test_provider_dispatch_accounting.py
+++ b/tests/unit/test_provider_dispatch_accounting.py
@@ -5,9 +5,15 @@ from collections.abc import Mapping, Sequence
 import pytest
 
 from google_work_agent.adapters.llm.prompt_input_guard import PromptInputGuardedProvider
-from google_work_agent.application.workflows.contracts import build_default_run_budget
+from google_work_agent.application.workflows.contracts import (
+    build_default_run_budget,
+    consume_llm_provider_calls,
+)
 from google_work_agent.application.workflows.provider_dispatch_budget import (
-    bind_provider_dispatch_budget,
+    current_provider_dispatch_budget,
+    legacy_post_call_projection,
+    provider_dispatch_budget_scope,
+    provider_dispatch_execution_scope,
 )
 from google_work_agent.ports import (
     ActualRuntime,
@@ -105,7 +111,9 @@ def _schema() -> OutputSchemaDefinition:
     return OutputSchemaDefinition(schema_version="1", json_schema={"type": "object"})
 
 
-def _invoke_structured(guarded: PromptInputGuardedProvider, *, prompt_input=None) -> None:
+def _invoke_structured(
+    guarded: PromptInputGuardedProvider, *, prompt_input: Mapping[str, object] | None = None
+) -> None:
     guarded.invoke_structured(
         prompt_ref=_prompt_ref(),
         prompt_input={} if prompt_input is None else prompt_input,
@@ -115,47 +123,18 @@ def _invoke_structured(guarded: PromptInputGuardedProvider, *, prompt_input=None
     )
 
 
-def test_failed_primary_dispatch_is_counted_before_timeout() -> None:
-    budget = build_default_run_budget()
-    bind_provider_dispatch_budget(budget)
-    provider = _FakeProvider(fail_structured=True)
-    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
-
-    with pytest.raises(TimeoutError, match="provider timeout"):
-        _invoke_structured(guarded)
-
-    assert provider.structured_dispatches == 1
-    assert budget["llm_calls_used"] == 1
+def _invoke_tool(guarded: PromptInputGuardedProvider) -> None:
+    guarded.invoke_tool_call(
+        prompt_ref=_prompt_ref(),
+        prompt_input={},
+        tools=(ToolDefinition(name="fake_tool", description="fake", parameters={}),),
+        runtime_policy=RuntimePolicy(),
+        api_key=None,
+    )
 
 
-def test_failed_primary_plus_successful_fallback_counts_two_dispatches() -> None:
-    budget = build_default_run_budget()
-    bind_provider_dispatch_budget(budget)
-    primary = _FakeProvider(fail_structured=True)
-    fallback = _FakeProvider()
-    primary_guard = PromptInputGuardedProvider(primary, _RecordingValidator())
-    fallback_guard = PromptInputGuardedProvider(fallback, _RecordingValidator())
-
-    with pytest.raises(TimeoutError):
-        _invoke_structured(primary_guard)
-    _invoke_structured(fallback_guard)
-
-    assert primary.structured_dispatches == 1
-    assert fallback.structured_dispatches == 1
-    assert budget["llm_calls_used"] == 2
-
-
-def test_failed_schema_repair_dispatch_counts_and_uses_canonical_failure_record() -> None:
-    budget = build_default_run_budget()
-    bind_provider_dispatch_budget(budget)
-    initial = _FakeProvider()
-    repair = _FakeProvider(fail_structured=True)
-    initial_guard = PromptInputGuardedProvider(initial, _RecordingValidator())
-    validator = _RecordingValidator()
-    repair_guard = PromptInputGuardedProvider(repair, validator)
-
-    _invoke_structured(initial_guard)
-    legacy_repair_input = {
+def _legacy_repair_input() -> dict[str, object]:
+    return {
         "base_projection": {"request_intent": {}},
         "candidate_output": {"bad": True},
         "failure_record": {
@@ -170,8 +149,61 @@ def test_failed_schema_repair_dispatch_counts_and_uses_canonical_failure_record(
             "evidence_refs": [],
         },
     }
-    with pytest.raises(TimeoutError, match="provider timeout"):
-        _invoke_structured(repair_guard, prompt_input=legacy_repair_input)
+
+
+def test_primary_success_counts_one_dispatch() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider()
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        _invoke_structured(guarded)
+
+    assert provider.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 1
+
+
+def test_failed_primary_dispatch_is_counted_before_timeout() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider(fail_structured=True)
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        with pytest.raises(TimeoutError, match="provider timeout"):
+            _invoke_structured(guarded)
+
+    assert provider.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 1
+
+
+def test_failed_primary_plus_successful_fallback_counts_two_dispatches() -> None:
+    budget = build_default_run_budget()
+    primary = _FakeProvider(fail_structured=True)
+    fallback = _FakeProvider()
+    primary_guard = PromptInputGuardedProvider(primary, _RecordingValidator())
+    fallback_guard = PromptInputGuardedProvider(fallback, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        with pytest.raises(TimeoutError):
+            _invoke_structured(primary_guard)
+        _invoke_structured(fallback_guard)
+
+    assert primary.structured_dispatches == 1
+    assert fallback.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 2
+
+
+def test_schema_repair_success_counts_two_dispatches_and_canonicalizes_failure_record() -> None:
+    budget = build_default_run_budget()
+    initial = _FakeProvider()
+    repair = _FakeProvider()
+    initial_guard = PromptInputGuardedProvider(initial, _RecordingValidator())
+    validator = _RecordingValidator()
+    repair_guard = PromptInputGuardedProvider(repair, validator)
+
+    with provider_dispatch_budget_scope(budget):
+        _invoke_structured(initial_guard)
+        _invoke_structured(repair_guard, prompt_input=_legacy_repair_input())
 
     assert initial.structured_dispatches == 1
     assert repair.structured_dispatches == 1
@@ -193,20 +225,120 @@ def test_failed_schema_repair_dispatch_counts_and_uses_canonical_failure_record(
     }
 
 
-def test_failed_tool_call_dispatch_is_counted() -> None:
+def test_failed_schema_repair_dispatch_counts_two() -> None:
     budget = build_default_run_budget()
-    bind_provider_dispatch_budget(budget)
-    provider = _FakeProvider(fail_tool=True)
+    initial = _FakeProvider()
+    repair = _FakeProvider(fail_structured=True)
+    initial_guard = PromptInputGuardedProvider(initial, _RecordingValidator())
+    repair_guard = PromptInputGuardedProvider(repair, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        _invoke_structured(initial_guard)
+        with pytest.raises(TimeoutError, match="provider timeout"):
+            _invoke_structured(repair_guard, prompt_input=_legacy_repair_input())
+
+    assert initial.structured_dispatches == 1
+    assert repair.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 2
+
+
+def test_tool_call_success_counts_one_dispatch() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider()
     guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
 
-    with pytest.raises(TimeoutError, match="tool provider timeout"):
-        guarded.invoke_tool_call(
-            prompt_ref=_prompt_ref(),
-            prompt_input={},
-            tools=(ToolDefinition(name="fake_tool", description="fake", parameters={}),),
-            runtime_policy=RuntimePolicy(),
-            api_key=None,
-        )
+    with provider_dispatch_budget_scope(budget):
+        _invoke_tool(guarded)
 
     assert provider.tool_dispatches == 1
     assert budget["llm_calls_used"] == 1
+
+
+def test_failed_tool_call_dispatch_is_counted() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider(fail_tool=True)
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        with pytest.raises(TimeoutError, match="tool provider timeout"):
+            _invoke_tool(guarded)
+
+    assert provider.tool_dispatches == 1
+    assert budget["llm_calls_used"] == 1
+
+
+def test_tool_call_repair_counts_each_actual_dispatch() -> None:
+    budget = build_default_run_budget()
+    initial = _FakeProvider()
+    repair = _FakeProvider()
+    initial_guard = PromptInputGuardedProvider(initial, _RecordingValidator())
+    repair_guard = PromptInputGuardedProvider(repair, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        _invoke_tool(initial_guard)
+        _invoke_tool(repair_guard)
+
+    assert initial.tool_dispatches + repair.tool_dispatches == 2
+    assert budget["llm_calls_used"] == 2
+
+
+def test_execution_scope_clears_budget_after_success_and_unrelated_probe_is_unaccounted() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider()
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with provider_dispatch_execution_scope():
+        with provider_dispatch_budget_scope(budget):
+            _invoke_structured(guarded)
+        assert current_provider_dispatch_budget() is None
+
+    assert current_provider_dispatch_budget() is None
+    _invoke_structured(guarded)
+    assert provider.structured_dispatches == 2
+    assert budget["llm_calls_used"] == 1
+
+
+def test_execution_scope_clears_budget_after_escaping_provider_error() -> None:
+    budget = build_default_run_budget()
+    provider = _FakeProvider(fail_structured=True)
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with pytest.raises(TimeoutError, match="provider timeout"):
+        with provider_dispatch_execution_scope():
+            with provider_dispatch_budget_scope(budget):
+                _invoke_structured(guarded)
+
+    assert provider.structured_dispatches == 1
+    assert budget["llm_calls_used"] == 1
+    assert current_provider_dispatch_budget() is None
+
+
+@pytest.mark.parametrize(
+    ("case_name", "dispatches"),
+    [
+        ("initial_only", 1),
+        ("initial_plus_schema_repair", 2),
+        ("initial_plus_semantic_revision", 2),
+        ("initial_plus_repair_plus_semantic_revision_and_repair", 4),
+    ],
+)
+def test_legacy_tool_route_post_call_bridge_preserves_actual_dispatch_count(
+    case_name: str,
+    dispatches: int,
+) -> None:
+    del case_name
+    budget = build_default_run_budget()
+    provider = _FakeProvider()
+    guarded = PromptInputGuardedProvider(provider, _RecordingValidator())
+
+    with provider_dispatch_budget_scope(budget):
+        for _ in range(dispatches):
+            _invoke_structured(guarded)
+        compatibility_projection = legacy_post_call_projection(budget)
+
+    final_budget = consume_llm_provider_calls(
+        compatibility_projection,
+        provider_calls_consumed=1,
+    )
+    assert provider.structured_dispatches == dispatches
+    assert final_budget["llm_calls_used"] == dispatches


### PR DESCRIPTION
## Scope

Implements Agent 3 Wave 1C only:
- IMP-134 Tool Route semantic revision FailureRecord
- IMP-135 Retrieval Query semantic revision FailureRecord
- IMP-136 Retrieval Evidence semantic revision FailureRecord
- IMP-137 Planning Argument semantic revision FailureRecord
- IMP-139 provider-dispatch RunBudget accounting + durability follow-up

Explicitly does not modify IMP-130~133 Runtime V2 Agent work.

## FailureRecord contract

- One canonical typed `FailureRecordV1` projector/validator.
- Revision Product Prompt roots remain exactly `base_projection`, `candidate_output`, `failure_record`.
- Prompt Input Guard validates the nested FailureRecord exact schema.
- Generic Schema Repair outer IMP-138 envelope remains unchanged; its historical nested enum aliases are normalized at the guarded-provider boundary through the canonical projector.

## Provider accounting authority

- Actual consumption occurs at `PromptInputGuardedProvider` immediately after local prompt validation and immediately before the real provider delegate dispatch.
- Primary, fallback, schema-repair, tool-call, and tool-call-repair dispatches are therefore counted independently; a timeout/error after dispatch still consumes one call.
- `RunBudgetV1.llm_calls_used` remains the sole numeric/durable authority. No process-local numeric counter was added.
- `WorkflowInvocationCoordinator.start/resume/recover_open_run` now use a bounded provider-dispatch execution scope so stale ContextVar budget references are cleared on success and escaping exceptions.
- Tool Route's legacy post-call +1 bridge remains compatibility-only and Tool Route now wraps its own semantic invocation in a bounded budget scope with token reset.

## Durability evidence added

- Compiled `StateGraph` + `SqliteSaver` regression: starting from N=3, primary dispatch times out, fallback dispatch succeeds, state returns with N+2=5, SQLite connection is closed/reopened, and restored checkpoint budget remains 5.
- Production coordinator already terminalizes exceptions escaping the workflow runtime as durable `FAILED`, so an escaped provider exception has no same-Run retry/resume continuation. Retry/fallback/repair paths that recover inside the node are covered separately by the checkpoint regression.

## Dispatch regression tests added/expanded

- primary success = 1
- primary timeout = 1
- primary timeout + fallback success = 2
- initial + schema repair success = 2
- initial + schema repair timeout = 2
- tool-call success = 1
- tool-call timeout = 1
- tool-call initial + repair = actual dispatch count
- ContextVar cleanup after success and escaping provider error
- Tool Route compatibility bridge: initial only / repair / semantic revision / repair+revision combinations preserve final `llm_calls_used == actual provider dispatches`
- canonical FailureRecord exact schema and nested guard rejection

## Diff hygiene

Restored explanatory comments/docstrings that had been removed incidentally from Context Retrieval, Retrieval Query, Tool Route, and Prompt Input Guard. Production diff is limited to Wave 1C contracts/accounting plus invocation-scope durability wiring.

## Test/CI status

Tests are committed, but no GitHub Actions workflow run or commit status check exists for the current head. Do not treat this PR as test-PASS yet. PR remains Draft and unmerged pending an executable test gate.