### PR TITLE
refactor: close pre-gate use-case grammar gaps

### DIFF
--- a/src/google_work_agent/application/use_cases/action/cancel_pending_action.py
+++ b/src/google_work_agent/application/use_cases/action/cancel_pending_action.py
@@ -1,10 +1,11 @@
 """Application boundary for pending Action cancellation authorization."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.action.transitions.cancel_pending_action import transition_cancel_pending_action
 from google_work_agent.domain.commands import ActionCommand
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
+from google_work_agent.domain.enums import ActionStatus, EffectType, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class CancelPendingActionCommand:
@@ -13,8 +14,30 @@ class CancelPendingActionCommand:
     expected_version: int
     effect_type: EffectType
 
-CancelPendingActionResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class CancelPendingActionResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class CancelPendingActionHandler:
     def __call__(self, command: CancelPendingActionCommand) -> CancelPendingActionResult:
-        return transition_cancel_pending_action(command.current_status, command.current_version, command.expected_version, effect_type=command.effect_type)
+        result = transition_cancel_pending_action(
+            command.current_status,
+            command.current_version,
+            command.expected_version,
+            effect_type=command.effect_type,
+        )
+        return CancelPendingActionResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/action/modify_action.py
+++ b/src/google_work_agent/application/use_cases/action/modify_action.py
@@ -1,10 +1,11 @@
 """Application boundary for Action modification authorization."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.action.transitions.modify_action import transition_modify_action
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
 from google_work_agent.domain.commands import ActionCommand
+from google_work_agent.domain.enums import ActionStatus, EffectType, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class ModifyActionCommand:
@@ -13,8 +14,30 @@ class ModifyActionCommand:
     expected_version: int
     effect_type: EffectType
 
-ModifyActionResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class ModifyActionResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class ModifyActionHandler:
     def __call__(self, command: ModifyActionCommand) -> ModifyActionResult:
-        return transition_modify_action(command.current_status, command.current_version, command.expected_version, effect_type=command.effect_type)
+        result = transition_modify_action(
+            command.current_status,
+            command.current_version,
+            command.expected_version,
+            effect_type=command.effect_type,
+        )
+        return ModifyActionResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/action/prepare_write_retry.py
+++ b/src/google_work_agent/application/use_cases/action/prepare_write_retry.py
@@ -1,10 +1,11 @@
 """Application boundary for FAILED write retry preparation."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.action.transitions.prepare_write_retry import transition_prepare_write_retry
 from google_work_agent.domain.commands import ActionCommand
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
+from google_work_agent.domain.enums import ActionStatus, EffectType, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class PrepareWriteRetryCommand:
@@ -13,8 +14,30 @@ class PrepareWriteRetryCommand:
     expected_version: int
     effect_type: EffectType
 
-PrepareWriteRetryResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class PrepareWriteRetryResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class PrepareWriteRetryHandler:
     def __call__(self, command: PrepareWriteRetryCommand) -> PrepareWriteRetryResult:
-        return transition_prepare_write_retry(command.current_status, command.current_version, command.expected_version, effect_type=command.effect_type)
+        result = transition_prepare_write_retry(
+            command.current_status,
+            command.current_version,
+            command.expected_version,
+            effect_type=command.effect_type,
+        )
+        return PrepareWriteRetryResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/action/reject_action.py
+++ b/src/google_work_agent/application/use_cases/action/reject_action.py
@@ -1,10 +1,11 @@
 """Application boundary for Action rejection authorization."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.action.transitions.reject_action import transition_reject_action
 from google_work_agent.domain.commands import ActionCommand
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
+from google_work_agent.domain.enums import ActionStatus, EffectType, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class RejectActionCommand:
@@ -13,8 +14,30 @@ class RejectActionCommand:
     expected_version: int
     effect_type: EffectType
 
-RejectActionResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class RejectActionResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class RejectActionHandler:
     def __call__(self, command: RejectActionCommand) -> RejectActionResult:
-        return transition_reject_action(command.current_status, command.current_version, command.expected_version, effect_type=command.effect_type)
+        result = transition_reject_action(
+            command.current_status,
+            command.current_version,
+            command.expected_version,
+            effect_type=command.effect_type,
+        )
+        return RejectActionResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/approval/approve_action.py
+++ b/src/google_work_agent/application/use_cases/approval/approve_action.py
@@ -1,10 +1,11 @@
 """Application boundary for explicit Action approval authorization."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.approval.transitions.approve_action import transition_approve_action
 from google_work_agent.domain.commands import ActionCommand
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
+from google_work_agent.domain.enums import ActionStatus, EffectType, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class ApproveActionCommand:
@@ -14,8 +15,31 @@ class ApproveActionCommand:
     effect_type: EffectType
     plan_review_passed: bool
 
-ApproveActionResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class ApproveActionResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class ApproveActionHandler:
     def __call__(self, command: ApproveActionCommand) -> ApproveActionResult:
-        return transition_approve_action(command.current_status, command.current_version, command.expected_version, effect_type=command.effect_type, plan_review_passed=command.plan_review_passed)
+        result = transition_approve_action(
+            command.current_status,
+            command.current_version,
+            command.expected_version,
+            effect_type=command.effect_type,
+            plan_review_passed=command.plan_review_passed,
+        )
+        return ApproveActionResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/claim/claim_execution.py
+++ b/src/google_work_agent/application/use_cases/claim/claim_execution.py
@@ -1,21 +1,49 @@
 """Application boundary for durable write execution claims."""
 
 from dataclasses import dataclass
+
 from google_work_agent.domain.claim.guards.claim_execution import ClaimExecutionGuardInput, guard_claim_execution
 from google_work_agent.domain.claim.transitions.claim_execution import transition_claim_execution
 from google_work_agent.domain.commands import ActionCommand
-from google_work_agent.domain.enums import ActionStatus, EffectType
-from google_work_agent.domain.results import CommandResult
+from google_work_agent.domain.enums import ActionStatus, ResultCode
+
 
 @dataclass(frozen=True, slots=True)
 class ClaimExecutionCommand:
     guard: ClaimExecutionGuardInput
     expected_version: int
 
-ClaimExecutionResult = CommandResult[ActionStatus, ActionCommand]
+
+@dataclass(frozen=True, slots=True)
+class ClaimExecutionResult:
+    applied: bool
+    result_code: ResultCode
+    current_status: ActionStatus
+    current_version: int
+    next_allowed_commands: tuple[ActionCommand, ...]
+    conflict_detail: str | None = None
+
 
 class ClaimExecutionHandler:
-    """Authorize the domain claim. Persistence must atomically consume Approval and insert Attempt."""
+    """Authorize the domain claim.
+
+    Durable Approval consumption and ExecutionAttempt insertion remain the
+    persistence Closure responsibility; this boundary does not dispatch writes.
+    """
+
     def __call__(self, command: ClaimExecutionCommand) -> ClaimExecutionResult:
         guard_claim_execution(command.guard)
-        return transition_claim_execution(command.guard.action_status, command.guard.action_version, command.expected_version, effect_type=command.guard.effect_type)
+        result = transition_claim_execution(
+            command.guard.action_status,
+            command.guard.action_version,
+            command.expected_version,
+            effect_type=command.guard.effect_type,
+        )
+        return ClaimExecutionResult(
+            applied=result.applied,
+            result_code=result.result_code,
+            current_status=result.current_status,
+            current_version=result.current_version,
+            next_allowed_commands=result.next_allowed_commands,
+            conflict_detail=result.conflict_detail,
+        )

--- a/src/google_work_agent/application/use_cases/execution_attempt/execute_action.py
+++ b/src/google_work_agent/application/use_cases/execution_attempt/execute_action.py
@@ -4,21 +4,47 @@ from __future__ import annotations
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from json import loads
 
 from google_work_agent.application.ports import ConnectorExecutionPort, ConnectorWriteRequest
 from google_work_agent.application.write_action_arguments import coerce_int
-from google_work_agent.application.write_execution_contracts import ExecutedWriteActionResult
 from google_work_agent.application.write_execution_integrity import read_claim_token
-from google_work_agent.application.write_persistence import require_action, require_approval, require_attempt, require_plan, require_run
+from google_work_agent.application.write_persistence import (
+    require_action,
+    require_approval,
+    require_attempt,
+    require_plan,
+    require_run,
+)
 from google_work_agent.domain import ExecutionAttemptStatus, RunStatus, calculate_canonical_json_hash
-from google_work_agent.ports import UnitOfWork
+from google_work_agent.ports import ResourceSnapshot, UnitOfWork
+
+
+@dataclass(frozen=True, slots=True)
+class ExecuteActionCommand:
+    action_id: str
+    claim_token: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExecuteActionResult:
+    snapshot: ResourceSnapshot
+    response_metadata_json: str
 
 
 class ExecuteActionHandler:
     """Execute a claimed action; this handler never creates or acquires a claim."""
 
-    def __init__(self, *, unit_of_work_factory: Callable[[], UnitOfWork], connector_execution: ConnectorExecutionPort, now_ms: Callable[[], int], signing_secret: str, service_instance_id: str) -> None:
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: Callable[[], UnitOfWork],
+        connector_execution: ConnectorExecutionPort,
+        now_ms: Callable[[], int],
+        signing_secret: str,
+        service_instance_id: str,
+    ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._connector_execution = connector_execution
         self._now_ms = now_ms
@@ -27,17 +53,21 @@ class ExecuteActionHandler:
         self._used_nonces: set[str] = set()
         self._nonce_lock = threading.Lock()
 
-    def __call__(self, *, action_id: str, claim_token: str) -> ExecutedWriteActionResult:
+    def __call__(self, command: ExecuteActionCommand) -> ExecuteActionResult:
+        action_id = command.action_id
+        claim_token = command.claim_token
         payload = read_claim_token(claim_token, signing_secret=self._signing_secret)
         if str(payload["service_instance_id"]) != self._service_instance_id:
             raise PermissionError("claim token service binding mismatch")
         if self._now_ms() >= coerce_int(payload["expires_at_ms"]):
             raise PermissionError("claim token has expired")
+
         nonce = str(payload["nonce"])
         with self._nonce_lock:
             if nonce in self._used_nonces:
                 raise PermissionError("claim token has already been used")
             self._used_nonces.add(nonce)
+
         try:
             with self._unit_of_work_factory() as unit_of_work:
                 action = require_action(unit_of_work, action_id)
@@ -59,6 +89,18 @@ class ExecuteActionHandler:
             with self._nonce_lock:
                 self._used_nonces.discard(nonce)
             raise
-        prepared = self._connector_execution.prepare_write(tool_name=action.tool_name, arguments=loads(action.arguments_json), recovery_fingerprint=approval.recovery_fingerprint)
-        snapshot = self._connector_execution.execute_write(ConnectorWriteRequest(prepared=prepared, claim_payload=payload, approval_arguments_hash=action.arguments_hash, execution_arguments_hash=calculate_canonical_json_hash(prepared.arguments)))
-        return ExecutedWriteActionResult(snapshot=snapshot, response_metadata_json="")
+
+        prepared = self._connector_execution.prepare_write(
+            tool_name=action.tool_name,
+            arguments=loads(action.arguments_json),
+            recovery_fingerprint=approval.recovery_fingerprint,
+        )
+        snapshot = self._connector_execution.execute_write(
+            ConnectorWriteRequest(
+                prepared=prepared,
+                claim_payload=payload,
+                approval_arguments_hash=action.arguments_hash,
+                execution_arguments_hash=calculate_canonical_json_hash(prepared.arguments),
+            )
+        )
+        return ExecuteActionResult(snapshot=snapshot, response_metadata_json="")

--- a/src/google_work_agent/application/use_cases/recovery/recover_create.py
+++ b/src/google_work_agent/application/use_cases/recovery/recover_create.py
@@ -1,28 +1,102 @@
 """Recover an uncertain CREATE without dispatching a new write."""
 
 from __future__ import annotations
+
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from google_work_agent.application.ports import ConnectorExecutionPort
 from google_work_agent.application.write_execution_contracts import WriteActionResponse
 from google_work_agent.application.write_persistence import require_action, require_approval, require_attempt
-from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand, RecoverUnknownCreateActionCommand
+from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand
 from google_work_agent.domain import ResultCode
 from google_work_agent.ports import UnitOfWork
 
 
+@dataclass(frozen=True, slots=True)
+class RecoverCreateCommand:
+    command_id: str
+    request_hash: str
+    action_id: str
+    attempt_id: str
+    expected_action_version: int
+    expected_attempt_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverCreateResult:
+    applied: bool
+    result_code: str
+    action_id: str
+    action_status: str
+    action_version: int
+    next_allowed_commands: tuple[str, ...]
+    approval_id: str | None = None
+    attempt_id: str | None = None
+    claim_token: str | None = None
+    safe_error_code: str | None = None
+    conflict_detail: str | None = None
+
+
+def _to_result(response: WriteActionResponse) -> RecoverCreateResult:
+    return RecoverCreateResult(
+        applied=response.applied,
+        result_code=response.result_code,
+        action_id=response.action_id,
+        action_status=response.action_status,
+        action_version=response.action_version,
+        next_allowed_commands=response.next_allowed_commands,
+        approval_id=response.approval_id,
+        attempt_id=response.attempt_id,
+        claim_token=response.claim_token,
+        safe_error_code=response.safe_error_code,
+        conflict_detail=response.conflict_detail,
+    )
+
+
 class RecoverCreateHandler:
-    def __init__(self, *, unit_of_work_factory: Callable[[], UnitOfWork], connector_execution: ConnectorExecutionPort, recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse]) -> None:
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: Callable[[], UnitOfWork],
+        connector_execution: ConnectorExecutionPort,
+        recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse],
+    ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._connector_execution = connector_execution
         self._recover_existing_result = recover_existing_result
 
-    def __call__(self, command: RecoverUnknownCreateActionCommand) -> WriteActionResponse:
+    def __call__(self, command: RecoverCreateCommand) -> RecoverCreateResult:
         with self._unit_of_work_factory() as unit_of_work:
             action = require_action(unit_of_work, command.action_id)
             attempt = require_attempt(unit_of_work, command.attempt_id)
             approval = require_approval(unit_of_work, attempt.approval_id)
-        candidates = self._connector_execution.search_recovery_candidates(tool_name=action.tool_name, recovery_fingerprint=approval.recovery_fingerprint)
+
+        candidates = self._connector_execution.search_recovery_candidates(
+            tool_name=action.tool_name,
+            recovery_fingerprint=approval.recovery_fingerprint,
+        )
         if len(candidates) != 1:
-            return WriteActionResponse(False, ResultCode.RECOVERY_REQUIRED.value, action.id, action.status, action.version, (), attempt_id=attempt.id, conflict_detail="CREATE recovery requires exactly one existing candidate; blind recreate is forbidden")
-        return self._recover_existing_result(RecoverExistingWriteResultCommand(command.command_id, command.request_hash, command.action_id, command.attempt_id, command.expected_action_version, command.expected_attempt_version, candidates[0]))
+            return RecoverCreateResult(
+                False,
+                ResultCode.RECOVERY_REQUIRED.value,
+                action.id,
+                action.status,
+                action.version,
+                (),
+                attempt_id=attempt.id,
+                conflict_detail="CREATE recovery requires exactly one existing candidate; blind recreate is forbidden",
+            )
+
+        response = self._recover_existing_result(
+            RecoverExistingWriteResultCommand(
+                command.command_id,
+                command.request_hash,
+                command.action_id,
+                command.attempt_id,
+                command.expected_action_version,
+                command.expected_attempt_version,
+                candidates[0],
+            )
+        )
+        return _to_result(response)

--- a/src/google_work_agent/application/use_cases/recovery/recover_delete.py
+++ b/src/google_work_agent/application/use_cases/recovery/recover_delete.py
@@ -1,47 +1,140 @@
 """Recover an uncertain DELETE through target absence only."""
 
 from __future__ import annotations
+
 from collections.abc import Callable
+from dataclasses import dataclass
 from json import loads
 
 from google_work_agent.application.ports import ConnectorExecutionPort
 from google_work_agent.application.write_action_arguments import dict_argument, required_argument_string
 from google_work_agent.application.write_execution_contracts import WriteActionResponse
 from google_work_agent.application.write_persistence import require_action, require_attempt
-from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand, RecoverUnknownDeleteActionCommand
+from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand
 from google_work_agent.domain import PolicyViolationError, ResultCode
-from google_work_agent.ports import GoogleWorkspaceErrorCode, GoogleWorkspaceGatewayError, ResourceSnapshot, ResourceType, UnitOfWork
+from google_work_agent.ports import (
+    GoogleWorkspaceErrorCode,
+    GoogleWorkspaceGatewayError,
+    ResourceSnapshot,
+    ResourceType,
+    UnitOfWork,
+)
 
 DELETE_TARGETS = {
     "calendar_delete_event": (ResourceType.CALENDAR_EVENT, "event_id", "calendar_id"),
     "tasks_delete_task": (ResourceType.TASK, "task_id", "task_list_id"),
 }
 
+
+@dataclass(frozen=True, slots=True)
+class RecoverDeleteCommand:
+    command_id: str
+    request_hash: str
+    action_id: str
+    attempt_id: str
+    expected_action_version: int
+    expected_attempt_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverDeleteResult:
+    applied: bool
+    result_code: str
+    action_id: str
+    action_status: str
+    action_version: int
+    next_allowed_commands: tuple[str, ...]
+    approval_id: str | None = None
+    attempt_id: str | None = None
+    claim_token: str | None = None
+    safe_error_code: str | None = None
+    conflict_detail: str | None = None
+
+
+def _to_result(response: WriteActionResponse) -> RecoverDeleteResult:
+    return RecoverDeleteResult(
+        applied=response.applied,
+        result_code=response.result_code,
+        action_id=response.action_id,
+        action_status=response.action_status,
+        action_version=response.action_version,
+        next_allowed_commands=response.next_allowed_commands,
+        approval_id=response.approval_id,
+        attempt_id=response.attempt_id,
+        claim_token=response.claim_token,
+        safe_error_code=response.safe_error_code,
+        conflict_detail=response.conflict_detail,
+    )
+
+
 class RecoverDeleteHandler:
-    def __init__(self, *, unit_of_work_factory: Callable[[], UnitOfWork], connector_execution: ConnectorExecutionPort, recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse]) -> None:
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: Callable[[], UnitOfWork],
+        connector_execution: ConnectorExecutionPort,
+        recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse],
+    ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._connector_execution = connector_execution
         self._recover_existing_result = recover_existing_result
 
-    def __call__(self, command: RecoverUnknownDeleteActionCommand) -> WriteActionResponse:
+    def __call__(self, command: RecoverDeleteCommand) -> RecoverDeleteResult:
         with self._unit_of_work_factory() as unit_of_work:
             action = require_action(unit_of_work, command.action_id)
             attempt = require_attempt(unit_of_work, command.attempt_id)
+
         if action.tool_name not in DELETE_TARGETS:
             raise PolicyViolationError("DELETE recovery requires a registered GET_ABSENT tool")
+
         arguments = dict_argument(loads(action.arguments_json))
         absent = False
         try:
-            self._connector_execution.fetch_verification_snapshot(tool_name=action.tool_name, arguments=arguments, fallback_resource_id=None)
+            self._connector_execution.fetch_verification_snapshot(
+                tool_name=action.tool_name,
+                arguments=arguments,
+                fallback_resource_id=None,
+            )
         except LookupError:
             absent = True
         except GoogleWorkspaceGatewayError as error:
             if error.code is not GoogleWorkspaceErrorCode.NOT_FOUND:
                 raise
             absent = True
+
         if not absent:
-            return WriteActionResponse(False, ResultCode.RECOVERY_REQUIRED.value, action.id, action.status, action.version, (), attempt_id=attempt.id, conflict_detail="DELETE target is still present; blind re-delete is forbidden")
+            return RecoverDeleteResult(
+                False,
+                ResultCode.RECOVERY_REQUIRED.value,
+                action.id,
+                action.status,
+                action.version,
+                (),
+                attempt_id=attempt.id,
+                conflict_detail="DELETE target is still present; blind re-delete is forbidden",
+            )
+
         resource_type, id_field, parent_field = DELETE_TARGETS[action.tool_name]
         parent_id = required_argument_string(arguments, parent_field)
-        snapshot = ResourceSnapshot(fixture_snapshot_id="recovery-absence", resource_type=resource_type, resource_id=required_argument_string(arguments, id_field), parent_id=parent_id, related_resource_ids=(parent_id,), version="deleted", recovery_fingerprint=None, payload={"deleted": True})
-        return self._recover_existing_result(RecoverExistingWriteResultCommand(command.command_id, command.request_hash, command.action_id, command.attempt_id, command.expected_action_version, command.expected_attempt_version, snapshot))
+        snapshot = ResourceSnapshot(
+            fixture_snapshot_id="recovery-absence",
+            resource_type=resource_type,
+            resource_id=required_argument_string(arguments, id_field),
+            parent_id=parent_id,
+            related_resource_ids=(parent_id,),
+            version="deleted",
+            recovery_fingerprint=None,
+            payload={"deleted": True},
+        )
+        response = self._recover_existing_result(
+            RecoverExistingWriteResultCommand(
+                command.command_id,
+                command.request_hash,
+                command.action_id,
+                command.attempt_id,
+                command.expected_action_version,
+                command.expected_attempt_version,
+                snapshot,
+            )
+        )
+        return _to_result(response)

--- a/src/google_work_agent/application/use_cases/recovery/recover_send.py
+++ b/src/google_work_agent/application/use_cases/recovery/recover_send.py
@@ -1,28 +1,102 @@
 """Recover an uncertain SEND by locating an existing sent result only."""
 
 from __future__ import annotations
+
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from google_work_agent.application.ports import ConnectorExecutionPort
 from google_work_agent.application.write_execution_contracts import WriteActionResponse
 from google_work_agent.application.write_persistence import require_action, require_approval, require_attempt
-from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand, RecoverUnknownSendActionCommand
+from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand
 from google_work_agent.domain import ResultCode
 from google_work_agent.ports import UnitOfWork
 
 
+@dataclass(frozen=True, slots=True)
+class RecoverSendCommand:
+    command_id: str
+    request_hash: str
+    action_id: str
+    attempt_id: str
+    expected_action_version: int
+    expected_attempt_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverSendResult:
+    applied: bool
+    result_code: str
+    action_id: str
+    action_status: str
+    action_version: int
+    next_allowed_commands: tuple[str, ...]
+    approval_id: str | None = None
+    attempt_id: str | None = None
+    claim_token: str | None = None
+    safe_error_code: str | None = None
+    conflict_detail: str | None = None
+
+
+def _to_result(response: WriteActionResponse) -> RecoverSendResult:
+    return RecoverSendResult(
+        applied=response.applied,
+        result_code=response.result_code,
+        action_id=response.action_id,
+        action_status=response.action_status,
+        action_version=response.action_version,
+        next_allowed_commands=response.next_allowed_commands,
+        approval_id=response.approval_id,
+        attempt_id=response.attempt_id,
+        claim_token=response.claim_token,
+        safe_error_code=response.safe_error_code,
+        conflict_detail=response.conflict_detail,
+    )
+
+
 class RecoverSendHandler:
-    def __init__(self, *, unit_of_work_factory: Callable[[], UnitOfWork], connector_execution: ConnectorExecutionPort, recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse]) -> None:
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: Callable[[], UnitOfWork],
+        connector_execution: ConnectorExecutionPort,
+        recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse],
+    ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._connector_execution = connector_execution
         self._recover_existing_result = recover_existing_result
 
-    def __call__(self, command: RecoverUnknownSendActionCommand) -> WriteActionResponse:
+    def __call__(self, command: RecoverSendCommand) -> RecoverSendResult:
         with self._unit_of_work_factory() as unit_of_work:
             action = require_action(unit_of_work, command.action_id)
             attempt = require_attempt(unit_of_work, command.attempt_id)
             approval = require_approval(unit_of_work, attempt.approval_id)
-        candidates = self._connector_execution.search_recovery_candidates(tool_name=action.tool_name, recovery_fingerprint=approval.recovery_fingerprint)
+
+        candidates = self._connector_execution.search_recovery_candidates(
+            tool_name=action.tool_name,
+            recovery_fingerprint=approval.recovery_fingerprint,
+        )
         if len(candidates) != 1:
-            return WriteActionResponse(False, ResultCode.RECOVERY_REQUIRED.value, action.id, action.status, action.version, (), attempt_id=attempt.id, conflict_detail="SEND recovery requires exactly one sent-message candidate; blind resend is forbidden")
-        return self._recover_existing_result(RecoverExistingWriteResultCommand(command.command_id, command.request_hash, command.action_id, command.attempt_id, command.expected_action_version, command.expected_attempt_version, candidates[0]))
+            return RecoverSendResult(
+                False,
+                ResultCode.RECOVERY_REQUIRED.value,
+                action.id,
+                action.status,
+                action.version,
+                (),
+                attempt_id=attempt.id,
+                conflict_detail="SEND recovery requires exactly one sent-message candidate; blind resend is forbidden",
+            )
+
+        response = self._recover_existing_result(
+            RecoverExistingWriteResultCommand(
+                command.command_id,
+                command.request_hash,
+                command.action_id,
+                command.attempt_id,
+                command.expected_action_version,
+                command.expected_attempt_version,
+                candidates[0],
+            )
+        )
+        return _to_result(response)

--- a/src/google_work_agent/application/use_cases/recovery/recover_update.py
+++ b/src/google_work_agent/application/use_cases/recovery/recover_update.py
@@ -1,38 +1,140 @@
 """Recover an uncertain UPDATE through a target read, never a resend."""
 
 from __future__ import annotations
+
 from collections.abc import Callable
+from dataclasses import dataclass
 from json import loads
 from typing import cast
 
 from google_work_agent.application.ports import ConnectorExecutionPort
 from google_work_agent.application.use_cases.verification.normalize_snapshot import normalize_snapshot
 from google_work_agent.application.write_execution_contracts import WriteActionResponse
-from google_work_agent.application.write_persistence import require_action, require_approval, require_attempt, resolve_snapshot_fallback_resource_id
-from google_work_agent.application.write_recovery_contracts import RecoverExistingWriteResultCommand, RecoverUnknownUpdateActionCommand, ResolveUnknownWriteAsFailedCommand
+from google_work_agent.application.write_persistence import (
+    require_action,
+    require_approval,
+    require_attempt,
+    resolve_snapshot_fallback_resource_id,
+)
+from google_work_agent.application.write_recovery_contracts import (
+    RecoverExistingWriteResultCommand,
+    ResolveUnknownWriteAsFailedCommand,
+)
 from google_work_agent.domain import ResultCode
 from google_work_agent.ports import UnitOfWork
 
 
+@dataclass(frozen=True, slots=True)
+class RecoverUpdateCommand:
+    command_id: str
+    request_hash: str
+    action_id: str
+    attempt_id: str
+    expected_action_version: int
+    expected_attempt_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverUpdateResult:
+    applied: bool
+    result_code: str
+    action_id: str
+    action_status: str
+    action_version: int
+    next_allowed_commands: tuple[str, ...]
+    approval_id: str | None = None
+    attempt_id: str | None = None
+    claim_token: str | None = None
+    safe_error_code: str | None = None
+    conflict_detail: str | None = None
+
+
+def _to_result(response: WriteActionResponse) -> RecoverUpdateResult:
+    return RecoverUpdateResult(
+        applied=response.applied,
+        result_code=response.result_code,
+        action_id=response.action_id,
+        action_status=response.action_status,
+        action_version=response.action_version,
+        next_allowed_commands=response.next_allowed_commands,
+        approval_id=response.approval_id,
+        attempt_id=response.attempt_id,
+        claim_token=response.claim_token,
+        safe_error_code=response.safe_error_code,
+        conflict_detail=response.conflict_detail,
+    )
+
+
 class RecoverUpdateHandler:
-    def __init__(self, *, unit_of_work_factory: Callable[[], UnitOfWork], connector_execution: ConnectorExecutionPort, recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse], resolve_as_failed: Callable[[ResolveUnknownWriteAsFailedCommand], WriteActionResponse]) -> None:
+    def __init__(
+        self,
+        *,
+        unit_of_work_factory: Callable[[], UnitOfWork],
+        connector_execution: ConnectorExecutionPort,
+        recover_existing_result: Callable[[RecoverExistingWriteResultCommand], WriteActionResponse],
+        resolve_as_failed: Callable[[ResolveUnknownWriteAsFailedCommand], WriteActionResponse],
+    ) -> None:
         self._unit_of_work_factory = unit_of_work_factory
         self._connector_execution = connector_execution
         self._recover_existing_result = recover_existing_result
         self._resolve_as_failed = resolve_as_failed
 
-    def __call__(self, command: RecoverUnknownUpdateActionCommand) -> WriteActionResponse:
+    def __call__(self, command: RecoverUpdateCommand) -> RecoverUpdateResult:
         with self._unit_of_work_factory() as unit_of_work:
             action = require_action(unit_of_work, command.action_id)
             attempt = require_attempt(unit_of_work, command.attempt_id)
             approval = require_approval(unit_of_work, attempt.approval_id)
-            fallback_resource_id = resolve_snapshot_fallback_resource_id(unit_of_work, action=action, resource_ref_id=action.target_resource_ref_id)
-        snapshot = self._connector_execution.fetch_verification_snapshot(tool_name=action.tool_name, arguments=loads(action.arguments_json), fallback_resource_id=fallback_resource_id)
+            fallback_resource_id = resolve_snapshot_fallback_resource_id(
+                unit_of_work,
+                action=action,
+                resource_ref_id=action.target_resource_ref_id,
+            )
+
+        snapshot = self._connector_execution.fetch_verification_snapshot(
+            tool_name=action.tool_name,
+            arguments=loads(action.arguments_json),
+            fallback_resource_id=fallback_resource_id,
+        )
         actual = normalize_snapshot(snapshot)
         expected = cast(dict[str, object], loads(action.expected_json))
+
         if actual == expected:
-            return self._recover_existing_result(RecoverExistingWriteResultCommand(command.command_id, command.request_hash, command.action_id, command.attempt_id, command.expected_action_version, command.expected_attempt_version, snapshot))
+            response = self._recover_existing_result(
+                RecoverExistingWriteResultCommand(
+                    command.command_id,
+                    command.request_hash,
+                    command.action_id,
+                    command.attempt_id,
+                    command.expected_action_version,
+                    command.expected_attempt_version,
+                    snapshot,
+                )
+            )
+            return _to_result(response)
+
         source = cast(dict[str, object], loads(approval.source_snapshot_json))
         if actual == source:
-            return self._resolve_as_failed(ResolveUnknownWriteAsFailedCommand(command.command_id, command.request_hash, command.action_id, command.attempt_id, command.expected_action_version, command.expected_attempt_version, "NO_RECOVERY_CANDIDATE", "target still matches the approved source snapshot"))
-        return WriteActionResponse(False, ResultCode.RECOVERY_REQUIRED.value, action.id, action.status, action.version, (), attempt_id=attempt.id, conflict_detail="UPDATE recovery observed neither expected nor source state; manual resolution required")
+            response = self._resolve_as_failed(
+                ResolveUnknownWriteAsFailedCommand(
+                    command.command_id,
+                    command.request_hash,
+                    command.action_id,
+                    command.attempt_id,
+                    command.expected_action_version,
+                    command.expected_attempt_version,
+                    "NO_RECOVERY_CANDIDATE",
+                    "target still matches the approved source snapshot",
+                )
+            )
+            return _to_result(response)
+
+        return RecoverUpdateResult(
+            False,
+            ResultCode.RECOVERY_REQUIRED.value,
+            action.id,
+            action.status,
+            action.version,
+            (),
+            attempt_id=attempt.id,
+            conflict_detail="UPDATE recovery observed neither expected nor source state; manual resolution required",
+        )

--- a/src/google_work_agent/application/use_cases/verification/normalize_snapshot.py
+++ b/src/google_work_agent/application/use_cases/verification/normalize_snapshot.py
@@ -1,6 +1,18 @@
 """Canonical projection used by verification and recovery reads."""
 
+from dataclasses import dataclass
+
 from google_work_agent.ports import ResourceSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizeSnapshotQuery:
+    snapshot: ResourceSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizeSnapshotResult:
+    projection: dict[str, object]
 
 
 def normalize_snapshot(snapshot: ResourceSnapshot) -> dict[str, object]:
@@ -13,3 +25,8 @@ def normalize_snapshot(snapshot: ResourceSnapshot) -> dict[str, object]:
         "version": snapshot.version,
         "payload": payload,
     }
+
+
+class NormalizeSnapshotHandler:
+    def __call__(self, query: NormalizeSnapshotQuery) -> NormalizeSnapshotResult:
+        return NormalizeSnapshotResult(projection=normalize_snapshot(query.snapshot))


### PR DESCRIPTION
## Supervisor Pre-Gate Fix

Base immutable staging SHA: `2910a601683f21fd45bba2b8baf70048e564c43e`

Purpose: close the cross-worker Repository Architecture v1.4 application-use-case grammar gaps discovered after Wave-1 assembly, without changing product behavior or safety contracts.

### Scope
- Replace R2 `Result = CommandResult[...]` aliases with owner-local Result classes for Action / Approval / Claim use cases.
- Add canonical owner-local Command/Query + Result boundaries to the R3 execution/recovery/verification use cases.
- Preserve UNKNOWN_RESULT no-blind-resend behavior and existing domain transitions.
- Keep durable ClaimExecution persistence atomicity and production caller cut-over as Closure Wave obligations; this PR does not falsely declare those completed.

### Gate target
Every production file under `application/use_cases/**` must satisfy `<Verb><Object>Command|Query + <Verb><Object>Result + <Verb><Object>Handler` as enforced by `tests/architecture/test_repository_architecture.py`.

### Supervisor status
`PRE_GATE_CANDIDATE` — do not treat as main-ready or Structural Refactor complete until architecture CI/static verification is complete.