### PR TITLE
test(e2e): validate pre-e2e stack and core product journeys

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.9.1",
+        "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "6.4.8",
         "@testing-library/react": "16.0.1",
         "@testing-library/user-event": "14.5.2",
@@ -1135,9 +1136,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,6 +1192,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1288,9 +1302,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,9 +1316,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,9 +1330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,9 +1344,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,9 +1358,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,9 +1372,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,9 +1386,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1407,9 +1400,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1414,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,9 +1428,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1458,9 +1442,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1475,9 +1456,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +1470,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4309,6 +4284,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "test": "vitest",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "test:e2e": "npm run build && playwright test --config=playwright.config.ts"
   },
   "dependencies": {
     "react": "18.3.1",
@@ -17,14 +18,15 @@
   },
   "devDependencies": {
     "@eslint/js": "9.9.1",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "16.0.1",
     "@testing-library/user-event": "14.5.2",
     "@types/node": "22.10.2",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "@vitest/coverage-v8": "2.0.5",
     "@vitejs/plugin-react": "4.3.1",
+    "@vitest/coverage-v8": "2.0.5",
     "eslint": "9.9.1",
     "eslint-plugin-react-hooks": "5.1.0-rc.0",
     "globals": "15.9.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from "@playwright/test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const port = 18765;
+const baseURL = `http://127.0.0.1:${port}`;
+const runtimeRoot = mkdtempSync(join(tmpdir(), "gwa-product-e2e-"));
+const python = process.platform === "win32"
+  ? ".\\.venv\\Scripts\\python.exe"
+  : "./.venv/bin/python";
+
+export default defineConfig({
+  testDir: "./tests/product-e2e",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  reporter: [["list"]],
+  outputDir: "test-results/product-e2e",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chrome",
+      use: { ...devices["Desktop Chrome"], channel: "chrome" },
+    },
+  ],
+  webServer: {
+    command: `${python} -m tests.e2e.browser_product_server`,
+    cwd: "..",
+    env: {
+      ...process.env,
+      GWA_ARCHITECTURE_FINAL_CUTOVER: "1",
+      GWA_BROWSER_E2E_PORT: String(port),
+      GWA_BROWSER_E2E_RUNTIME_ROOT: runtimeRoot,
+    },
+    url: `${baseURL}/health/live`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/frontend/src/api/contract.ts
+++ b/frontend/src/api/contract.ts
@@ -404,9 +404,3 @@ export type CalendarContainer = {
   title: string;
   primary: boolean;
 };
-
-export type EventEnvelope = {
-  eventId: string;
-  eventType: string;
-  payload: Record<string, unknown>;
-};

--- a/frontend/src/features/approval/action_plan_card.tsx
+++ b/frontend/src/features/approval/action_plan_card.tsx
@@ -55,13 +55,13 @@ function ActionDecisionCard({ action, approval, busy, canRetry, formatTime, onAp
         <label key={item}><input type="checkbox" checked={acknowledgements.has(item)} onChange={(event) => setAcknowledgements((current) => { const next = new Set(current); if (event.target.checked) next.add(item); else next.delete(item); return next; })} /> {item === "TASK_DUPLICATE" ? "중복 가능성을 확인했습니다." : "일정 충돌 가능성을 확인했습니다."}</label>
       ))}
       {action.next_allowed_commands.includes("MODIFY_ACTION") && editableFields.some((field) => field !== "attachments") ? (
-        <fieldset><legend>수정</legend>{editableFields.filter((field) => field !== "attachments").map((field) => <label key={field}>{field}<input value={editValues[field] ?? ""} onChange={(event) => setEditValues((current) => ({ ...current, [field]: event.target.value }))} /></label>)}<button className="button-secondary" type="button" disabled={busy === `modify-${action.action_id}` || Object.keys(patch).length === 0} onClick={() => onModify(action, patch)}>수정</button></fieldset>
+        <fieldset><legend>수정</legend>{editableFields.filter((field) => field !== "attachments").map((field) => <label key={field}>{field}<input value={editValues[field] ?? ""} onChange={(event) => setEditValues((current) => ({ ...current, [field]: event.target.value }))} /></label>)}<button className="button-secondary" type="button" disabled={busy !== null || Object.keys(patch).length === 0} onClick={() => onModify(action, patch)}>수정</button></fieldset>
       ) : null}
-      {action.attachment_allowed && action.next_allowed_commands.includes("MODIFY_ACTION") ? <AttachmentPicker disabled={busy === `modify-${action.action_id}`} onStaged={(descriptors) => onAttachDescriptors(action, descriptors)} /> : null}
+      {action.attachment_allowed && action.next_allowed_commands.includes("MODIFY_ACTION") ? <AttachmentPicker disabled={busy !== null} onStaged={(descriptors) => onAttachDescriptors(action, descriptors)} /> : null}
       <div className="button-row">
-        {action.next_allowed_commands.includes("APPROVE_ACTION") ? <button className="button-primary" type="button" disabled={busy === `approve-${action.action_id}` || missingAcknowledgement} onClick={() => onApprove(action, acknowledgements)}>{approvalLabel(duplicate, conflict)}</button> : null}
-        {action.next_allowed_commands.includes("REJECT_ACTION") ? <button className="button-danger" type="button" disabled={busy === `reject-${action.action_id}`} onClick={() => onReject(action)}>거절</button> : null}
-        {canRetry ? <button className="button-secondary" type="button" disabled={busy === `retry-${action.action_id}`} onClick={() => onRetry(action)}>다시 준비</button> : null}
+        {action.next_allowed_commands.includes("APPROVE_ACTION") ? <button className="button-primary" type="button" disabled={busy !== null || missingAcknowledgement} onClick={() => onApprove(action, acknowledgements)}>{approvalLabel(duplicate, conflict)}</button> : null}
+        {action.next_allowed_commands.includes("REJECT_ACTION") ? <button className="button-danger" type="button" disabled={busy !== null} onClick={() => onReject(action)}>거절</button> : null}
+        {canRetry ? <button className="button-secondary" type="button" disabled={busy !== null} onClick={() => onRetry(action)}>다시 준비</button> : null}
       </div>
       {action.status === "UNKNOWN_RESULT" ? <p className="status-warn">실제 결과를 확인하는 중입니다. 새 쓰기 실행은 잠시 막혀 있습니다.</p> : null}
     </article>

--- a/frontend/src/features/conversation/ConversationView.tsx
+++ b/frontend/src/features/conversation/ConversationView.tsx
@@ -4,6 +4,7 @@ import type { StagedAttachmentDescriptor } from "../attachment";
 import { ActionPlanCard } from "../approval";
 import { RecoveryCard } from "../recovery";
 import { ConfirmationCard, ContextPreviewCard, ExecutionStatusCard, ExternalLlmDisclosureCard, RequestComposer, RunProgress } from "../run";
+import type { RunSseEvent } from "../run/api/run_sse_event";
 import { DateSeparator, UserMessageBubble } from "./MessageBubble";
 
 type RecoveryKind = NonNullable<RunSnapshot["recovery"]>["allowed_resolution_kinds"][number];
@@ -14,6 +15,7 @@ export type ConversationViewModel = {
     historyMessages: ConversationMessage[];
     runSnapshot: RunSnapshot | null;
     runContext: RunContext | null;
+    latestRunEvent?: RunSseEvent | null;
     confirmationText: string;
     setConfirmationText: Dispatch<SetStateAction<string>>;
     composerText: string;
@@ -41,7 +43,7 @@ export type ConversationViewProps = { children: ReactNode; viewModel: Conversati
 
 export function ConversationView({ children, viewModel }: ConversationViewProps): JSX.Element {
   const { controller, resourceContext, formatTime, onOpenSettings, onOpenDiagnostics } = viewModel;
-  const { selectedConversationId, historyMessages, runSnapshot, runContext, confirmationText, setConfirmationText, composerText, composerError, setComposerText, setComposerError, busyCommand, handleStartRun, handleApprove, handleSimpleAction, handleAttachDescriptors, handleCancelRun, handleResumeRun, handleAdjustContext, handleConfirmation, handleResolveRecovery } = controller;
+  const { selectedConversationId, historyMessages, runSnapshot, runContext, latestRunEvent, confirmationText, setConfirmationText, composerText, composerError, setComposerText, setComposerError, busyCommand, handleStartRun, handleApprove, handleSimpleAction, handleAttachDescriptors, handleCancelRun, handleResumeRun, handleAdjustContext, handleConfirmation, handleResolveRecovery } = controller;
   const showTransientRequest = Boolean(runContext?.request_text)
     && !historyMessages.some((message) => message.role === "USER" && message.run_id === runContext?.run_id);
   const timelineRef = useRef<HTMLDivElement | null>(null);
@@ -53,7 +55,7 @@ export function ConversationView({ children, viewModel }: ConversationViewProps)
 
   return (
     <>
-      {runSnapshot ? <RunProgress snapshot={runSnapshot} busy={busyCommand} onCancel={() => void handleCancelRun()} onResume={(kind) => void handleResumeRun(kind)} /> : null}
+      {runSnapshot ? <RunProgress snapshot={runSnapshot} latestEvent={latestRunEvent} busy={busyCommand} onCancel={() => void handleCancelRun()} onResume={(kind) => void handleResumeRun(kind)} /> : null}
       <div className="panel-body">
         <div className="central-scroll-area" ref={timelineRef}>
           {children}

--- a/frontend/src/features/conversation/useConversation.ts
+++ b/frontend/src/features/conversation/useConversation.ts
@@ -79,6 +79,7 @@ export function useConversation({ currentAccount, selectedResourceHandles, onSta
     historyMessages: history.historyMessages,
     runSnapshot: run.runSnapshot,
     runContext: run.runContext,
+    latestRunEvent: run.latestRunEvent,
     composerText: composer.composerText,
     composerError: composer.composerError,
     busyCommand,

--- a/frontend/src/features/run/api/run_sse_event.ts
+++ b/frontend/src/features/run/api/run_sse_event.ts
@@ -1,0 +1,118 @@
+export const RUN_SSE_EVENT_TYPES = [
+  "run_status", "phase_changed", "tool_routing", "retrieval_progress",
+  "confirmation_required", "analysis_progress", "plan_updated", "approval_required",
+  "action_status", "verification_result", "reauth_required", "recovery_required",
+  "completed", "error",
+] as const;
+
+export type RunSseEventType = typeof RUN_SSE_EVENT_TYPES[number];
+
+type RunStatus = "CREATED" | "ANALYZING" | "RETRIEVING" | "WAITING_CONFIRMATION" | "PLANNING" | "WAITING_APPROVAL" | "EXECUTING" | "VERIFYING" | "COMPLETED" | "CANCEL_REQUESTED" | "CANCELLED" | "REAUTH_REQUIRED" | "RECOVERY_REQUIRED" | "FAILED" | "BLOCKED";
+type WorkflowPhase = "INITIALIZE" | "REQUEST_ANALYSIS" | "TOOL_ROUTING" | "WAITING_CONFIRMATION" | "CONTEXT_RETRIEVAL" | "WORK_ANALYSIS" | "SOLUTION_PLANNING" | "PLAN_REVIEW" | "DOMAIN_VALIDATION" | "WAITING_APPROVAL" | "PREFLIGHT" | "ACTION_EXECUTION" | "READ_EXECUTION" | "VERIFICATION" | "RESPONSE_SYNTHESIS" | "RECOVERY" | "FINALIZE";
+type ActionStatus = "PROPOSED" | "MODIFIED" | "APPROVED" | "REJECTED" | "EXPIRED" | "EXECUTING" | "UNKNOWN_RESULT" | "EXECUTED" | "VERIFIED" | "FAILED" | "BLOCKED" | "DEPENDENCY_BLOCKED" | "MISMATCH" | "CANCELLED";
+type RecoveryResolution = "RECHECK" | "ACCEPT_PARTIAL" | "CREATE_CORRECTIVE_PLAN" | "CANCEL" | "FAIL";
+
+export type RunSsePayloadByType = {
+  run_status: { status: RunStatus; snapshot_version: number };
+  phase_changed: { phase: WorkflowPhase };
+  tool_routing: { route_revision: number; input_route_count: number; output_mode: "ANSWER" | "ACTION" };
+  retrieval_progress: { coverage: "NONE" | "PARTIAL" | "SUFFICIENT"; completed_sources: number; total_sources: number };
+  confirmation_required: { interrupt_id: string; question: string; options: string[] };
+  analysis_progress: { completed_stage: string };
+  plan_updated: { plan_id: string | null; revision_no: number };
+  approval_required: { action_ids: string[] };
+  action_status: { action_id: string; status: ActionStatus };
+  verification_result: { action_id: string; outcome: "VERIFIED" | "MISMATCH" };
+  reauth_required: { connector_id: string };
+  recovery_required: { recovery: {
+    reason_code: "UNKNOWN_RESULT" | "VERIFICATION_MISMATCH" | "CHECKPOINT_MISMATCH" | "CONTRACT_VIOLATION";
+    target: { target_kind: "RUN" } | { target_kind: "ACTION"; action_id: string };
+    allowed_resolution_kinds: RecoveryResolution[];
+  } };
+  completed: { status: "COMPLETED" | "BLOCKED" | "FAILED" | "CANCELLED"; result_kind: "SUCCESS" | "PARTIAL" | "BLOCKED" | "FAILED" | "CANCELLED" };
+  error: { error_code: string; recoverable: boolean };
+};
+
+type RunSseEnvelope<K extends RunSseEventType> = {
+  schema_version: 1;
+  event_id: string;
+  run_id: string;
+  action_id: string | null;
+  occurred_at_ms: number;
+  event_type: K;
+  payload: RunSsePayloadByType[K];
+  projection_version: number;
+};
+
+export type RunSseEvent = {
+  [K in RunSseEventType]: RunSseEnvelope<K>
+}[RunSseEventType];
+
+const RUN_STATUSES: readonly RunStatus[] = ["CREATED", "ANALYZING", "RETRIEVING", "WAITING_CONFIRMATION", "PLANNING", "WAITING_APPROVAL", "EXECUTING", "VERIFYING", "COMPLETED", "CANCEL_REQUESTED", "CANCELLED", "REAUTH_REQUIRED", "RECOVERY_REQUIRED", "FAILED", "BLOCKED"];
+const WORKFLOW_PHASES: readonly WorkflowPhase[] = ["INITIALIZE", "REQUEST_ANALYSIS", "TOOL_ROUTING", "WAITING_CONFIRMATION", "CONTEXT_RETRIEVAL", "WORK_ANALYSIS", "SOLUTION_PLANNING", "PLAN_REVIEW", "DOMAIN_VALIDATION", "WAITING_APPROVAL", "PREFLIGHT", "ACTION_EXECUTION", "READ_EXECUTION", "VERIFICATION", "RESPONSE_SYNTHESIS", "RECOVERY", "FINALIZE"];
+const ACTION_STATUSES: readonly ActionStatus[] = ["PROPOSED", "MODIFIED", "APPROVED", "REJECTED", "EXPIRED", "EXECUTING", "UNKNOWN_RESULT", "EXECUTED", "VERIFIED", "FAILED", "BLOCKED", "DEPENDENCY_BLOCKED", "MISMATCH", "CANCELLED"];
+const RECOVERY_REASONS = ["UNKNOWN_RESULT", "VERIFICATION_MISMATCH", "CHECKPOINT_MISMATCH", "CONTRACT_VIOLATION"] as const;
+const RECOVERY_RESOLUTIONS: readonly RecoveryResolution[] = ["RECHECK", "ACCEPT_PARTIAL", "CREATE_CORRECTIVE_PLAN", "CANCEL", "FAIL"];
+const TERMINAL_STATUSES = ["COMPLETED", "BLOCKED", "FAILED", "CANCELLED"] as const;
+const RESULT_KINDS = ["SUCCESS", "PARTIAL", "BLOCKED", "FAILED", "CANCELLED"] as const;
+
+export class RunSseContractError extends Error {}
+
+export function decodeRunSseEvent(data: string): RunSseEvent {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(data) as unknown;
+  } catch {
+    throw new RunSseContractError("SSE data is not valid JSON");
+  }
+  if (!isRecord(raw) || !hasExactKeys(raw, ["schema_version", "event_id", "run_id", "action_id", "occurred_at_ms", "event_type", "payload", "projection_version"])) throw new RunSseContractError("SSE envelope fields are invalid");
+  if (raw.schema_version !== 1 || !isString(raw.event_id) || !isString(raw.run_id) || !(raw.action_id === null || isString(raw.action_id)) || !isInteger(raw.occurred_at_ms) || !isInteger(raw.projection_version) || !isEventType(raw.event_type)) throw new RunSseContractError("SSE envelope values are invalid");
+  validatePayload(raw.event_type, raw.payload);
+  return raw as RunSseEvent;
+}
+
+function validatePayload(eventType: RunSseEventType, raw: unknown): void {
+  if (!isRecord(raw)) throw new RunSseContractError(`${eventType} payload must be an object`);
+  switch (eventType) {
+    case "run_status": requireShape(raw, ["status", "snapshot_version"], isOneOf(raw.status, RUN_STATUSES) && isInteger(raw.snapshot_version)); return;
+    case "phase_changed": requireShape(raw, ["phase"], isOneOf(raw.phase, WORKFLOW_PHASES)); return;
+    case "tool_routing": requireShape(raw, ["route_revision", "input_route_count", "output_mode"], isInteger(raw.route_revision) && isInteger(raw.input_route_count) && isOneOf(raw.output_mode, ["ANSWER", "ACTION"])); return;
+    case "retrieval_progress": requireShape(raw, ["coverage", "completed_sources", "total_sources"], isOneOf(raw.coverage, ["NONE", "PARTIAL", "SUFFICIENT"]) && isInteger(raw.completed_sources) && isInteger(raw.total_sources)); return;
+    case "confirmation_required": requireShape(raw, ["interrupt_id", "question", "options"], isString(raw.interrupt_id) && isString(raw.question) && isStringArray(raw.options)); return;
+    case "analysis_progress": requireShape(raw, ["completed_stage"], isString(raw.completed_stage)); return;
+    case "plan_updated": requireShape(raw, ["plan_id", "revision_no"], (raw.plan_id === null || isString(raw.plan_id)) && isInteger(raw.revision_no)); return;
+    case "approval_required": requireShape(raw, ["action_ids"], isStringArray(raw.action_ids)); return;
+    case "action_status": requireShape(raw, ["action_id", "status"], isString(raw.action_id) && isOneOf(raw.status, ACTION_STATUSES)); return;
+    case "verification_result": requireShape(raw, ["action_id", "outcome"], isString(raw.action_id) && isOneOf(raw.outcome, ["VERIFIED", "MISMATCH"])); return;
+    case "reauth_required": requireShape(raw, ["connector_id"], isString(raw.connector_id)); return;
+    case "recovery_required": validateRecovery(raw); return;
+    case "completed": requireShape(raw, ["status", "result_kind"], isOneOf(raw.status, TERMINAL_STATUSES) && isOneOf(raw.result_kind, RESULT_KINDS)); return;
+    case "error": requireShape(raw, ["error_code", "recoverable"], isString(raw.error_code) && typeof raw.recoverable === "boolean"); return;
+    default: assertNever(eventType);
+  }
+}
+
+function validateRecovery(raw: Record<string, unknown>): void {
+  if (!hasExactKeys(raw, ["recovery"]) || !isRecord(raw.recovery)) throw new RunSseContractError("recovery_required payload is invalid");
+  const recovery = raw.recovery;
+  if (!hasExactKeys(recovery, ["reason_code", "target", "allowed_resolution_kinds"]) || !isOneOf(recovery.reason_code, RECOVERY_REASONS) || !isOneOfArray(recovery.allowed_resolution_kinds, RECOVERY_RESOLUTIONS) || !isRecord(recovery.target)) throw new RunSseContractError("recovery projection is invalid");
+  const target = recovery.target;
+  const validTarget = target.target_kind === "RUN"
+    ? hasExactKeys(target, ["target_kind"])
+    : target.target_kind === "ACTION" && hasExactKeys(target, ["target_kind", "action_id"]) && isString(target.action_id);
+  if (!validTarget) throw new RunSseContractError("recovery target is invalid");
+}
+
+function requireShape(raw: Record<string, unknown>, keys: readonly string[], valid: boolean): void {
+  if (!hasExactKeys(raw, keys) || !valid) throw new RunSseContractError("SSE payload fields are invalid");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+function isString(value: unknown): value is string { return typeof value === "string"; }
+function isInteger(value: unknown): value is number { return typeof value === "number" && Number.isInteger(value); }
+function isStringArray(value: unknown): value is string[] { return Array.isArray(value) && value.every(isString); }
+function isOneOf<T extends string>(value: unknown, allowed: readonly T[]): value is T { return typeof value === "string" && allowed.includes(value as T); }
+function isOneOfArray<T extends string>(value: unknown, allowed: readonly T[]): value is T[] { return Array.isArray(value) && value.every((item) => isOneOf(item, allowed)); }
+function isEventType(value: unknown): value is RunSseEventType { return isOneOf(value, RUN_SSE_EVENT_TYPES); }
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean { const actual = Object.keys(value); return actual.length === keys.length && keys.every((key) => Object.hasOwn(value, key)); }
+function assertNever(value: never): never { throw new RunSseContractError(`unsupported SSE event: ${String(value)}`); }

--- a/frontend/src/features/run/api/subscribe_run_events.ts
+++ b/frontend/src/features/run/api/subscribe_run_events.ts
@@ -1,7 +1,7 @@
-import type { EventEnvelope } from "../../../api/contract";
+import { decodeRunSseEvent, RUN_SSE_EVENT_TYPES, type RunSseEvent } from "./run_sse_event";
 
 export type RunEventHandlers = {
-  onEvent: (event: EventEnvelope) => void;
+  onEvent: (event: RunSseEvent) => void;
   onSnapshotRequired: () => void;
   onStateChange: (message: string) => void;
 };
@@ -11,18 +11,23 @@ export function subscribeRunEvents(runId: string, handlers: RunEventHandlers): (
   const seen = new Set<string>();
   eventSource.onopen = () => handlers.onStateChange("실시간 상태가 연결되었습니다.");
   eventSource.onerror = () => handlers.onStateChange("실시간 연결을 다시 시도하고 있습니다.");
-  for (const eventType of ["run_status", "phase_changed", "confirmation_required", "plan_updated", "approval_required", "action_status", "verification_result", "reauth_required", "recovery_required", "EXTERNAL_LLM_SCOPE_PUBLISHED", "completed", "error", "snapshot_required"]) {
+  for (const eventType of RUN_SSE_EVENT_TYPES) {
     eventSource.addEventListener(eventType, (event) => {
       const messageEvent = event as MessageEvent<string>;
-      if (messageEvent.lastEventId && seen.has(messageEvent.lastEventId)) return;
-      if (messageEvent.lastEventId) seen.add(messageEvent.lastEventId);
-      if (eventType === "snapshot_required") {
-        eventSource.close();
-        handlers.onSnapshotRequired();
-        return;
+      try {
+        const decoded = decodeRunSseEvent(messageEvent.data);
+        if (decoded.event_type !== eventType || (messageEvent.lastEventId && decoded.event_id !== messageEvent.lastEventId)) throw new Error("SSE transport identity mismatch");
+        if (messageEvent.lastEventId && seen.has(messageEvent.lastEventId)) return;
+        if (messageEvent.lastEventId) seen.add(messageEvent.lastEventId);
+        handlers.onEvent(decoded);
+      } catch {
+        handlers.onStateChange("실시간 이벤트 계약 오류가 감지되었습니다. 실행 상태를 새로 확인해 주세요.");
       }
-      handlers.onEvent({ eventId: messageEvent.lastEventId, eventType, payload: JSON.parse(messageEvent.data) as Record<string, unknown> });
     });
   }
+  eventSource.addEventListener("snapshot_required", () => {
+    eventSource.close();
+    handlers.onSnapshotRequired();
+  });
   return () => eventSource.close();
 }

--- a/frontend/src/features/run/run_progress.tsx
+++ b/frontend/src/features/run/run_progress.tsx
@@ -1,7 +1,9 @@
 import type { RunSnapshot } from "../../api/contract";
+import type { RunSseEvent } from "./api/run_sse_event";
 
-export function RunProgress({ snapshot, busy, onCancel, onResume }: {
+export function RunProgress({ snapshot, latestEvent = null, busy, onCancel, onResume }: {
   snapshot: RunSnapshot;
+  latestEvent?: RunSseEvent | null;
   busy: string | null;
   onCancel: () => void;
   onResume: (resumeKind: "SAFE_CHECKPOINT_RESUME") => void;
@@ -9,6 +11,7 @@ export function RunProgress({ snapshot, busy, onCancel, onResume }: {
   const resumeAction = snapshot.error?.actions.find(
     (action) => action.kind === "RESUME_SAFE_CHECKPOINT" && action.resume_kind === "SAFE_CHECKPOINT_RESUME",
   );
+  const eventLabel = latestEvent ? eventProgressLabel(latestEvent) : null;
   return (
     <div className={`panel-header run-header${snapshot.run.status === "FAILED" ? " run-header--failed" : ""}`}>
       <div>
@@ -17,6 +20,7 @@ export function RunProgress({ snapshot, busy, onCancel, onResume }: {
         <div className="muted">
           작업 {snapshot.execution_status.terminal_action_count}/{snapshot.execution_status.action_count}
         </div>
+        {eventLabel ? <div className="muted" data-testid="run-event-progress">{eventLabel}</div> : null}
         {snapshot.run.status === "FAILED" ? <div className="status-warn">작업을 완료하지 못했습니다.</div> : null}
         {snapshot.terminal_result_kind === "PARTIAL" ? <div className="status-warn">일부 작업은 완료되었고 나머지는 취소되었습니다.</div> : null}
       </div>
@@ -30,6 +34,15 @@ export function RunProgress({ snapshot, busy, onCancel, onResume }: {
       </div>
     </div>
   );
+}
+
+function eventProgressLabel(event: RunSseEvent): string | null {
+  switch (event.event_type) {
+    case "tool_routing": return `도구 경로 ${event.payload.input_route_count}개 분석 완료`;
+    case "retrieval_progress": return `자료 확인 ${event.payload.completed_sources}/${event.payload.total_sources}`;
+    case "analysis_progress": return `분석 완료: ${event.payload.completed_stage}`;
+    default: return null;
+  }
 }
 
 function statusLabel(status: string): string {

--- a/frontend/src/features/run/use_run_projection.ts
+++ b/frontend/src/features/run/use_run_projection.ts
@@ -3,6 +3,7 @@ import type { RunContext, RunSnapshot } from "../../api/contract";
 import { getRunContext, getRunSnapshot } from "./api/get_run_snapshot";
 import { adjustRunContext, cancelRun, confirmRun, resumeRun } from "./api/run_commands";
 import { subscribeRunEvents } from "./api/subscribe_run_events";
+import type { RunSseEvent } from "./api/run_sse_event";
 
 export type PendingConfirmation = {
   interruptId: string;
@@ -31,6 +32,7 @@ type UseRunProjectionOptions = {
 export function useRunProjection({ busyCommand, setBusyCommand, commandIdFor, completeCommand, beginConversationProjection, getConversationProjection, isCurrentProjection, reloadConversationHistory, selectConversationHistory, isRunHistorySynced, markRunHistorySynced, onStatusLine }: UseRunProjectionOptions) {
   const [runSnapshot, setRunSnapshot] = useState<RunSnapshot | null>(null);
   const [runContext, setRunContext] = useState<RunContext | null>(null);
+  const [latestRunEvent, setLatestRunEvent] = useState<RunSseEvent | null>(null);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingConfirmation | null>(null);
   const [confirmationText, setConfirmationText] = useState("");
   const subscriptionRef = useRef<(() => void) | null>(null);
@@ -42,6 +44,7 @@ export function useRunProjection({ busyCommand, setBusyCommand, commandIdFor, co
     subscriptionRunIdRef.current = null;
     setRunSnapshot(null);
     setRunContext(null);
+    setLatestRunEvent(null);
     setPendingConfirmation(null);
     setConfirmationText("");
   }, []);
@@ -76,7 +79,10 @@ export function useRunProjection({ busyCommand, setBusyCommand, commandIdFor, co
     subscriptionRef.current?.();
     subscriptionRef.current = subscribeRunEvents(runId, {
       onStateChange: onStatusLine,
-      onEvent: () => { void refreshRun(runId, conversationId, generation); },
+      onEvent: (event) => {
+        setLatestRunEvent(event);
+        void refreshRun(runId, conversationId, generation);
+      },
       onSnapshotRequired: () => {
         subscriptionRef.current = null;
         subscriptionRunIdRef.current = null;
@@ -186,5 +192,5 @@ export function useRunProjection({ busyCommand, setBusyCommand, commandIdFor, co
     } finally { setBusyCommand(null); }
   }, [busyCommand, commandIdFor, completeCommand, confirmationText, pendingConfirmation, refreshRun, runSnapshot, setBusyCommand]);
 
-  return { runSnapshot, runContext, pendingConfirmation, confirmationText, setConfirmationText, resetRunProjection, refreshRun, selectRun, selectConversation, handleCancelRun, handleResumeRun, handleResumeAfterReauth, handleAdjustContext, handleConfirmation };
+  return { runSnapshot, runContext, latestRunEvent, pendingConfirmation, confirmationText, setConfirmationText, resetRunProjection, refreshRun, selectRun, selectConversation, handleCancelRun, handleResumeRun, handleResumeAfterReauth, handleAdjustContext, handleConfirmation };
 }

--- a/frontend/tests/app/app_integration.test.tsx
+++ b/frontend/tests/app/app_integration.test.tsx
@@ -102,7 +102,17 @@ class FakeEventSource {
   }
 
   emit(type: string, payload: Record<string, unknown>, eventId = `${type}-1`): void {
-    const event = { data: JSON.stringify(payload), lastEventId: eventId } as MessageEvent<string>;
+    const data = type === "snapshot_required" ? payload : {
+      schema_version: 1,
+      event_id: eventId,
+      run_id: "run-1",
+      action_id: null,
+      occurred_at_ms: 1,
+      event_type: type,
+      payload,
+      projection_version: 1,
+    };
+    const event = { data: JSON.stringify(data), lastEventId: eventId } as MessageEvent<string>;
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
     }
@@ -686,12 +696,12 @@ test("adds the stored assistant answer once the open run reaches a terminal stat
   const requestsBeforeCompletion = historyRequests;
 
   runFinished = true;
-  FakeEventSource.instances[0].emit("completed", { outcome: "COMPLETED" }, "evt-completed");
+  FakeEventSource.instances[0].emit("completed", { status: "COMPLETED", result_kind: "SUCCESS" }, "evt-completed");
 
   expect(await screen.findByText("요약 결과입니다.")).toBeInTheDocument();
   expect(screen.getAllByText("이번 주 요약")).toHaveLength(1);
 
-  FakeEventSource.instances[0].emit("run_status", { run_status: "COMPLETED" }, "evt-status");
+  FakeEventSource.instances[0].emit("run_status", { status: "COMPLETED", snapshot_version: 2 }, "evt-status");
   await waitFor(() => expect(historyRequests).toBe(requestsBeforeCompletion + 1));
 });
 
@@ -953,7 +963,7 @@ test("confirms an interrupt and explicitly resolves a mismatch", async () => {
   await screen.findByText("Which task should be updated?");
   expect(screen.getByLabelText("확인 응답")).toBeEnabled();
   FakeEventSource.instances[0].emit("confirmation_required", {
-    user_interrupt: { interrupt_id: "interrupt-1", question: "Which task should be updated?" },
+    interrupt_id: "interrupt-1", question: "Which task should be updated?", options: [],
   });
   await user.type(screen.getByLabelText("확인 응답"), "Use the follow-up task");
   await user.click(screen.getByRole("button", { name: "응답 보내기" }));
@@ -2697,7 +2707,7 @@ test("Action risk follows the SSE-refreshed snapshot without rendering raw JSON"
   options.actionRisk = {
     schedule: { outcome: "WARNING", candidate_resource_ids: ["task-sensitive-1"] },
   };
-  FakeEventSource.instances[0]?.emit("action_status", { action_id: "action-1" });
+  FakeEventSource.instances[0]?.emit("action_status", { action_id: "action-1", status: "PROPOSED" });
 
   expect(
     await screen.findByText("서버 검증에서 확인된 위험 정보가 있습니다. 승인 전에 확인해 주세요."),

--- a/frontend/tests/architecture/feature_authority.test.ts
+++ b/frontend/tests/architecture/feature_authority.test.ts
@@ -1,11 +1,19 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, extname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
 const FRONTEND_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const REPOSITORY_ROOT = join(FRONTEND_ROOT, "..");
 const SOURCE_ROOT = join(FRONTEND_ROOT, "src");
 const FEATURE_ROOT = join(SOURCE_ROOT, "features");
+const DIRECTORY_OWNERSHIP_SOURCE = join(
+  REPOSITORY_ROOT,
+  "docs",
+  "canonical",
+  "16-repository-architecture",
+  "02-directory-ownership.md",
+);
 
 const FEATURE_OWNERS = [
   "approval",
@@ -18,41 +26,29 @@ const FEATURE_OWNERS = [
   "settings",
 ];
 
-const RESPONSIBILITY_MODULES = [
-  "startup_flow",
-  "startup_check",
-  "first_run_onboarding",
-  "session_bootstrap",
-  "api_compatibility_gate",
-  "main_shell",
-  "top_bar",
-  "resource_sidebar",
-  "resource_viewer",
-  "list_resources",
-  "session_page_cache",
-  "selected_resource_context",
-  "request_composer",
-  "subscribe_run_events",
-  "run_progress",
-  "confirmation_card",
-  "execution_status_card",
-  "conversation_history_panel",
-  "get_conversation_history",
-  "action_plan_card",
-  "recovery_card",
-  "settings_drawer",
-  "diagnostics_panel",
-  "attachment_list",
-  "download_attachment",
-  "attachment_picker",
-  "stage_attachment",
-];
-
 function sourceFiles(root: string): string[] {
   return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
     const path = join(root, entry.name);
     return entry.isDirectory() ? sourceFiles(path) : [path];
   }).filter((path) => [".ts", ".tsx"].includes(extname(path)) && !path.endsWith(".test.ts") && !path.endsWith(".test.tsx"));
+}
+
+function canonicalResponsibilityManifest(): readonly (readonly [string, string, string])[] {
+  const markdown = readFileSync(DIRECTORY_OWNERSHIP_SOURCE, "utf8");
+  const section = markdown
+    .split("### Frontend exact responsibility manifest", 2)[1]
+    ?.split("Frontend naming is deterministic", 1)[0];
+  expect(section, "canonical Frontend responsibility manifest").toBeDefined();
+  return section!.split("\n")
+    .filter((line) => line.startsWith("|") && !line.includes("---") && !line.includes("UI / Functional surface"))
+    .map((line) => {
+      const cells = line.slice(1, -1).split("|").map((cell) => cell.trim());
+      return [
+        cells[2].replaceAll("`", "").replace(/^frontend\//, ""),
+        cells[3].replaceAll("`", "").replace(/\(\)$/, ""),
+        cells[4].replaceAll("`", "").replace(/^frontend\//, ""),
+      ] as const;
+    });
 }
 
 describe("frontend canonical authority", () => {
@@ -66,9 +62,24 @@ describe("frontend canonical authority", () => {
     expect(actual).not.toEqual(expect.arrayContaining(["gmail", "tasks", "calendar"]));
   });
 
-  test("the canonical P0 responsibility manifest is present exactly once", () => {
+  test("the canonical P0 responsibility manifest fixes exact paths, symbols, and test owners", () => {
+    const responsibilityManifest = canonicalResponsibilityManifest();
+    expect(responsibilityManifest.length).toBeGreaterThan(0);
     const modules = sourceFiles(SOURCE_ROOT).map((path) => relative(SOURCE_ROOT, path).replace(/\\/g, "/").replace(/\.[^.]+$/, ""));
-    for (const responsibility of RESPONSIBILITY_MODULES) {
+    for (const [productionPath, primarySymbol, testOwnerPath] of responsibilityManifest) {
+      const production = join(FRONTEND_ROOT, productionPath);
+      const testOwner = join(FRONTEND_ROOT, testOwnerPath);
+      expect(existsSync(production), productionPath).toBe(true);
+      expect(existsSync(testOwner), testOwnerPath).toBe(true);
+
+      const productionSource = readFileSync(production, "utf8");
+      const escapedSymbol = primarySymbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      expect(productionSource, `${productionPath}::${primarySymbol}`).toMatch(
+        new RegExp(`\\bexport\\s+(?:default\\s+)?(?:async\\s+)?(?:function|class|const|let|var)\\s+${escapedSymbol}\\b`),
+      );
+      expect(readFileSync(testOwner, "utf8"), testOwnerPath).toContain("expect(");
+
+      const responsibility = productionPath.split("/").at(-1)?.replace(/\.[^.]+$/, "");
       const owners = modules.filter((module) => module.split("/").at(-1) === responsibility);
       expect(owners, responsibility).toHaveLength(1);
     }

--- a/frontend/tests/features/run/api/subscribe_run_events.test.ts
+++ b/frontend/tests/features/run/api/subscribe_run_events.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, test, vi } from "vitest";
 import { subscribeRunEvents } from "../../../../src/features/run/api/subscribe_run_events";
+import { RUN_SSE_EVENT_TYPES, type RunSseEventType } from "../../../../src/features/run/api/run_sse_event";
+
+const payloads: Record<RunSseEventType, Record<string, unknown>> = {
+  run_status: { status: "ANALYZING", snapshot_version: 2 },
+  phase_changed: { phase: "TOOL_ROUTING" },
+  tool_routing: { route_revision: 1, input_route_count: 2, output_mode: "ACTION" },
+  retrieval_progress: { coverage: "PARTIAL", completed_sources: 1, total_sources: 2 },
+  confirmation_required: { interrupt_id: "i-1", question: "계속할까요?", options: ["예"] },
+  analysis_progress: { completed_stage: "WORK_ANALYSIS" },
+  plan_updated: { plan_id: "p-1", revision_no: 2 },
+  approval_required: { action_ids: ["a-1"] },
+  action_status: { action_id: "a-1", status: "APPROVED" },
+  verification_result: { action_id: "a-1", outcome: "VERIFIED" },
+  reauth_required: { connector_id: "google" },
+  recovery_required: { recovery: { reason_code: "CHECKPOINT_MISMATCH", target: { target_kind: "RUN" }, allowed_resolution_kinds: ["RECHECK", "CANCEL", "FAIL"] } },
+  completed: { status: "COMPLETED", result_kind: "SUCCESS" },
+  error: { error_code: "INTERNAL_ERROR", recoverable: false },
+};
 
 class FakeEventSource {
   listeners = new Map<string, Array<(event: MessageEvent<string>) => void>>();
@@ -10,28 +28,64 @@ class FakeEventSource {
   addEventListener(type: string, listener: (event: MessageEvent<string>) => void): void {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
   }
-  emit(type: string, payload: Record<string, unknown>, eventId = `${type}-1`): void {
-    const event = { data: JSON.stringify(payload), lastEventId: eventId } as MessageEvent<string>;
+  emit(type: string, payload: unknown, eventId = `${type}-1`): void {
+    const data = type === "snapshot_required" ? payload : {
+      schema_version: 1, event_id: eventId, run_id: "run-1", action_id: null,
+      occurred_at_ms: 1, event_type: type, payload, projection_version: 1,
+    };
+    const event = { data: JSON.stringify(data), lastEventId: eventId } as MessageEvent<string>;
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+  emitRaw(type: string, data: unknown, eventId = `${type}-1`): void {
+    const event = { data: JSON.stringify(data), lastEventId: eventId } as MessageEvent<string>;
     for (const listener of this.listeners.get(type) ?? []) listener(event);
   }
 }
 
+function setup() {
+  let current: FakeEventSource | null = null;
+  Object.defineProperty(globalThis, "EventSource", { configurable: true, value: vi.fn((url: string, init?: EventSourceInit) => (current = new FakeEventSource(url, init))) });
+  const onEvent = vi.fn();
+  const onSnapshotRequired = vi.fn();
+  const onStateChange = vi.fn();
+  const unsubscribe = subscribeRunEvents("run/1", { onEvent, onSnapshotRequired, onStateChange });
+  return { current: () => current!, onEvent, onSnapshotRequired, onStateChange, unsubscribe };
+}
+
 describe("subscribeRunEvents", () => {
+  test("declares, decodes, and dispatches the exact canonical 14-event set", () => {
+    const context = setup();
+    expect(RUN_SSE_EVENT_TYPES).toHaveLength(14);
+    expect(context.current().listeners.size).toBe(15);
+    for (const eventType of RUN_SSE_EVENT_TYPES) context.current().emit(eventType, payloads[eventType]);
+    expect(context.onEvent).toHaveBeenCalledTimes(14);
+    expect(context.onEvent.mock.calls.map(([event]) => event.event_type)).toEqual(RUN_SSE_EVENT_TYPES);
+    context.unsubscribe();
+  });
+
   test("observes unique events and closes before requesting a durable snapshot", () => {
-    let current: FakeEventSource | null = null;
-    Object.defineProperty(globalThis, "EventSource", { configurable: true, value: vi.fn((url: string, init?: EventSourceInit) => (current = new FakeEventSource(url, init))) });
-    const onEvent = vi.fn();
-    const onSnapshotRequired = vi.fn();
-    const unsubscribe = subscribeRunEvents("run/1", { onEvent, onSnapshotRequired, onStateChange: vi.fn() });
-    expect(current!.url).toBe("/api/v1/runs/run%2F1/events");
-    current!.emit("plan_updated", { revision: 1 }, "event-1");
-    current!.emit("plan_updated", { revision: 2 }, "event-1");
-    expect(onEvent).toHaveBeenCalledTimes(1);
-    current!.emit("EXTERNAL_LLM_SCOPE_PUBLISHED", { scope_revision: 2 }, "event-2");
-    expect(onEvent).toHaveBeenLastCalledWith(expect.objectContaining({ eventType: "EXTERNAL_LLM_SCOPE_PUBLISHED" }));
-    current!.emit("snapshot_required", {}, "");
-    expect(current!.close).toHaveBeenCalled();
-    expect(onSnapshotRequired).toHaveBeenCalledOnce();
-    unsubscribe();
+    const context = setup();
+    expect(context.current().url).toBe("/api/v1/runs/run%2F1/events");
+    context.current().emit("plan_updated", payloads.plan_updated, "event-1");
+    context.current().emit("plan_updated", payloads.plan_updated, "event-1");
+    expect(context.onEvent).toHaveBeenCalledTimes(1);
+    context.current().emit("snapshot_required", {}, "");
+    expect(context.current().close).toHaveBeenCalled();
+    expect(context.onSnapshotRequired).toHaveBeenCalledOnce();
+  });
+
+  test.each(["RUN_UPDATED", "EXTERNAL_LLM_SCOPE_PUBLISHED", "unknown"])("does not accept non-SSE event %s", (eventType) => {
+    const context = setup();
+    context.current().emit(eventType, {});
+    expect(context.onEvent).not.toHaveBeenCalled();
+  });
+
+  test("rejects mismatched, undeclared, and malformed envelopes without trusted-state dispatch", () => {
+    const context = setup();
+    context.current().emit("run_status", payloads.phase_changed, "bad-1");
+    context.current().emit("run_status", { ...payloads.run_status, token: "secret" }, "bad-2");
+    context.current().emitRaw("run_status", { schema_version: 1 }, "bad-3");
+    expect(context.onEvent).not.toHaveBeenCalled();
+    expect(context.onStateChange).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/tests/features/run/run_progress.test.tsx
+++ b/frontend/tests/features/run/run_progress.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { expect, test, vi } from "vitest";
 import type { RunSnapshot } from "../../../src/api/contract";
 import { RunProgress } from "../../../src/features/run/run_progress";
+import type { RunSseEvent } from "../../../src/features/run/api/run_sse_event";
 
 test("RunProgress exposes only server-projected cancel and resume actions", async () => {
   const snapshot = { run: { status: "BLOCKED", next_allowed_commands: ["REQUEST_CANCEL"] }, execution_status: { action_count: 1, terminal_action_count: 0 }, terminal_result_kind: "NONE", error: { actions: [{ kind: "RESUME_SAFE_CHECKPOINT", resume_kind: "SAFE_CHECKPOINT_RESUME" }] } } as RunSnapshot;
@@ -10,4 +11,18 @@ test("RunProgress exposes only server-projected cancel and resume actions", asyn
   render(<RunProgress snapshot={snapshot} busy={null} onCancel={vi.fn()} onResume={onResume} />);
   await userEvent.setup().click(screen.getByRole("button", { name: "재개" }));
   expect(onResume).toHaveBeenCalledWith("SAFE_CHECKPOINT_RESUME");
+});
+
+test.each([
+  ["tool_routing", { route_revision: 1, input_route_count: 2, output_mode: "ACTION" }, "도구 경로 2개 분석 완료"],
+  ["retrieval_progress", { coverage: "PARTIAL", completed_sources: 1, total_sources: 3 }, "자료 확인 1/3"],
+  ["analysis_progress", { completed_stage: "WORK_ANALYSIS" }, "분석 완료: WORK_ANALYSIS"],
+] as const)("RunProgress preserves canonical %s progress", (eventType, payload, label) => {
+  const snapshot = { run: { status: "ANALYZING", next_allowed_commands: [] }, execution_status: { action_count: 0, terminal_action_count: 0 }, terminal_result_kind: "NONE" } as RunSnapshot;
+  const latestEvent = {
+    schema_version: 1, event_id: "event-1", run_id: "run-1", action_id: null,
+    occurred_at_ms: 1, event_type: eventType, payload, projection_version: 1,
+  } as RunSseEvent;
+  render(<RunProgress snapshot={snapshot} latestEvent={latestEvent} busy={null} onCancel={vi.fn()} onResume={vi.fn()} />);
+  expect(screen.getByTestId("run-event-progress")).toHaveTextContent(label);
 });

--- a/frontend/tests/product-e2e/core_product_journeys.spec.ts
+++ b/frontend/tests/product-e2e/core_product_journeys.spec.ts
@@ -1,0 +1,352 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+type ProductRow = Record<string, unknown>;
+
+type ProductState = {
+  run: ProductRow;
+  plans: ProductRow[];
+  actions: ProductRow[];
+  action_dependencies: ProductRow[];
+  approvals: ProductRow[];
+  execution_attempts: ProductRow[];
+  verifications: ProductRow[];
+  messages: ProductRow[];
+  workflow_binding: ProductRow;
+  audit_events: ProductRow[];
+  run_count: number;
+  command_count: number;
+  mcp_events: ProductRow[];
+  llm_invocations: ProductRow[];
+};
+
+type StartedRun = {
+  runId: string;
+  requestPayload: Record<string, unknown>;
+};
+
+const baseURL = "http://127.0.0.1:18765";
+const writeTools = new Set([
+  "calendar_create_event",
+  "gmail_create_draft",
+  "gmail_send_message",
+  "tasks_create_task",
+]);
+
+let context: BrowserContext;
+let page: Page;
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async ({ browser }, testInfo) => {
+  testInfo.setTimeout(120_000);
+  context = await browser.newContext();
+  page = await context.newPage();
+  await page.goto(
+    "/#bootstrap_secret=browser-product-e2e-bootstrap-secret"
+      + "&service_instance_id=browser-product-e2e-service",
+  );
+
+  await expect(page.getByRole("main").getByRole("heading", { name: "Google Work Agent 시작하기" })).toBeVisible();
+  await expect(page.getByText("설정 상태를 확인하고 있습니다.", { exact: true })).toHaveCount(0);
+  const consent = page.getByLabel("외부 LLM으로 요청 컨텍스트를 전송하는 데 동의합니다.");
+  await consent.check();
+  await expect(consent).toBeChecked();
+  await page.getByRole("button", { name: "동의 저장" }).click();
+  await expect(page.getByText("완료 · 개인정보·외부 LLM 전송 동의")).toBeVisible();
+  await page.getByLabel("API Key").fill("browser-product-e2e-gemini-key");
+  await page.getByLabel("저장 방식").selectOption("SESSION_ONLY");
+  await page.getByRole("button", { name: "저장하고 연결 검사" }).click();
+  await expect(page.getByText("완료 · API LLM 연결")).toBeVisible();
+  const completeSetup = page.getByRole("button", { name: "설정 완료하고 시작" });
+  await expect(completeSetup).toBeEnabled();
+  await completeSetup.click();
+  await expect(page.getByRole("textbox", { name: /선택한 .*업무를 요청하세요/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: /새 대화/ })).toBeVisible();
+});
+
+test.afterAll(async () => {
+  await context.close();
+});
+
+test("E2E_001_ANSWER_ONLY_PASS", async () => {
+  const baseline = await productState("missing-run");
+  const { runId } = await startNewRun("E2E:ANSWER_ONLY 현재 상태를 설명해줘");
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi("E2E completed: ANSWER_ONLY");
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.plans).toHaveLength(0);
+  expect(completed.actions).toHaveLength(0);
+  expect(completed.approvals).toHaveLength(0);
+  expect(completed.messages.filter((message) => message.role === "ASSISTANT")).toHaveLength(1);
+  expect(writeCount(completed) - writeCount(baseline)).toBe(0);
+  expect(auditTypes(completed)).toContain("RUN_COMPLETED");
+});
+
+test("E2E_002_GMAIL_READ_PASS", async () => {
+  await beginNewConversation();
+  const resourceCheckbox = page.getByRole("checkbox", { name: "E2E mail 선택" });
+  await expect(resourceCheckbox).toBeVisible();
+  await resourceCheckbox.check();
+  await expect(page.getByText("요청에 사용할 자료 1개")).toBeVisible();
+  await expect(page.getByText("E2E mail", { exact: true }).last()).toBeVisible();
+  const baseline = await productState("missing-run");
+
+  const { runId, requestPayload } = await startRun(
+    "E2E:GMAIL_READ 선택한 메일의 핵심 내용을 알려줘",
+  );
+  expect(requestPayload.entry_mode).toBe("RESOURCE_SELECTED");
+  expect(requestPayload.selected_resource_handles).toEqual([expect.any(String)]);
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi("E2E completed: GMAIL_READ");
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.actions).toHaveLength(0);
+  expect(toolCount(completed, "gmail_search_threads") - toolCount(baseline, "gmail_search_threads")).toBe(1);
+  expect(writeCount(completed) - writeCount(baseline)).toBe(0);
+  expect(completed.messages.filter((message) => message.role === "ASSISTANT")).toHaveLength(1);
+
+  await resourceCheckbox.uncheck();
+  await expect(page.getByText("요청에 사용할 자료 1개")).toHaveCount(0);
+});
+
+test("E2E_003_TASK_CREATE_APPROVE_VERIFY_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:APPROVED_WRITE 새 태스크를 만들어줘");
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  const card = await actionCard("tasks_create_task");
+  expect(toolCount(waiting, "tasks_create_task") - toolCount(baseline, "tasks_create_task")).toBe(0);
+  await approve(card);
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi();
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.actions.map((action) => action.status)).toEqual(["VERIFIED"]);
+  expect(completed.execution_attempts.map((attempt) => attempt.status)).toEqual(["SUCCEEDED"]);
+  expect(completed.verifications.map((verification) => verification.status)).toEqual(["VERIFIED"]);
+  expect(assistantMessages(completed)).toHaveLength(1);
+  expect(toolCount(completed, "tasks_create_task") - toolCount(baseline, "tasks_create_task")).toBe(1);
+  expect(toolCount(completed, "tasks_get_task") - toolCount(baseline, "tasks_get_task")).toBe(1);
+  expect(auditTypes(completed)).toEqual(expect.arrayContaining(["ACTION_APPROVED", "RUN_COMPLETED"]));
+});
+
+test("E2E_004_CALENDAR_CREATE_APPROVE_VERIFY_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:CALENDAR_WRITE 새 일정을 만들어줘");
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  const card = await actionCard("calendar_create_event");
+  expect(toolCount(waiting, "calendar_create_event") - toolCount(baseline, "calendar_create_event")).toBe(0);
+  await approve(card);
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi();
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.actions.map((action) => action.status)).toEqual(["VERIFIED"]);
+  expect(completed.verifications.map((verification) => verification.status)).toEqual(["VERIFIED"]);
+  expect(assistantMessages(completed)).toHaveLength(1);
+  expect(toolCount(completed, "calendar_create_event") - toolCount(baseline, "calendar_create_event")).toBe(1);
+  expect(toolCount(completed, "calendar_get_event") - toolCount(baseline, "calendar_get_event")).toBe(1);
+});
+
+test("E2E_005_REJECT_WRITE_ZERO_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:REJECTION 태스크 생성 계획을 준비해줘");
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  const card = await actionCard("tasks_create_task");
+  expect(writeCount(waiting) - writeCount(baseline)).toBe(0);
+  await card.getByRole("button", { name: "거절", exact: true }).click();
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi();
+  await expect(page.getByText("일부 작업은 완료되었고 나머지는 취소되었습니다.")).toBeVisible();
+  expect(completed.run.terminal_result_kind).toBe("PARTIAL");
+  expect(completed.actions.map((action) => action.status)).toEqual(["REJECTED"]);
+  expect(completed.execution_attempts).toHaveLength(0);
+  expect(completed.verifications).toHaveLength(0);
+  expect(assistantMessages(completed)).toHaveLength(1);
+  expect(writeCount(completed) - writeCount(baseline)).toBe(0);
+  expect(auditTypes(completed)).toEqual(expect.arrayContaining(["ACTION_REJECTED", "RUN_COMPLETED"]));
+});
+
+test("E2E_006_CONFIRMATION_RESUME_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:RESTART_RESUME 모호한 대상을 처리해줘");
+  const interrupted = await waitForRunStatus(runId, "WAITING_CONFIRMATION");
+
+  const confirmation = page.getByRole("article").filter({ hasText: "추가 확인" });
+  await expect(confirmation).toBeVisible();
+  const originalThreadId = interrupted.workflow_binding.langgraph_thread_id;
+  const originalRunCount = interrupted.run_count;
+  await confirmation.getByRole("textbox", { name: "확인 응답" }).fill("E2E Tasks 목록을 사용해줘.");
+  await confirmation.getByRole("button", { name: "응답 보내기" }).click();
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  expect(waiting.run_count).toBe(originalRunCount);
+  expect(waiting.run_count - baseline.run_count).toBe(1);
+  expect(waiting.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  const identifyGoalCalls = waiting.llm_invocations.filter(
+    (invocation) => invocation.scenario === "RESTART_RESUME"
+      && invocation.prompt_id === "request_understanding.identify_goal",
+  );
+  // LangGraph re-enters only the interrupted semantic-owner subgraph and
+  // injects the response there; the Main workflow, Run, and thread stay intact.
+  expect(
+    identifyGoalCalls.map((invocation) => Boolean(invocation.has_confirmation_response)),
+  ).toEqual([false, true]);
+  expect(auditTypes(waiting)).toEqual(expect.arrayContaining(["CONFIRMATION_REQUESTED", "CONFIRMATION_RESUMED"]));
+
+  await approve(await actionCard("tasks_create_task"));
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+  await assertCompletedUi();
+  expect(completed.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(assistantMessages(completed)).toHaveLength(1);
+  expect(toolCount(completed, "tasks_create_task") - toolCount(baseline, "tasks_create_task")).toBe(1);
+});
+
+test("E2E_007_PARTIAL_APPROVAL_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:PARTIAL_APPROVAL 태스크와 일정을 준비해줘");
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  expect(waiting.actions).toHaveLength(2);
+  expect(waiting.action_dependencies).toHaveLength(0);
+  const taskCard = await actionCard("tasks_create_task");
+  const calendarCard = await actionCard("calendar_create_event");
+  const rejectCalendar = calendarCard.getByRole("button", { name: "거절", exact: true });
+  await approve(taskCard);
+  await expect(rejectCalendar).toBeEnabled();
+  await rejectCalendar.click();
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+
+  await assertCompletedUi();
+  await expect(page.getByText("일부 작업은 완료되었고 나머지는 취소되었습니다.")).toBeVisible();
+  const statusByTool = Object.fromEntries(completed.actions.map((action) => [action.tool_name, action.status]));
+  expect(statusByTool).toEqual({ calendar_create_event: "REJECTED", tasks_create_task: "VERIFIED" });
+  expect(completed.run.terminal_result_kind).toBe("PARTIAL");
+  expect(toolCount(completed, "tasks_create_task") - toolCount(baseline, "tasks_create_task")).toBe(1);
+  expect(toolCount(completed, "calendar_create_event") - toolCount(baseline, "calendar_create_event")).toBe(0);
+  expect(completed.verifications).toHaveLength(1);
+  expect(completed.verifications[0].status).toBe("VERIFIED");
+  expect(assistantMessages(completed)).toHaveLength(1);
+});
+
+test("E2E_008_REFRESH_SSE_RECOVERY_PASS", async () => {
+  await beginNewConversation();
+  const baseline = await productState("missing-run");
+  const { runId } = await startRun("E2E:APPROVED_WRITE 새로고침 후 태스크를 만들어줘");
+  const waiting = await waitForRunStatus(runId, "WAITING_APPROVAL");
+  await expect(await actionCard("tasks_create_task")).toBeVisible();
+  const originalRunCount = waiting.run_count;
+  const originalCommandCount = waiting.command_count;
+  const originalThreadId = waiting.workflow_binding.langgraph_thread_id;
+
+  await page.reload();
+  await expect(page.getByRole("region", { name: "에이전트 대화" })).toBeVisible();
+  await expect(await actionCard("tasks_create_task")).toBeVisible();
+  const restored = await waitForRunStatus(runId, "WAITING_APPROVAL");
+  expect(restored.run_count).toBe(originalRunCount);
+  expect(restored.command_count).toBe(originalCommandCount);
+  expect(restored.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(writeCount(restored) - writeCount(baseline)).toBe(0);
+
+  await approve(await actionCard("tasks_create_task"));
+  const completed = await waitForRunStatus(runId, "COMPLETED");
+  await assertCompletedUi();
+  expect(completed.run_count).toBe(originalRunCount);
+  expect(completed.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(toolCount(completed, "tasks_create_task") - toolCount(baseline, "tasks_create_task")).toBe(1);
+  expect(completed.actions.map((action) => action.status)).toEqual(["VERIFIED"]);
+  expect(assistantMessages(completed)).toHaveLength(1);
+});
+
+async function beginNewConversation(): Promise<void> {
+  await page.getByRole("button", { name: /새 대화/ }).click();
+  await expect(page.getByRole("region", { name: "Action Plan" })).toHaveCount(0);
+}
+
+async function startNewRun(requestText: string): Promise<StartedRun> {
+  await beginNewConversation();
+  return startRun(requestText);
+}
+
+async function startRun(requestText: string): Promise<StartedRun> {
+  const composer = page.getByRole("textbox", { name: /선택한 .*업무를 요청하세요/ });
+  await composer.fill(requestText);
+  const responsePromise = page.waitForResponse((response) => (
+    response.request().method() === "POST"
+      && new URL(response.url()).pathname === "/api/v1/runs"
+  ));
+  await page.getByRole("button", { name: "보내기", exact: true }).click();
+  const response = await responsePromise;
+  expect(response.status()).toBe(202);
+  const payload = await response.json() as { run_id: string };
+  const requestPayload = response.request().postDataJSON() as Record<string, unknown>;
+  return { runId: payload.run_id, requestPayload };
+}
+
+async function productState(runId: string): Promise<ProductState> {
+  const response = await context.request.get(
+    `${baseURL}/__e2e__/state/${encodeURIComponent(runId)}`,
+  );
+  expect(response.ok()).toBe(true);
+  return await response.json() as ProductState;
+}
+
+async function waitForRunStatus(runId: string, status: string): Promise<ProductState> {
+  let current = await productState(runId);
+  await expect.poll(async () => {
+    current = await productState(runId);
+    return current.run.status;
+  }).toBe(status);
+  return current;
+}
+
+async function actionCard(toolName: string) {
+  const card = page
+    .getByRole("region", { name: "Action Plan" })
+    .getByRole("article")
+    .filter({ hasText: toolName });
+  await expect(card).toBeVisible();
+  return card;
+}
+
+async function approve(card: Awaited<ReturnType<typeof actionCard>>): Promise<void> {
+  const acknowledgements = card.getByRole("checkbox");
+  for (let index = 0; index < await acknowledgements.count(); index += 1) {
+    await acknowledgements.nth(index).check();
+  }
+  await card.getByRole("button", {
+    name: /^(승인|확인하고 승인|충돌을 알고도 진행|그래도 새로 만들기)$/,
+  }).click();
+}
+
+async function assertCompletedUi(answer?: string): Promise<void> {
+  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toBeVisible();
+  let assistantMessage = page.getByRole("article").filter({ hasText: "에이전트 응답" });
+  if (answer) assistantMessage = assistantMessage.filter({ hasText: answer });
+  await expect(assistantMessage).toBeVisible();
+}
+
+function toolCount(state: ProductState, toolName: string): number {
+  return state.mcp_events.filter((event) => event.tool_name === toolName).length;
+}
+
+function writeCount(state: ProductState): number {
+  return state.mcp_events.filter((event) => writeTools.has(String(event.tool_name))).length;
+}
+
+function auditTypes(state: ProductState): unknown[] {
+  return state.audit_events.map((event) => event.event_type);
+}
+
+function assistantMessages(state: ProductState): ProductRow[] {
+  return state.messages.filter((message) => message.role === "ASSISTANT");
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     }
   },
   test: {
+    include: ["tests/**/*.test.{ts,tsx}"],
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
     coverage: {

--- a/launcher/serve_instance_control.py
+++ b/launcher/serve_instance_control.py
@@ -115,10 +115,8 @@ class _CurrentUserPipeListener:
             self._pending_handle = None
         connection = PipeConnection(handle)
         try:
-            # typeshed narrows these helpers to socket Connection even though AF_PIPE
-            # PipeConnection implements the same challenge byte protocol on Windows.
-            deliver_challenge(connection, self._authkey)  # type: ignore[arg-type]
-            answer_challenge(connection, self._authkey)  # type: ignore[arg-type]
+            deliver_challenge(connection, self._authkey)
+            answer_challenge(connection, self._authkey)
         except Exception:
             connection.close()
             raise

--- a/src/google_work_agent/adapters/langgraph/main/plan_persistence.py
+++ b/src/google_work_agent/adapters/langgraph/main/plan_persistence.py
@@ -266,7 +266,10 @@ class PlanPersistenceMixin:
         action_id_map = {action["action_id"]: action["action_id"] for action in plan["actions"]}
         retrieval_result = _require_state_value(state["retrieval_result"], "retrieval_result")
         evidence_ids = evidence_ids_from_plan(plan)
-        evidence_id_map = {item: item for item in evidence_ids}
+        # Retrieval evidence ids are logical, run-scoped references. Persisted
+        # Evidence ids are repository-wide identities and must stay unique when
+        # a later Run selects the same external resource segment.
+        evidence_id_map = {item: self._id_factory() for item in evidence_ids}
         if replan_from_plan_id is not None and not any(
             plan.id == replan_from_plan_id for plan in plans
         ):
@@ -278,7 +281,6 @@ class PlanPersistenceMixin:
             # evidence identities that already belong to an older Plan.
             plan_id = self._id_factory()
             action_id_map = {action["action_id"]: self._id_factory() for action in plan["actions"]}
-            evidence_id_map = {item: self._id_factory() for item in evidence_ids}
 
         evidence_drafts = {
             item["evidence_id"]: item

--- a/src/google_work_agent/adapters/langgraph/main/workflow.py
+++ b/src/google_work_agent/adapters/langgraph/main/workflow.py
@@ -1025,11 +1025,11 @@ class _WorkflowRuntimeComposition:
                 run_id=cast(str, facts["run_id"]),
                 occurred_at_ms=self._now_ms(),
                 event_type="error" if status == "FAILED" else "completed",
-                payload={
-                    "run_status": status,
-                    "run_version": facts["version"],
-                    "result_kind": facts["terminal_result_kind"],
-                },
+                payload=(
+                    {"error_code": "WORKFLOW_FAILED", "recoverable": False}
+                    if status == "FAILED"
+                    else {"status": status, "result_kind": facts["terminal_result_kind"]}
+                ),
             )
         )
 

--- a/src/google_work_agent/adapters/system/memory/sse_event_buffer.py
+++ b/src/google_work_agent/adapters/system/memory/sse_event_buffer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from queue import Empty, Queue
 from threading import Lock
 from typing import Literal, cast
@@ -46,13 +46,18 @@ class InMemorySseEventBuffer(SseEventBufferPort):
         self._lock = Lock()
 
     def append(self, event: RunSseEventV1) -> None:
+        validated = RunSseEventV1.model_validate(event)
         with self._lock:
             event_id = f"{self._service_instance_id}:{self._next_counter}"
             self._next_counter += 1
-            sanitized = cast(dict[str, object], sanitize_event_attributes(event.payload).values)
-            published = replace(event, event_id=event_id, payload=sanitized)
-            self._buffers[event.run_id].append(published)
-            subscribers = tuple(self._subscribers[event.run_id])
+            values = validated.model_dump(mode="python")
+            values["event_id"] = event_id
+            values["payload"] = sanitize_event_attributes(
+                validated.payload.model_dump(mode="python")
+            ).values
+            published = RunSseEventV1.model_validate(values)
+            self._buffers[validated.run_id].append(published)
+            subscribers = tuple(self._subscribers[validated.run_id])
         for subscriber in subscribers:
             subscriber.queue.put_nowait(published)
 

--- a/src/google_work_agent/adapters/system/workflow_outcome_projector.py
+++ b/src/google_work_agent/adapters/system/workflow_outcome_projector.py
@@ -149,13 +149,18 @@ def accepted_event_type(payload: dict[str, object]) -> RunSseEventTypeV1:
         interrupt_kind = interrupt_payload.get("interrupt_kind")
         if interrupt_kind == "CONFIRMATION":
             return "confirmation_required"
-        if interrupt_kind == "APPROVAL":
+        action_ids = interrupt_payload.get("action_ids")
+        if (
+            interrupt_kind == "APPROVAL"
+            and isinstance(action_ids, list)
+            and all(isinstance(item, str) for item in action_ids)
+        ):
             return "approval_required"
     phase = payload.get("phase")
     if phase == "WAITING_CONFIRMATION":
         return "confirmation_required"
     if phase == "WAITING_APPROVAL":
-        return "approval_required"
+        return "run_status"
     return "run_status"
 
 

--- a/src/google_work_agent/adapters/system/workflow_outcome_projector.py
+++ b/src/google_work_agent/adapters/system/workflow_outcome_projector.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from google_work_agent.application.use_cases.execution_attempt.write_execution_contracts import (
     WriteRunResponse,
@@ -16,12 +16,13 @@ from google_work_agent.application.use_cases.sse_event.project_run_event import 
     ProjectRunEventHandler,
 )
 from google_work_agent.domain.canonical import calculate_canonical_json_hash
-from google_work_agent.domain.recovery.model import RecoveryReasonV1
+from google_work_agent.domain.recovery.model import RECOVERY_RESOLUTION_MATRIX, RecoveryReasonV1
 from google_work_agent.domain.run.model import RunStatusV1
 from google_work_agent.ports.system.contracts.workflow_execution import WorkflowOutcome
 from google_work_agent.ports.system.contracts.workflow_handoff import (
     RegisteredResumeTargetRefV2,
 )
+from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventTypeV1
 
 
 class WorkflowOutcomeProjector:
@@ -43,25 +44,17 @@ class WorkflowOutcomeProjector:
         self._recovery_target = recovery_target
 
     def publish_cancel_response(self, response: WriteRunResponse) -> None:
-        event_type = (
-            "completed"
-            if response.run_status == RunStatusV1.CANCELLED.value
-            else "recovery_required"
-            if response.run_status == RunStatusV1.RECOVERY_REQUIRED.value
-            else "run_status"
-        )
-        self.publish(
-            ProjectRunEventCommand(
-                run_id=response.run_id,
-                occurred_at_ms=self._now_ms(),
-                event_type=event_type,
-                payload={
-                    "result_code": response.result_code,
-                    "run_status": response.run_status,
-                    "run_version": response.run_version,
-                    "result_kind": response.result_kind,
-                },
+        if response.run_status == RunStatusV1.CANCELLED.value:
+            self._publish(
+                response.run_id,
+                "completed",
+                {"status": "CANCELLED", "result_kind": "CANCELLED"},
             )
+            return
+        self._publish(
+            response.run_id,
+            "run_status",
+            {"status": response.run_status, "snapshot_version": response.run_version},
         )
 
     def handle_result(
@@ -80,14 +73,7 @@ class WorkflowOutcomeProjector:
                 expected_version=expected_version,
                 reason="CHECKPOINT_MISMATCH",
             )
-            self.publish(
-                ProjectRunEventCommand(
-                    run_id=run_id,
-                    occurred_at_ms=self._now_ms(),
-                    event_type="recovery_required",
-                    payload={"outcome": outcome.value},
-                )
-            )
+            self._publish(run_id, "recovery_required", _recovery_payload("CHECKPOINT_MISMATCH"))
             return
         if outcome is WorkflowOutcome.FAILED:
             self._require_recovery_result(
@@ -102,20 +88,30 @@ class WorkflowOutcomeProjector:
             WorkflowOutcome.RECOVERY_REQUIRED: "recovery_required",
             WorkflowOutcome.FAILED: "error",
         }[outcome]
-        self.publish(
-            ProjectRunEventCommand(
-                run_id=run_id,
-                occurred_at_ms=self._now_ms(),
-                event_type=event_type,
-                payload={"outcome": outcome.value, **payload},
-            )
-        )
+        event_payload = _canonical_payload(event_type, payload, expected_version)
+        if event_payload is not None:
+            self._publish(run_id, event_type, event_payload)
 
     def publish(self, event: ProjectRunEventCommand) -> None:
         try:
             self._project_run_event(event)
         except Exception:
             return
+
+    def _publish(
+        self,
+        run_id: str,
+        event_type: RunSseEventTypeV1,
+        payload: dict[str, object],
+    ) -> None:
+        self.publish(
+            ProjectRunEventCommand(
+                run_id=run_id,
+                occurred_at_ms=self._now_ms(),
+                event_type=event_type,
+                payload=payload,
+            )
+        )
 
     def _require_recovery_result(
         self,
@@ -147,7 +143,7 @@ class WorkflowOutcomeProjector:
             raise RuntimeError(result.conflict_detail or "RequireRecovery was not applied")
 
 
-def accepted_event_type(payload: dict[str, object]) -> str:
+def accepted_event_type(payload: dict[str, object]) -> RunSseEventTypeV1:
     interrupt_payload = payload.get("user_interrupt")
     if isinstance(interrupt_payload, dict):
         interrupt_kind = interrupt_payload.get("interrupt_kind")
@@ -161,3 +157,52 @@ def accepted_event_type(payload: dict[str, object]) -> str:
     if phase == "WAITING_APPROVAL":
         return "approval_required"
     return "run_status"
+
+
+def _canonical_payload(
+    event_type: RunSseEventTypeV1,
+    payload: Mapping[str, object],
+    snapshot_version: int,
+) -> dict[str, object] | None:
+    if event_type == "run_status" and isinstance(payload.get("run_status"), str):
+        return {"status": payload["run_status"], "snapshot_version": snapshot_version}
+    if event_type == "phase_changed" and isinstance(payload.get("phase"), str):
+        return {"phase": payload["phase"]}
+    if event_type == "error":
+        error_code = payload.get("error_code")
+        return {
+            "error_code": error_code if isinstance(error_code, str) else "WORKFLOW_FAILED",
+            "recoverable": True,
+        }
+    interrupt = payload.get("user_interrupt")
+    if event_type == "confirmation_required" and isinstance(interrupt, Mapping):
+        interrupt_id, question, options = (
+            interrupt.get("interrupt_id"),
+            interrupt.get("question"),
+            interrupt.get("options"),
+        )
+        if (
+            isinstance(interrupt_id, str)
+            and isinstance(question, str)
+            and isinstance(options, list)
+        ):
+            labels = [item.get("label") for item in options if isinstance(item, Mapping)]
+            if all(isinstance(label, str) for label in labels):
+                return {"interrupt_id": interrupt_id, "question": question, "options": labels}
+    if event_type == "approval_required" and isinstance(interrupt, Mapping):
+        action_ids = interrupt.get("action_ids")
+        if isinstance(action_ids, list) and all(isinstance(item, str) for item in action_ids):
+            return {"action_ids": action_ids}
+    return None
+
+
+def _recovery_payload(reason: RecoveryReasonV1) -> dict[str, object]:
+    return {
+        "recovery": {
+            "reason_code": reason,
+            "target": {"target_kind": "RUN"},
+            "allowed_resolution_kinds": [
+                item.value for item in RECOVERY_RESOLUTION_MATRIX[reason]
+            ],
+        }
+    }

--- a/src/google_work_agent/api/composition.py
+++ b/src/google_work_agent/api/composition.py
@@ -2303,7 +2303,11 @@ def build_production_runtime(
 
     project_external_llm_transfer_scope = ProjectExternalLlmTransferScopeHandler(
         checkpoint,
-        ProjectRunEventHandler(event_publisher),
+        EmitTraceEventHandler(
+            unit_of_work_factory=unit_of_work_factory,
+            environment=oauth_environment.value,
+            release_version=release_version,
+        ),
     )
     project_context_preview = ProjectContextPreviewHandler(
         unit_of_work_factory=read_unit_of_work_factory,

--- a/src/google_work_agent/api/routes/runs.py
+++ b/src/google_work_agent/api/routes/runs.py
@@ -1,9 +1,9 @@
 """Run routes."""
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import asdict
 from json import dumps
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from fastapi import APIRouter, Header, Request, Response, status
 from fastapi.responses import StreamingResponse
@@ -28,6 +28,7 @@ from google_work_agent.api.schemas.runs.get_run_context import (
     RunContextResponse,
 )
 from google_work_agent.api.schemas.runs.get_run_snapshot import RunSnapshotResponseV1
+from google_work_agent.api.schemas.runs.list_run_events import serialize_run_sse_event
 from google_work_agent.api.schemas.runs.resolve_recovery import ResolveRecoveryRequestV1
 from google_work_agent.api.schemas.runs.resume_run import ResumeRunRequestV2
 from google_work_agent.api.schemas.runs.start_run import StartRunRequest, StartRunResponseV1
@@ -67,6 +68,10 @@ from google_work_agent.application.use_cases.run.start_run import StartRunComman
 from google_work_agent.application.use_cases.sse_event.list_run_events import ListRunEventsQuery
 from google_work_agent.domain.recovery.model import RecoveryResolution
 from google_work_agent.ports.system.api_access_port import EndpointPolicy
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RunSseEventTypeV1,
+    RunSseEventV1,
+)
 
 router = APIRouter(prefix="/api/v1")
 
@@ -209,7 +214,7 @@ def stream_events(
         )
     if replay.cursor_status == "CURSOR_EXPIRED":
         return StreamingResponse(
-            iter((_format_sse("", "snapshot_required", {"run_id": run_id}),)),
+            iter((_format_transport_sse("", "snapshot_required", {"run_id": run_id}),)),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache"},
         )
@@ -225,7 +230,7 @@ def stream_events(
         try:
             for event in catchup.events:
                 emitted_ids.add(event.event_id)
-                yield _format_sse(event.event_id, event.event_type, event.payload)
+                yield _format_run_sse(event)
             while True:
                 maybe_event = subscription.poll(0.1)
                 if maybe_event is None:
@@ -234,7 +239,7 @@ def stream_events(
                 if maybe_event.event_id in emitted_ids:
                     continue
                 emitted_ids.add(maybe_event.event_id)
-                yield _format_sse(maybe_event.event_id, maybe_event.event_type, maybe_event.payload)
+                yield _format_run_sse(maybe_event)
         finally:
             transport.close_subscription(subscription)
 
@@ -243,7 +248,19 @@ def stream_events(
     )
 
 
-def _format_sse(event_id: str, event_type: str, payload: dict[str, object]) -> str:
+def _format_run_sse(event: RunSseEventV1) -> str:
+    return _format_transport_sse(
+        event.event_id,
+        event.event_type,
+        serialize_run_sse_event(event),
+    )
+
+
+def _format_transport_sse(
+    event_id: str,
+    event_type: RunSseEventTypeV1 | Literal["snapshot_required"],
+    payload: Mapping[str, object],
+) -> str:
     return f"id: {event_id}\nevent: {event_type}\ndata: {dumps(payload, sort_keys=True)}\n\n"
 
 

--- a/src/google_work_agent/api/schemas/runs/list_run_events.py
+++ b/src/google_work_agent/api/schemas/runs/list_run_events.py
@@ -1,19 +1,10 @@
-"""Canonical Run-scoped SSE wire envelope."""
+"""Serialize the canonical Run-scoped SSE wire envelope without redefining it."""
 
-from typing import Literal
-
-from google_work_agent.api.schemas.model import ApiModel
+from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
 
 
-class RunSseEventResponseV1(ApiModel):
-    schema_version: Literal[1]
-    event_id: str
-    run_id: str
-    action_id: str | None
-    occurred_at_ms: int
-    event_type: str
-    payload: dict[str, object]
-    projection_version: int
+def serialize_run_sse_event(event: RunSseEventV1) -> dict[str, object]:
+    return event.model_dump(mode="json")
 
 
-__all__ = ["RunSseEventResponseV1"]
+__all__ = ["serialize_run_sse_event"]

--- a/src/google_work_agent/application/use_cases/action/reject_action.py
+++ b/src/google_work_agent/application/use_cases/action/reject_action.py
@@ -229,7 +229,7 @@ class RejectActionHandler:
                         occurred_at_ms=now_ms,
                         action_id=command.action_id,
                         event_type="action_status",
-                        payload={"action_status": "REJECTED"},
+                        payload={"action_id": command.action_id, "status": "REJECTED"},
                     )
                 )
             if handoff_id is not None:

--- a/src/google_work_agent/application/use_cases/run/project_external_llm_transfer_scope.py
+++ b/src/google_work_agent/application/use_cases/run/project_external_llm_transfer_scope.py
@@ -4,14 +4,19 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Literal
 
-from google_work_agent.application.use_cases.sse_event.project_run_event import (
-    ProjectRunEventCommand,
-    ProjectRunEventHandler,
+from google_work_agent.application.use_cases.trace_event.emit_trace_event import (
+    EmitTraceEventCommand,
+    EmitTraceEventHandler,
 )
 from google_work_agent.domain.canonical import calculate_canonical_json_hash
 from google_work_agent.ports.system.checkpoint_port import CheckpointPort
 from google_work_agent.ports.system.contracts.external_llm_transfer_scope import (
     ExternalLlmTransferScopeV1,
+)
+from google_work_agent.ports.system.contracts.observability import (
+    EventCategory,
+    ObservabilityContext,
+    Severity,
 )
 
 
@@ -34,12 +39,12 @@ class ProjectExternalLlmTransferScopeHandler:
     def __init__(
         self,
         checkpoint: CheckpointPort,
-        project_run_event: ProjectRunEventHandler | None = None,
+        emit_trace_event: EmitTraceEventHandler | None = None,
     ) -> None:
         self._checkpoint = checkpoint
-        self._project_run_event = project_run_event
+        self._emit_trace_event = emit_trace_event
         self._publication_lock = Lock()
-        self._announced_scopes: set[tuple[str, int, str]] = set()
+        self._traced_scopes: set[tuple[str, int, str]] = set()
 
     def __call__(
         self, query: ProjectExternalLlmTransferScopeQueryV1
@@ -54,10 +59,10 @@ class ProjectExternalLlmTransferScopeHandler:
         data_classes = sorted(set(query.data_classes))
         if not source_kinds or not data_classes or any(not item.strip() for item in source_kinds):
             raise ValueError("external-LLM scope must be non-empty")
-        if self._project_run_event is not None and (
+        if self._emit_trace_event is not None and (
             query.occurred_at_ms is None or query.occurred_at_ms < 0
         ):
-            raise ValueError("scope publication event requires occurred_at_ms")
+            raise ValueError("scope trace requires occurred_at_ms")
         scope_hash = calculate_canonical_json_hash(
             {
                 "run_id": query.run_id,
@@ -81,25 +86,28 @@ class ProjectExternalLlmTransferScopeHandler:
                 self._checkpoint.store_external_llm_scope(scope)
                 self._checkpoint.flush()
             publication_key = (scope.run_id, scope.scope_revision, scope.scope_hash)
-            if (
-                self._project_run_event is not None
-                and publication_key not in self._announced_scopes
-            ):
+            if self._emit_trace_event is not None and publication_key not in self._traced_scopes:
                 assert query.occurred_at_ms is not None
-                self._project_run_event(
-                    ProjectRunEventCommand(
-                        run_id=query.run_id,
+                self._emit_trace_event(
+                    EmitTraceEventCommand(
+                        correlation=ObservabilityContext(run_id=query.run_id),
+                        event_name="EXTERNAL_LLM_SCOPE_PUBLISHED",
+                        event_category=EventCategory.LLM,
                         occurred_at_ms=query.occurred_at_ms,
-                        event_type="EXTERNAL_LLM_SCOPE_PUBLISHED",
-                        payload={
+                        severity=Severity.INFO,
+                        component="external-llm-transfer-scope",
+                        attributes={
                             "scope_revision": scope.scope_revision,
                             "scope_hash": scope.scope_hash,
                             "source_kinds": list(scope.source_kinds),
                             "data_classes": list(scope.data_classes),
                         },
+                        result_code="SCOPE_PUBLISHED",
+                        status="SUCCESS",
+                        required=True,
                     )
                 )
-                self._announced_scopes.add(publication_key)
+                self._traced_scopes.add(publication_key)
             return scope
 
 

--- a/src/google_work_agent/application/use_cases/sse_event/project_run_event.py
+++ b/src/google_work_agent/application/use_cases/sse_event/project_run_event.py
@@ -1,15 +1,19 @@
-"""Project a bounded Run fact into the process-local SSE buffer."""
+"""Project one canonical Run fact into the process-local SSE buffer."""
 
 from dataclasses import dataclass
 
-from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1, SseEventBufferPort
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RunSseEventTypeV1,
+    RunSseEventV1,
+    SseEventBufferPort,
+)
 
 
 @dataclass(frozen=True, slots=True)
 class ProjectRunEventCommand:
     run_id: str
     occurred_at_ms: int
-    event_type: str
+    event_type: RunSseEventTypeV1
     payload: dict[str, object]
     action_id: str | None = None
     projection_version: int = 1
@@ -20,15 +24,17 @@ class ProjectRunEventHandler:
         self._event_buffer = event_buffer
 
     def __call__(self, command: ProjectRunEventCommand) -> RunSseEventV1:
-        event = RunSseEventV1(
-            schema_version=1,
-            event_id="pending",
-            run_id=command.run_id,
-            action_id=command.action_id,
-            occurred_at_ms=command.occurred_at_ms,
-            event_type=command.event_type,
-            payload=command.payload,
-            projection_version=command.projection_version,
+        event = RunSseEventV1.model_validate(
+            {
+                "schema_version": 1,
+                "event_id": "pending",
+                "run_id": command.run_id,
+                "action_id": command.action_id,
+                "occurred_at_ms": command.occurred_at_ms,
+                "event_type": command.event_type,
+                "payload": command.payload,
+                "projection_version": command.projection_version,
+            }
         )
         self._event_buffer.append(event)
         return event

--- a/src/google_work_agent/ports/system/sse_event_buffer_port.py
+++ b/src/google_work_agent/ports/system/sse_event_buffer_port.py
@@ -2,36 +2,286 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Annotated, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr, model_validator
 
 
-@dataclass(frozen=True, slots=True)
-class RunSseEventV1:
+class _ClosedSseModel(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid", frozen=True, strict=True, revalidate_instances="always"
+    )
+
+
+type RunSseEventTypeV1 = Literal[
+    "run_status",
+    "phase_changed",
+    "tool_routing",
+    "retrieval_progress",
+    "confirmation_required",
+    "analysis_progress",
+    "plan_updated",
+    "approval_required",
+    "action_status",
+    "verification_result",
+    "reauth_required",
+    "recovery_required",
+    "completed",
+    "error",
+]
+
+RUN_SSE_EVENT_TYPES_V1 = frozenset(
+    {
+        "run_status",
+        "phase_changed",
+        "tool_routing",
+        "retrieval_progress",
+        "confirmation_required",
+        "analysis_progress",
+        "plan_updated",
+        "approval_required",
+        "action_status",
+        "verification_result",
+        "reauth_required",
+        "recovery_required",
+        "completed",
+        "error",
+    }
+)
+
+
+class RunStatusSsePayloadV1(_ClosedSseModel):
+    status: Literal[
+        "CREATED",
+        "ANALYZING",
+        "RETRIEVING",
+        "WAITING_CONFIRMATION",
+        "PLANNING",
+        "WAITING_APPROVAL",
+        "EXECUTING",
+        "VERIFYING",
+        "COMPLETED",
+        "CANCEL_REQUESTED",
+        "CANCELLED",
+        "REAUTH_REQUIRED",
+        "RECOVERY_REQUIRED",
+        "FAILED",
+        "BLOCKED",
+    ]
+    snapshot_version: StrictInt
+
+
+class PhaseChangedSsePayloadV1(_ClosedSseModel):
+    phase: Literal[
+        "INITIALIZE",
+        "REQUEST_ANALYSIS",
+        "TOOL_ROUTING",
+        "WAITING_CONFIRMATION",
+        "CONTEXT_RETRIEVAL",
+        "WORK_ANALYSIS",
+        "SOLUTION_PLANNING",
+        "PLAN_REVIEW",
+        "DOMAIN_VALIDATION",
+        "WAITING_APPROVAL",
+        "PREFLIGHT",
+        "ACTION_EXECUTION",
+        "READ_EXECUTION",
+        "VERIFICATION",
+        "RESPONSE_SYNTHESIS",
+        "RECOVERY",
+        "FINALIZE",
+    ]
+
+
+class ToolRoutingSsePayloadV1(_ClosedSseModel):
+    route_revision: StrictInt
+    input_route_count: StrictInt
+    output_mode: Literal["ANSWER", "ACTION"]
+
+
+class RetrievalProgressSsePayloadV1(_ClosedSseModel):
+    coverage: Literal["NONE", "PARTIAL", "SUFFICIENT"]
+    completed_sources: StrictInt
+    total_sources: StrictInt
+
+
+class ConfirmationRequiredSsePayloadV1(_ClosedSseModel):
+    interrupt_id: StrictStr
+    question: StrictStr
+    options: list[StrictStr]
+
+
+class AnalysisProgressSsePayloadV1(_ClosedSseModel):
+    completed_stage: StrictStr
+
+
+class PlanUpdatedSsePayloadV1(_ClosedSseModel):
+    plan_id: StrictStr | None
+    revision_no: StrictInt
+
+
+class ApprovalRequiredSsePayloadV1(_ClosedSseModel):
+    action_ids: list[StrictStr]
+
+
+class ActionStatusSsePayloadV1(_ClosedSseModel):
+    action_id: StrictStr
+    status: Literal[
+        "PROPOSED",
+        "MODIFIED",
+        "APPROVED",
+        "REJECTED",
+        "EXPIRED",
+        "EXECUTING",
+        "UNKNOWN_RESULT",
+        "EXECUTED",
+        "VERIFIED",
+        "FAILED",
+        "BLOCKED",
+        "DEPENDENCY_BLOCKED",
+        "MISMATCH",
+        "CANCELLED",
+    ]
+
+
+class VerificationResultSsePayloadV1(_ClosedSseModel):
+    action_id: StrictStr
+    outcome: Literal["VERIFIED", "MISMATCH"]
+
+
+class ReauthRequiredSsePayloadV1(_ClosedSseModel):
+    connector_id: StrictStr
+
+
+class _RunRecoveryTargetV1(_ClosedSseModel):
+    target_kind: Literal["RUN"]
+
+
+class _ActionRecoveryTargetV1(_ClosedSseModel):
+    target_kind: Literal["ACTION"]
+    action_id: StrictStr
+
+
+class _RecoveryUiProjectionV1(_ClosedSseModel):
+    reason_code: Literal[
+        "UNKNOWN_RESULT",
+        "VERIFICATION_MISMATCH",
+        "CHECKPOINT_MISMATCH",
+        "CONTRACT_VIOLATION",
+    ]
+    target: Annotated[
+        _RunRecoveryTargetV1 | _ActionRecoveryTargetV1,
+        Field(discriminator="target_kind"),
+    ]
+    allowed_resolution_kinds: list[
+        Literal["RECHECK", "ACCEPT_PARTIAL", "CREATE_CORRECTIVE_PLAN", "CANCEL", "FAIL"]
+    ]
+
+
+class RecoveryRequiredSsePayloadV1(_ClosedSseModel):
+    recovery: _RecoveryUiProjectionV1
+
+
+class CompletedSsePayloadV1(_ClosedSseModel):
+    status: Literal["COMPLETED", "BLOCKED", "FAILED", "CANCELLED"]
+    result_kind: Literal["SUCCESS", "PARTIAL", "BLOCKED", "FAILED", "CANCELLED"]
+
+
+class ErrorSsePayloadV1(_ClosedSseModel):
+    error_code: StrictStr
+    recoverable: StrictBool
+
+
+type SsePayloadV1 = (
+    RunStatusSsePayloadV1
+    | PhaseChangedSsePayloadV1
+    | ToolRoutingSsePayloadV1
+    | RetrievalProgressSsePayloadV1
+    | ConfirmationRequiredSsePayloadV1
+    | AnalysisProgressSsePayloadV1
+    | PlanUpdatedSsePayloadV1
+    | ApprovalRequiredSsePayloadV1
+    | ActionStatusSsePayloadV1
+    | VerificationResultSsePayloadV1
+    | ReauthRequiredSsePayloadV1
+    | RecoveryRequiredSsePayloadV1
+    | CompletedSsePayloadV1
+    | ErrorSsePayloadV1
+)
+
+SSE_PAYLOAD_TYPE_BY_EVENT_V1: dict[RunSseEventTypeV1, type[_ClosedSseModel]] = {
+    "run_status": RunStatusSsePayloadV1,
+    "phase_changed": PhaseChangedSsePayloadV1,
+    "tool_routing": ToolRoutingSsePayloadV1,
+    "retrieval_progress": RetrievalProgressSsePayloadV1,
+    "confirmation_required": ConfirmationRequiredSsePayloadV1,
+    "analysis_progress": AnalysisProgressSsePayloadV1,
+    "plan_updated": PlanUpdatedSsePayloadV1,
+    "approval_required": ApprovalRequiredSsePayloadV1,
+    "action_status": ActionStatusSsePayloadV1,
+    "verification_result": VerificationResultSsePayloadV1,
+    "reauth_required": ReauthRequiredSsePayloadV1,
+    "recovery_required": RecoveryRequiredSsePayloadV1,
+    "completed": CompletedSsePayloadV1,
+    "error": ErrorSsePayloadV1,
+}
+
+
+def _require_matching_payload(event_type: RunSseEventTypeV1, payload: SsePayloadV1) -> None:
+    expected = SSE_PAYLOAD_TYPE_BY_EVENT_V1[event_type]
+    if type(payload) is not expected:
+        raise ValueError(f"{event_type} requires {expected.__name__}")
+
+
+class RunSseEventV1(_ClosedSseModel):
     schema_version: Literal[1]
-    event_id: str
-    run_id: str
-    action_id: str | None
-    occurred_at_ms: int
-    event_type: str
-    payload: dict[str, object]
-    projection_version: int
+    event_id: StrictStr
+    run_id: StrictStr
+    action_id: StrictStr | None
+    occurred_at_ms: StrictInt
+    event_type: RunSseEventTypeV1
+    payload: SsePayloadV1
+    projection_version: StrictInt
+
+    @model_validator(mode="after")
+    def validate_payload_mapping(self) -> RunSseEventV1:
+        _require_matching_payload(self.event_type, self.payload)
+        return self
 
 
-@dataclass(frozen=True, slots=True)
-class SseEventPageV1:
+class SseEventPageV1(_ClosedSseModel):
     schema_version: Literal[1]
     events: tuple[RunSseEventV1, ...]
-    next_event_id: str | None
+    next_event_id: StrictStr | None
     cursor_status: Literal["OK", "CURSOR_EXPIRED"]
 
 
 class SseEventBufferPort(Protocol):
     def append(self, event: RunSseEventV1) -> None: ...
-
     def list_after(self, run_id: str, last_event_id: str | None, limit: int) -> SseEventPageV1: ...
-
     def clear_run(self, run_id: str) -> None: ...
 
 
-__all__ = ["RunSseEventV1", "SseEventBufferPort", "SseEventPageV1"]
+__all__ = [
+    "ActionStatusSsePayloadV1",
+    "AnalysisProgressSsePayloadV1",
+    "ApprovalRequiredSsePayloadV1",
+    "CompletedSsePayloadV1",
+    "ConfirmationRequiredSsePayloadV1",
+    "ErrorSsePayloadV1",
+    "PhaseChangedSsePayloadV1",
+    "PlanUpdatedSsePayloadV1",
+    "RUN_SSE_EVENT_TYPES_V1",
+    "ReauthRequiredSsePayloadV1",
+    "RecoveryRequiredSsePayloadV1",
+    "RetrievalProgressSsePayloadV1",
+    "RunSseEventTypeV1",
+    "RunSseEventV1",
+    "RunStatusSsePayloadV1",
+    "SSE_PAYLOAD_TYPE_BY_EVENT_V1",
+    "SseEventBufferPort",
+    "SseEventPageV1",
+    "SsePayloadV1",
+    "ToolRoutingSsePayloadV1",
+    "VerificationResultSsePayloadV1",
+]

--- a/tests/architecture/test_canonical_test_ownership.py
+++ b/tests/architecture/test_canonical_test_ownership.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src" / "google_work_agent"
+MAPPING_SOURCE = (
+    ROOT
+    / "docs"
+    / "canonical"
+    / "16-repository-architecture"
+    / "01-spec-to-code-deterministic-mapping.md"
+)
+DIRECTORY_SOURCE = (
+    ROOT / "docs" / "canonical" / "16-repository-architecture" / "02-directory-ownership.md"
+)
+
+
+def _symbols(path: Path) -> set[str]:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return {
+        node.name
+        for node in module.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _section(markdown: str, heading: str, next_heading: str) -> str:
+    _, separator, tail = markdown.partition(heading)
+    assert separator, f"missing canonical manifest heading: {heading}"
+    return tail.partition(next_heading)[0]
+
+
+def _table_rows(section: str) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for line in section.splitlines():
+        if not line.startswith("|") or "---" in line:
+            continue
+        cells: list[str] = []
+        current: list[str] = []
+        in_code = False
+        for character in line.strip("|"):
+            if character == "`":
+                in_code = not in_code
+            if character == "|" and not in_code:
+                cells.append("".join(current).strip())
+                current = []
+            else:
+                current.append(character)
+        cells.append("".join(current).strip())
+        if cells and cells[0] not in {"Spec term", "Spec/API capability", "Responsibility"}:
+            rows.append(cells)
+    return rows
+
+
+def _application_manifest_from_source() -> dict[str, set[str]]:
+    markdown = MAPPING_SOURCE.read_text(encoding="utf-8")
+    core = _section(markdown, "### Application capability mapping", "### Run lifecycle closure")
+    local = _section(
+        markdown,
+        "### Local API boundary capability manifest",
+        "### Provider-neutral Application rule",
+    )
+    manifest: dict[str, set[str]] = {}
+    for cells in _table_rows(core):
+        owner = cells[1].strip("`")
+        operations = re.findall(r"`([a-z][a-z0-9_]*)`", cells[3])
+        manifest.setdefault(owner, set()).update(operations)
+    for cells in _table_rows(local):
+        owner = cells[1].strip("`")
+        operations = re.findall(r"`([a-z][a-z0-9_]*)`", cells[2])
+        manifest.setdefault(owner, set()).update(operations)
+    assert manifest and all(manifest.values()), "empty canonical Application manifest"
+    return manifest
+
+
+def _agent_manifest_from_source() -> dict[str, tuple[str, ...]]:
+    markdown = MAPPING_SOURCE.read_text(encoding="utf-8")
+    section = _section(markdown, "### Agent capability mapping", "### Runtime Node ID")
+    block = section.split("```", 2)[1]
+    manifest: dict[str, list[str]] = {}
+    owner: str | None = None
+    for line in block.splitlines():
+        if line.endswith("/"):
+            owner = line.removesuffix("/")
+            manifest[owner] = []
+        elif owner is not None and line.startswith("  "):
+            manifest[owner].append(line.strip())
+    assert manifest and all(manifest.values()), "empty canonical Agent manifest"
+    return {key: tuple(value) for key, value in manifest.items()}
+
+
+def _launcher_manifest_from_source() -> set[tuple[str, tuple[str, ...], str]]:
+    markdown = DIRECTORY_SOURCE.read_text(encoding="utf-8")
+    section = _section(markdown, "#### Launcher runtime", "#### Windows installer")
+    manifest: set[tuple[str, tuple[str, ...], str]] = set()
+    for cells in _table_rows(section):
+        filename = cells[1].strip("`").removeprefix("launcher/")
+        symbols = tuple(
+            symbol.strip().removesuffix("()") for symbol in re.findall(r"`([^`]+)`", cells[2])
+        )
+        test_owner = cells[3].strip("`")
+        manifest.add((filename, symbols, test_owner))
+    assert manifest, "empty canonical Launcher manifest"
+    return manifest
+
+
+def _has_asserting_test(path: Path) -> bool:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for function in (
+        node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    ):
+        if any(isinstance(node, ast.Assert) for node in ast.walk(function)):
+            return True
+        if any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"raises", "fail"}
+            for node in ast.walk(function)
+        ):
+            return True
+    return False
+
+
+def _handler_symbol(operation: str) -> str:
+    return "".join(part.capitalize() for part in operation.split("_")) + "Handler"
+
+
+def _assert_mapping(production: Path, symbols: tuple[str, ...], test_owner: Path) -> None:
+    assert production.is_file(), (
+        f"missing canonical production owner: {production.relative_to(ROOT)}"
+    )
+    assert set(symbols) <= _symbols(production), (
+        f"missing canonical symbol: {production.relative_to(ROOT)}::{symbols}"
+    )
+    assert test_owner.is_file(), f"missing canonical test owner: {test_owner.relative_to(ROOT)}"
+    assert _has_asserting_test(test_owner), (
+        f"canonical test owner has no asserting test: {test_owner.relative_to(ROOT)}"
+    )
+
+
+def test_required_application__manifest_has__exact_production_and_test_owners() -> None:
+    for owner, operations in _application_manifest_from_source().items():
+        for operation in operations:
+            _assert_mapping(
+                SRC / "application" / "use_cases" / owner / f"{operation}.py",
+                (_handler_symbol(operation),),
+                ROOT
+                / "tests"
+                / "unit"
+                / "application"
+                / "use_cases"
+                / owner
+                / f"test_{operation}.py",
+            )
+
+
+def test_required_agent__manifest_has__exact_production_and_test_owners() -> None:
+    for owner, operations in _agent_manifest_from_source().items():
+        for operation in operations:
+            _assert_mapping(
+                SRC / "application" / "agents" / owner / f"{operation}.py",
+                (operation,),
+                ROOT / "tests" / "unit" / "application" / "agents" / owner / f"test_{operation}.py",
+            )
+
+
+def test_launcher_runtime__manifest_has__exact_production_and_test_owners() -> None:
+    for filename, symbols, test_path in _launcher_manifest_from_source():
+        _assert_mapping(ROOT / "launcher" / filename, symbols, ROOT / test_path)

--- a/tests/architecture/test_run_conversation_event_api_authority.py
+++ b/tests/architecture/test_run_conversation_event_api_authority.py
@@ -439,7 +439,7 @@ def test_event_route_keeps__transport_but_not__replay_fallback_semantics() -> No
     source = (ROOT / "src/google_work_agent/api/routes/runs.py").read_text(encoding="utf-8")
     assert (
         "StreamingResponse" in source
-        and "_format_sse" in source
+        and "_format_run_sse" in source
         and ".subscribe(" in source
         and "keepalive" in source
     )

--- a/tests/component/langgraph/test_production_agent_subgraphs.py
+++ b/tests/component/langgraph/test_production_agent_subgraphs.py
@@ -1,0 +1,629 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from itertools import count
+from typing import Any, cast
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
+
+from google_work_agent.adapters.langgraph.main.state import (
+    GraphState,
+    WorkflowPhase,
+    initial_graph_state,
+)
+from google_work_agent.adapters.langgraph.main.supervisor import route_supervisor
+from google_work_agent.adapters.langgraph.profiles.profile_registry import GraphProfile
+from google_work_agent.adapters.langgraph.subgraphs.planning.graph import (
+    PlanningRuntimeDependencies,
+    PlanningSubgraph,
+)
+from google_work_agent.adapters.langgraph.subgraphs.planning.routing import (
+    route_after_assemble_plan as planning_assemble_routing,
+)
+from google_work_agent.adapters.langgraph.subgraphs.request_understanding.graph import (
+    RequestUnderstandingSubgraph,
+)
+from google_work_agent.adapters.langgraph.subgraphs.request_understanding.routing import (
+    route_after_finalize_intent as request_finalize_routing,
+)
+from google_work_agent.adapters.langgraph.subgraphs.retrieval.graph import RetrievalSubgraph
+from google_work_agent.adapters.langgraph.subgraphs.review.graph import (
+    ReviewRuntimeDependencies,
+    ReviewSubgraph,
+)
+from google_work_agent.adapters.langgraph.subgraphs.review.routing.route_after_entry import (
+    route_after_entry,
+)
+from google_work_agent.adapters.langgraph.subgraphs.tool_routing.graph import ToolRoutingSubgraph
+from google_work_agent.adapters.langgraph.subgraphs.tool_routing.routing import (
+    route_after_validate_route as tool_validation_routing,
+)
+from google_work_agent.adapters.langgraph.subgraphs.work_analysis.graph import WorkAnalysisSubgraph
+from google_work_agent.adapters.langgraph.subgraphs.work_analysis.routing import (
+    route_after_assess_information_gaps as work_gap_routing,
+)
+from google_work_agent.adapters.system.memory.retrieval_evidence_store import (
+    RunScopedEvidenceStore,
+)
+from google_work_agent.adapters.system.memory.run_retrieval_cache import (
+    InMemoryRunRetrievalCache,
+)
+from google_work_agent.application.agents.planning.contracts.planning_semantics import (
+    PlanningSemanticInvoker,
+)
+from google_work_agent.application.agents.review.contracts.review_findings import (
+    ReviewSemanticInvoker,
+)
+from google_work_agent.application.prompt_runtime.prompt_registry import DEVELOPMENT_SMOKE
+from google_work_agent.application.tool_registry.load_signed_tool_registry import (
+    load_development_tool_registry,
+)
+from google_work_agent.application.use_cases.run.account_provider_dispatch import (
+    provider_dispatch_execution_scope,
+)
+from google_work_agent.application.use_cases.run.guard_run_budget import build_default_run_budget
+from google_work_agent.ports.connector.connector_read_port import ConnectorReadResultV1
+from google_work_agent.ports.llm.structured_inference_contracts import (
+    OutputSchemaDefinition,
+    PromptReference,
+)
+from google_work_agent.ports.llm.structured_inference_port import StructuredInferenceResultV1
+from google_work_agent.ports.system.contracts.confirmation import (
+    ConfirmationResponseProjectionV1,
+)
+from google_work_agent.ports.system.contracts.workflow_execution import (
+    WorkflowCorrelationContext,
+    WorkflowStartRequest,
+)
+
+
+class _IdFactory:
+    def __init__(self) -> None:
+        self._values = count()
+
+    def __call__(self) -> str:
+        return f"component-id-{next(self._values)}"
+
+
+class _ComponentInferencePort:
+    def __init__(self, *, request_confirmation: bool = False) -> None:
+        self.request_confirmation = request_confirmation
+        self.calls: list[str] = []
+
+    def infer(
+        self,
+        requested_mode: str,
+        prompt_ref: PromptReference,
+        input_projection: Mapping[str, object],
+        output_schema_ref: OutputSchemaDefinition,
+    ) -> StructuredInferenceResultV1:
+        del requested_mode, output_schema_ref
+        prompt_id = prompt_ref.prompt_id
+        self.calls.append(prompt_id)
+        base = input_projection.get("base_projection", input_projection)
+        projection = cast(Mapping[str, object], base)
+        output = self._response(prompt_id, projection)
+        return StructuredInferenceResultV1(
+            schema_version=1,
+            structured_output=output,
+            provider="component-fake",
+            model="component-fake",
+            actual_runtime="API_LLM",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+            fallback_reason=None,
+        )
+
+    def _response(
+        self, prompt_id: str, projection: Mapping[str, object]
+    ) -> dict[str, object]:
+        has_confirmation = isinstance(projection.get("confirmation_response"), Mapping)
+        if prompt_id == "request_understanding.identify_goal":
+            return {
+                "goal": "schedule team sync" if has_confirmation else "summarize status",
+                "completion_conditions": ["return a result"],
+                "constraints": [],
+                "requested_effect_hints": ["READ"],
+                "requested_resource_hints": [],
+                "analysis_requirement": "NONE",
+            }
+        if prompt_id == "request_understanding.detect_ambiguity":
+            needs_confirmation = self.request_confirmation and not has_confirmation
+            return {
+                "requires_confirmation": needs_confirmation,
+                "reason_codes": ["MISSING_TARGET"] if needs_confirmation else [],
+                "missing_fields": ["target"] if needs_confirmation else [],
+            }
+        if prompt_id == "tool_routing.determine_io_resources":
+            return {
+                "schema_version": 1,
+                "input_resource_types": [],
+                "output_resource_types": [],
+                "output_effects": [],
+                "disposition": "NO_TOOL_NEEDED",
+            }
+        if prompt_id == "retrieval.plan_query":
+            return {
+                "schema_version": 2,
+                "route_queries": [
+                    {
+                        "route_id": "route-1",
+                        "operation": "SEARCH",
+                        "reason_codes": ["USER_REQUEST"],
+                        "search_spec": {
+                            "mode": "INITIAL",
+                            "constraints": [
+                                {
+                                    "kind": "KEYWORD",
+                                    "terms": ["status"],
+                                    "match_mode": "ANY",
+                                }
+                            ],
+                        },
+                        "detail_candidate_ref": None,
+                    }
+                ],
+                "required_information": ["status"],
+                "retrieval_order": ["route-1"],
+            }
+        if prompt_id == "retrieval.select_evidence":
+            ranked = cast(list[Mapping[str, object]], projection.get("ranked_segments", []))
+            segment_ids = [str(item["segment_id"]) for item in ranked]
+            return {
+                "schema_version": 2,
+                "evidence_drafts": [
+                    {
+                        "segment_id": segment_id,
+                        "role": "SUPPORTS",
+                        "relevance_reason": "status evidence",
+                    }
+                    for segment_id in segment_ids
+                ],
+                "selected_segment_ids": segment_ids,
+                "excluded_segment_ids": [],
+            }
+        if prompt_id == "retrieval.assess_sufficiency":
+            return {"schema_version": 2, "status": "SUFFICIENT", "issues": []}
+        if prompt_id == "work_analysis.extract_work_facts":
+            return {"fact_candidates": []}
+        if prompt_id == "work_analysis.assess_information_gaps":
+            return {
+                "disposition": "COMPLETE",
+                "ambiguities": [],
+                "retrieval_needs": [],
+                "evidence_refs": [],
+            }
+        if prompt_id == "work_analysis.assess_operational_risks":
+            return {
+                "risks": [],
+                "action_necessity_candidate": "NOT_REQUIRED",
+                "action_necessity_reason": "Answer only",
+                "evidence_refs": [],
+            }
+        raise AssertionError(f"unexpected component Prompt: {prompt_id}")
+
+
+class _ComponentConnectorReadPort:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute_read(
+        self, binding: Any, tool_arguments: dict[str, Any]
+    ) -> ConnectorReadResultV1:
+        del tool_arguments
+        self.call_count += 1
+        return ConnectorReadResultV1(
+            schema_version=1,
+            tool_id=binding.tool_id,
+            request_id="component-read-1",
+            output={
+                "items": [
+                    {
+                        "resource_type": "gmail_thread",
+                        "resource_id": "thread-1",
+                        "parent_id": None,
+                        "version": "v1",
+                        "related_resource_ids": [],
+                        "payload": {"subject": "Weekly status"},
+                    }
+                ]
+            },
+            next_page_token=None,
+            total_count=1,
+        )
+
+
+def _state(*, initial_target: str = "request_understanding") -> GraphState:
+    request = WorkflowStartRequest(
+        run_id="component-run-1",
+        conversation_id="component-conversation-1",
+        workflow_key="component-thread-1",
+        entry_mode="AGENT_SEARCH",
+        requested_mode="AUTO",
+        request_text="summarize status",
+        selected_resource_ids=(),
+        run_budget=build_default_run_budget(),
+        correlation=WorkflowCorrelationContext("component-request-1", None, "1"),
+    )
+    return initial_graph_state(
+        request,
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        graph_version="component-test",
+        initial_target=initial_target,
+    )
+
+
+def _intent() -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "goal": "summarize status",
+        "completion_conditions": ["return a result"],
+        "constraints": [],
+        "requested_effect_hints": ["READ"],
+        "requested_resource_hints": [],
+        "analysis_requirement": "NONE",
+        "ambiguity": {
+            "requires_confirmation": False,
+            "reason_codes": [],
+            "missing_fields": [],
+        },
+        "meta": {"artifact_id": "intent-1", "revision": 1, "based_on": []},
+    }
+
+
+def _answer_route_plan(*, with_input_route: bool = False) -> dict[str, object]:
+    input_routes: list[dict[str, object]] = []
+    if with_input_route:
+        input_routes.append(
+            {
+                "route_id": "route-1",
+                "resource_type": "EMAIL",
+                "connector_id": "google_workspace",
+                "allowed_read_tool_ids": ["gmail_search_threads"],
+                "required": True,
+                "reason_codes": ["USER_REQUEST"],
+            }
+        )
+    based_on = [{"artifact_id": "intent-1", "revision": 1}]
+    return {
+        "schema_version": 2,
+        "input_plan": {
+            "schema_version": 1,
+            "meta": {"artifact_id": "input-1", "revision": 1, "based_on": based_on},
+            "input_routes": input_routes,
+        },
+        "output_plan": {
+            "schema_version": 1,
+            "meta": {"artifact_id": "output-1", "revision": 1, "based_on": based_on},
+            "output_mode": "ANSWER",
+        },
+        "tool_registry_version": "component-test",
+    }
+
+
+def _retrieval_result() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "meta": {
+            "artifact_id": "retrieval-1",
+            "revision": 1,
+            "based_on": [{"artifact_id": "intent-1", "revision": 1}],
+        },
+        "coverage": "NO_FETCH_NEEDED",
+        "context_bundle_ref": None,
+        "evidence_refs": [],
+        "selected_segment_ids": [],
+        "excluded_segment_ids": [],
+        "source_resource_refs": [],
+        "source_statuses": [],
+        "availability_results": [],
+        "missing_information": [],
+        "retrieval_rounds": 0,
+    }
+
+
+def _merge_decision(
+    state: Mapping[str, object], update: Mapping[str, object], decision: Mapping[str, object]
+) -> dict[str, object]:
+    decision_state = cast(Mapping[str, object], decision["state_update"])
+    return {
+        **state,
+        **update,
+        **decision_state,
+        "__target__": cast(str, decision["target"]),
+    }
+
+
+def _confirm_early(_state: object) -> tuple[None, dict[str, object]]:
+    return None, {"__target__": "end", "__workflow_control__": {"stage": "PAUSED"}}
+
+
+def _edge_set(graph: Any) -> set[tuple[str, str]]:
+    return {(edge.source, edge.target) for edge in graph.get_graph().edges}
+
+
+def test_request_understanding__compiled_normal_path__produces_intent() -> None:
+    llm = _ComponentInferencePort()
+    graph = RequestUnderstandingSubgraph(
+        llm_runtime=llm,
+        prompt_manifest_path=None,
+        prompt_execution_scope=DEVELOPMENT_SMOKE,
+        id_factory=_IdFactory(),
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        transition_run=lambda _run_id, _transition: None,
+        merge_decision=cast(Any, _merge_decision),
+        confirm_inline=_confirm_early,
+    ).build()
+
+    with provider_dispatch_execution_scope():
+        result = graph.invoke(_state())
+
+    assert result["request_intent"]["goal"] == "summarize status"
+    assert llm.calls == [
+        "request_understanding.identify_goal",
+        "request_understanding.detect_ambiguity",
+    ]
+    assert ("finalize_intent", "identify_goal") in _edge_set(graph)
+
+
+def test_tool_routing__compiled_normal_path__produces_answer_route() -> None:
+    state = _state(initial_target="tool_route")
+    state["request_intent"] = cast(Any, _intent())
+    llm = _ComponentInferencePort()
+    graph = ToolRoutingSubgraph(
+        llm_runtime=llm,
+        tool_catalog=load_development_tool_registry(),
+        prompt_manifest_path=None,
+        prompt_execution_scope=DEVELOPMENT_SMOKE,
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        merge_decision=cast(Any, _merge_decision),
+        confirm_inline=cast(Any, _confirm_early),
+        id_factory=_IdFactory(),
+    ).build()
+
+    with provider_dispatch_execution_scope():
+        result = graph.invoke(state)
+
+    assert result["tool_route_plan"]["output_plan"]["output_mode"] == "ANSWER"
+    assert llm.calls == ["tool_routing.determine_io_resources"]
+    assert ("finalize_route", "determine_io_resources") in _edge_set(graph)
+
+
+def test_retrieval__compiled_normal_path__materializes_evidence() -> None:
+    state = _state(initial_target="context_retriever")
+    state["request_intent"] = cast(Any, _intent())
+    state["tool_route_plan"] = cast(Any, _answer_route_plan(with_input_route=True))
+    llm = _ComponentInferencePort()
+    connector = _ComponentConnectorReadPort()
+    graph = RetrievalSubgraph(
+        llm_runtime=llm,
+        prompt_manifest_path=None,
+        prompt_execution_scope=DEVELOPMENT_SMOKE,
+        id_factory=_IdFactory(),
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        transition_run=lambda _run_id, _transition: None,
+        merge_decision=cast(Any, _merge_decision),
+        evidence_store=RunScopedEvidenceStore(),
+        connector_reader=connector,
+        tool_catalog=load_development_tool_registry(),
+        read_result_cache=InMemoryRunRetrievalCache(),
+        confirm_inline=cast(Any, _confirm_early),
+    ).build()
+
+    with provider_dispatch_execution_scope():
+        result = graph.invoke(state)
+
+    assert result["retrieval_result"]["coverage"] == "SUFFICIENT"
+    assert result["retrieval_result"]["evidence_refs"]
+    assert connector.call_count == 1
+    assert ("assess_sufficiency", "plan_query") in _edge_set(graph)
+    assert ("finalize", "finalize") in _edge_set(graph)
+
+
+def test_work_analysis__compiled_normal_path__produces_analysis() -> None:
+    state = _state(initial_target="work_analysis")
+    state["request_intent"] = cast(Any, _intent())
+    state["tool_route_plan"] = cast(Any, _answer_route_plan())
+    state["retrieval_result"] = cast(Any, _retrieval_result())
+    llm = _ComponentInferencePort()
+    graph = WorkAnalysisSubgraph(
+        llm_runtime=llm,
+        prompt_manifest_path=None,
+        prompt_execution_scope=DEVELOPMENT_SMOKE,
+        id_factory=_IdFactory(),
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        transition_run=lambda _run_id, _transition: None,
+        merge_decision=cast(Any, _merge_decision),
+        evidence_store=RunScopedEvidenceStore(),
+        confirm_inline=cast(Any, _confirm_early),
+    ).build()
+
+    with provider_dispatch_execution_scope():
+        result = graph.invoke(state)
+
+    assert result["work_analysis_result"]["schema_version"] == 2
+    assert result["__target__"] == "SOLUTION_PLANNING"
+    assert ("finalize", "assess_operational_risks") in _edge_set(graph)
+
+
+def test_planning__compiled_normal_path__produces_answer() -> None:
+    calls: list[str] = []
+
+    def invoke(prompt_id: str, _prompt_input: Mapping[str, object]) -> Mapping[str, object]:
+        calls.append(prompt_id)
+        if prompt_id == "planning.outline_answer":
+            return {"sections": ["summary"], "evidence_refs": []}
+        return {"schema_version": 2, "answer": "done", "evidence_refs": []}
+
+    graph = PlanningSubgraph(
+        dependencies=PlanningRuntimeDependencies(
+            invoke=cast(PlanningSemanticInvoker, invoke)
+        )
+    ).build()
+    result = graph.invoke(
+        {
+            "user_request": "summarize status",
+            "request_intent": _intent(),
+            "tool_route_plan": _answer_route_plan(),
+            "work_analysis": {},
+            "evidence": [],
+        }
+    )
+
+    assert result["planning_disposition"] == "ANSWER"
+    assert calls == ["planning.outline_answer", "planning.compose_answer"]
+    assert ("compose_answer", "outline_answer") in _edge_set(graph)
+
+
+def test_review__compiled_normal_path__passes_review() -> None:
+    calls: list[str] = []
+
+    def invoke(prompt_id: str, _prompt_input: Mapping[str, object]) -> Mapping[str, object]:
+        calls.append(prompt_id)
+        return {"schema_version": 1, "dimension": prompt_id, "findings": []}
+
+    graph = ReviewSubgraph(
+        dependencies=ReviewRuntimeDependencies(invoke=cast(ReviewSemanticInvoker, invoke))
+    ).build()
+    result = graph.invoke(
+        {
+            "review_phase": "INITIAL",
+            "request_intent": _intent(),
+            "tool_route_plan": _answer_route_plan(),
+            "planning_result": {"answer": "done"},
+            "work_analysis": {},
+            "evidence": [],
+            "policy_summary": {},
+            "review_artifact_id": "review-1",
+            "review_revision": 1,
+            "review_based_on": [],
+        }
+    )
+
+    assert result["review_result"]["status"] == "PASS"
+    assert calls == ["review.inspect_goal_and_evidence"]
+    assert ("recheck", "aggregate_findings") in _edge_set(graph)
+
+
+def test_request_confirmation__interrupts_and_resumes__same_owner() -> None:
+    llm = _ComponentInferencePort(request_confirmation=True)
+
+    def confirm_inline(
+        state: Mapping[str, object],
+    ) -> tuple[ConfirmationResponseProjectionV1, None]:
+        user_interrupt = cast(Mapping[str, object], state["user_interrupt"])
+        resume = interrupt(
+            {
+                "semantic_owner_id": "REQUEST_UNDERSTANDING",
+                "origin_target": user_interrupt["origin_target"],
+            }
+        )
+        return cast(ConfirmationResponseProjectionV1, resume["confirmation_response"]), None
+
+    request_graph = RequestUnderstandingSubgraph(
+        llm_runtime=llm,
+        prompt_manifest_path=None,
+        prompt_execution_scope=DEVELOPMENT_SMOKE,
+        id_factory=_IdFactory(),
+        graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        transition_run=lambda _run_id, _transition: None,
+        merge_decision=cast(Any, _merge_decision),
+        confirm_inline=confirm_inline,
+    ).build()
+    wrapper = StateGraph(GraphState)
+    wrapper.add_node("request_understanding", request_graph)
+    wrapper.add_edge(START, "request_understanding")
+    wrapper.add_edge("request_understanding", END)
+    graph = wrapper.compile(checkpointer=InMemorySaver())
+    config: RunnableConfig = {
+        "configurable": {"thread_id": "component-confirmation-thread"}
+    }
+
+    with provider_dispatch_execution_scope():
+        interrupted = graph.invoke(_state(), config)
+
+    assert interrupted["__interrupt__"][0].value == {
+        "semantic_owner_id": "REQUEST_UNDERSTANDING",
+        "origin_target": "request.detect_ambiguity",
+    }
+    assert graph.get_state(config).next == ("request_understanding",)
+
+    with provider_dispatch_execution_scope():
+        resumed = graph.invoke(
+            Command(
+                resume={
+                    "confirmation_response": {
+                        "schema_version": 1,
+                        "response_kind": "FREE_TEXT",
+                        "selected_option": None,
+                        "free_text": "team sync tomorrow",
+                    }
+                }
+            ),
+            config,
+        )
+
+    assert resumed["request_intent"]["goal"] == "schedule team sync"
+    assert graph.get_state(config).next == ()
+    assert llm.calls.count("request_understanding.identify_goal") == 2
+
+
+@pytest.mark.parametrize(
+    ("router", "state"),
+    [
+        (request_finalize_routing.route_after_finalize_intent, {}),
+        (tool_validation_routing.route_after_validate_route, {}),
+        (work_gap_routing.route_after_assess_information_gaps, {}),
+        (planning_assemble_routing.route_after_assemble_plan, {}),
+        (route_after_entry, {"review_phase": "UNKNOWN"}),
+    ],
+)
+def test_agent_router__unknown_disposition__raises(
+    router: Callable[[Any], str], state: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError):
+        router(state)
+
+
+@pytest.mark.parametrize(
+    ("phase", "result"),
+    [
+        (WorkflowPhase.REQUEST_ANALYSIS, {"result": "UNKNOWN"}),
+        (WorkflowPhase.PLAN_REVIEW, {"status": "UNKNOWN"}),
+    ],
+)
+def test_supervisor__unknown_agent_disposition__raises(
+    phase: WorkflowPhase, result: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError):
+        route_supervisor(phase=phase, state=_state(), result=result)
+
+
+def test_supervisor__unknown_tool_disposition__routes_recovery() -> None:
+    decision = route_supervisor(
+        phase=WorkflowPhase.TOOL_ROUTING,
+        state=_state(),
+        result={"disposition": "UNKNOWN"},
+    )
+
+    assert decision["target"] == "RECOVERY"
+    assert decision["reason_code"] == "TOOL_ROUTE_CONTRACT_VIOLATION"
+
+
+def test_supervisor__unknown_retrieval_disposition__blocks_instead_of_normal_route() -> None:
+    decision = route_supervisor(
+        phase=WorkflowPhase.CONTEXT_RETRIEVAL,
+        state=_state(),
+        result={"disposition": "UNKNOWN", "typed_result": None},
+    )
+
+    assert decision["target"] == "FINALIZE"
+    finalize_intent = decision["state_update"]["finalize_intent"]
+    assert finalize_intent is not None
+    assert finalize_intent["intent"] == "BLOCKED"
+    assert finalize_intent["reason_code"] == "CONTEXT_BLOCKED"

--- a/tests/component/langgraph/test_production_main_graph.py
+++ b/tests/component/langgraph/test_production_main_graph.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import cast
+
+import pytest
+
+from google_work_agent.adapters.langgraph.main.graph import (
+    GraphNodeBindings,
+    MainControlNodeBindings,
+    WorkflowGraphComposition,
+)
+from google_work_agent.adapters.langgraph.main.state import GraphState, initial_graph_state
+from google_work_agent.adapters.langgraph.profiles.profile_registry import (
+    GraphProfile,
+    get_graph_profile_builder,
+    get_profile_owner_bindings,
+)
+from google_work_agent.adapters.langgraph.subgraphs.single_workflow import (
+    SingleWorkflowSubgraph,
+)
+from google_work_agent.adapters.langgraph.subgraphs.three_stage import (
+    ThreeStageOneSubgraph,
+    ThreeStageTwoSubgraph,
+)
+from google_work_agent.application.use_cases.run.guard_run_budget import build_default_run_budget
+from google_work_agent.ports.system.contracts.workflow_execution import (
+    WorkflowCorrelationContext,
+    WorkflowStartRequest,
+)
+
+_PROFILE_CASES = (
+    (
+        GraphProfile.SINGLE_BASELINE,
+        "single_workflow",
+        ("single_workflow",),
+    ),
+    (
+        GraphProfile.THREE_STAGE,
+        "stage_one",
+        ("stage_one", "stage_two", "stage_three"),
+    ),
+    (
+        GraphProfile.SIX_ROLE_BASELINE,
+        "request_understanding",
+        (
+            "request_understanding",
+            "tool_route",
+            "context_retriever",
+            "work_analysis",
+            "planning",
+            "review",
+        ),
+    ),
+)
+
+_CANONICAL_OWNER_BINDINGS = {
+    GraphProfile.SINGLE_BASELINE: {
+        "REQUEST_UNDERSTANDING": "UNIFIED_AGENT",
+        "TOOL_ROUTE": "UNIFIED_AGENT",
+        "RETRIEVAL": "UNIFIED_AGENT",
+        "WORK_ANALYSIS": "UNIFIED_AGENT",
+        "PLANNING": "UNIFIED_AGENT",
+        "REVIEW": "UNIFIED_AGENT",
+    },
+    GraphProfile.THREE_STAGE: {
+        "REQUEST_UNDERSTANDING": "STAGE_REQUEST_ROUTE_RETRIEVAL",
+        "TOOL_ROUTE": "STAGE_REQUEST_ROUTE_RETRIEVAL",
+        "RETRIEVAL": "STAGE_REQUEST_ROUTE_RETRIEVAL",
+        "WORK_ANALYSIS": "STAGE_ANALYSIS_PLANNING",
+        "PLANNING": "STAGE_ANALYSIS_PLANNING",
+        "REVIEW": "STAGE_REVIEW",
+    },
+    GraphProfile.SIX_ROLE_BASELINE: {
+        "REQUEST_UNDERSTANDING": "SIX_REQUEST_UNDERSTANDING",
+        "TOOL_ROUTE": "SIX_TOOL_ROUTE",
+        "RETRIEVAL": "SIX_RETRIEVAL",
+        "WORK_ANALYSIS": "SIX_WORK_ANALYSIS",
+        "PLANNING": "SIX_PLANNING",
+        "REVIEW": "SIX_REVIEW",
+    },
+}
+
+
+def _state(profile: GraphProfile, *, initial_target: str) -> GraphState:
+    request = WorkflowStartRequest(
+        run_id=f"main-component-{profile.value.lower()}",
+        conversation_id="main-component-conversation",
+        workflow_key=f"main-component-thread-{profile.value.lower()}",
+        entry_mode="AGENT_SEARCH",
+        requested_mode="AUTO",
+        request_text="main graph component smoke",
+        selected_resource_ids=(),
+        run_budget=build_default_run_budget(),
+        correlation=WorkflowCorrelationContext("main-component-request", None, "1"),
+    )
+    return initial_graph_state(
+        request,
+        graph_profile=profile,
+        graph_version="component-test",
+        initial_target=initial_target,
+    )
+
+
+def _target_node(target: str) -> Callable[[Mapping[str, object]], dict[str, object]]:
+    def node(_state: Mapping[str, object]) -> dict[str, object]:
+        return {"__target__": target}
+
+    return node
+
+
+def _controls(initial_target: str) -> MainControlNodeBindings:
+    def no_update(_state: Mapping[str, object]) -> dict[str, object]:
+        return {}
+
+    return MainControlNodeBindings(
+        initialize=_target_node(initial_target),
+        retrieval_entry=no_update,
+        planning_entry=no_update,
+        review_entry=no_update,
+        domain_validation=no_update,
+        preflight=no_update,
+        domain_reconcile=no_update,
+        action_execution=no_update,
+        verification=no_update,
+        recovery=no_update,
+        cancel_resolution=no_update,
+        response_synthesis=no_update,
+        terminal_commit=no_update,
+        finalize=no_update,
+    )
+
+
+def _bindings(
+    physical_node: Callable[[Mapping[str, object]], dict[str, object]],
+) -> GraphNodeBindings:
+    return GraphNodeBindings(
+        request_understanding=physical_node,
+        tool_route=physical_node,
+        context_retriever=physical_node,
+        work_analysis=physical_node,
+        planning=physical_node,
+        review=physical_node,
+        single_workflow=physical_node,
+        waiting_approval=physical_node,
+        stage_one=physical_node,
+        stage_two=physical_node,
+        stage_three=physical_node,
+    )
+
+
+def _composition(
+    profile: GraphProfile,
+    *,
+    initial_target: str,
+    physical_node: Callable[[Mapping[str, object]], dict[str, object]] | None = None,
+) -> WorkflowGraphComposition:
+    builder = get_graph_profile_builder(profile)
+    return cast(
+        WorkflowGraphComposition,
+        builder(
+            bindings=_bindings(physical_node or _target_node("response_synthesis")),
+            control_bindings=_controls(initial_target),
+            should_stop_for_cancel=lambda _run_id: False,
+            checkpointer=None,
+        ),
+    )
+
+
+@pytest.mark.parametrize(("profile", "initial_target", "topology"), _PROFILE_CASES)
+def test_main_graph_profile__compiles_and_invokes__normal_path(
+    profile: GraphProfile,
+    initial_target: str,
+    topology: tuple[str, ...],
+) -> None:
+    composition = _composition(profile, initial_target=initial_target)
+    graph = composition.build()
+
+    result = graph.invoke(_state(profile, initial_target=initial_target))
+
+    assert tuple(composition.native_subgraphs()) == topology
+    assert result["__target__"] == "response_synthesis"
+    assert graph.get_graph().nodes.keys() >= {
+        "initialize",
+        "response_synthesis",
+        "terminal_commit",
+        "finalize",
+        *topology,
+    }
+
+
+@pytest.mark.parametrize("profile", tuple(GraphProfile))
+def test_profile_owner_binding__for_every_profile__matches_canonical_map(
+    profile: GraphProfile,
+) -> None:
+    assert dict(get_profile_owner_bindings(profile)) == _CANONICAL_OWNER_BINDINGS[profile]
+
+
+def test_physical_profile_subgraphs__with_semantic_nodes__compile_and_invoke() -> None:
+    semantic_node = _target_node("response_synthesis")
+    cases = (
+        (
+            SingleWorkflowSubgraph(
+                request_understanding=semantic_node,
+                tool_route=semantic_node,
+                retrieval=semantic_node,
+                work_analysis=semantic_node,
+                planning=semantic_node,
+                review=semantic_node,
+            ).build(),
+            GraphProfile.SINGLE_BASELINE,
+            "single_workflow",
+            6,
+        ),
+        (
+            ThreeStageOneSubgraph(
+                request_understanding=semantic_node,
+                tool_route=semantic_node,
+                retrieval=semantic_node,
+            ).build(),
+            GraphProfile.THREE_STAGE,
+            "stage_one",
+            3,
+        ),
+        (
+            ThreeStageTwoSubgraph(
+                work_analysis=semantic_node,
+                planning=semantic_node,
+            ).build(),
+            GraphProfile.THREE_STAGE,
+            "stage_two",
+            2,
+        ),
+    )
+
+    for graph, profile, logical_target, semantic_node_count in cases:
+        state = _state(profile, initial_target=logical_target)
+        state["__logical_target__"] = logical_target
+        result = graph.invoke(state)
+        nodes = set(graph.get_graph().nodes) - {"__start__", "__end__"}
+        assert len(nodes) == semantic_node_count
+        assert result["__target__"] == "response_synthesis"
+
+
+def test_main_graph__physical_back_edge__is_bounded_and_reaches_terminal() -> None:
+    visits = 0
+
+    def physical_node(_state: Mapping[str, object]) -> dict[str, object]:
+        nonlocal visits
+        visits += 1
+        return {
+            "__target__": "single_workflow" if visits == 1 else "response_synthesis"
+        }
+
+    composition = _composition(
+        GraphProfile.SINGLE_BASELINE,
+        initial_target="single_workflow",
+        physical_node=physical_node,
+    )
+    result = composition.build().invoke(
+        _state(GraphProfile.SINGLE_BASELINE, initial_target="single_workflow")
+    )
+
+    assert visits == 2
+    assert result["__target__"] == "response_synthesis"
+
+
+def test_main_graph__unknown_successor__fails_closed() -> None:
+    composition = _composition(
+        GraphProfile.SIX_ROLE_BASELINE,
+        initial_target="request_understanding",
+        physical_node=_target_node("UNKNOWN_TARGET"),
+    )
+
+    with pytest.raises(ValueError, match="unregistered successor"):
+        composition.build().invoke(
+            _state(
+                GraphProfile.SIX_ROLE_BASELINE,
+                initial_target="request_understanding",
+            )
+        )

--- a/tests/e2e/browser_product_server.py
+++ b/tests/e2e/browser_product_server.py
@@ -1,0 +1,253 @@
+"""Test-only browser Product E2E host using the real production composition."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from tests.support.fakes.langgraph_e2e import LangGraphE2EGeminiTransport
+from tests.support.production_runtime import build_test_production_container
+from uvicorn import Config, Server
+
+from google_work_agent.adapters.langgraph.profiles.profile_registry import GraphProfile
+from google_work_agent.adapters.llm.runtime.llm_credential_router import (
+    SessionMemorySecretStore,
+)
+from google_work_agent.adapters.persistence.connection import connect_sqlite
+from google_work_agent.api import composition
+from google_work_agent.api.app import create_app
+
+_BOOTSTRAP_SECRET = "browser-product-e2e-bootstrap-secret"
+_SERVICE_INSTANCE_ID = "browser-product-e2e-service"
+_HOST = "127.0.0.1"
+_PORT = int(os.environ.get("GWA_BROWSER_E2E_PORT", "18765"))
+_RUNTIME_ROOT = Path(os.environ["GWA_BROWSER_E2E_RUNTIME_ROOT"]).resolve()
+_DATABASE_PATH = _RUNTIME_ROOT / "data" / "google_work_agent.db"
+_MCP_EVENTS_PATH = _RUNTIME_ROOT / "cache" / "langgraph-e2e-mcp-events.jsonl"
+_TRANSPORT = LangGraphE2EGeminiTransport()
+
+
+def _build_app() -> FastAPI:
+    with patch.object(composition, "GeminiHTTPClient", return_value=_TRANSPORT):
+        container = build_test_production_container(
+            host=_HOST,
+            port=_PORT,
+            runtime_root=_RUNTIME_ROOT,
+            bootstrap_secret=_BOOTSTRAP_SECRET,
+            service_instance_id=_SERVICE_INSTANCE_ID,
+            mcp_module_name="tests.fakes.langgraph_e2e_mcp_server",
+            keyring_store=SessionMemorySecretStore(),
+            graph_profile=GraphProfile.SIX_ROLE_BASELINE,
+        )
+    container = replace(container, client_address_resolver=lambda _request: _HOST)
+    application = create_app(container)
+    application.add_api_route(
+        "/__e2e__/state/{run_id}",
+        _product_state,
+        methods=["GET"],
+        include_in_schema=False,
+    )
+    debug_route = application.router.routes.pop()
+    frontend_index = next(
+        (
+            index
+            for index, route in enumerate(application.router.routes)
+            if any(
+                getattr(child, "path", None) == "/{path:path}"
+                for child in getattr(getattr(route, "original_router", None), "routes", ())
+            )
+        ),
+        len(application.router.routes),
+    )
+    application.router.routes.insert(frontend_index, debug_route)
+    return application
+
+
+def _product_state(run_id: str) -> dict[str, object]:
+    with connect_sqlite(_DATABASE_PATH) as connection:
+        run = _one(
+            connection,
+            """
+            SELECT id, conversation_id, status, langgraph_thread_id,
+                   terminal_result_kind, finished_at_ms
+              FROM runs
+             WHERE id = ?
+            """,
+            (run_id,),
+        )
+        plans = _all(
+            connection,
+            "SELECT id, status, revision_no FROM plans WHERE run_id = ? ORDER BY revision_no",
+            (run_id,),
+        )
+        actions = _all(
+            connection,
+            """
+            SELECT a.id, a.tool_name, a.status, a.effect_type, a.connector_id,
+                   a.verification_policy, a.position
+              FROM actions AS a
+              JOIN plans AS p ON p.id = a.plan_id
+             WHERE p.run_id = ?
+             ORDER BY p.revision_no, a.position
+            """,
+            (run_id,),
+        )
+        dependencies = _all(
+            connection,
+            """
+            SELECT d.action_id, d.depends_on_action_id
+              FROM action_dependencies AS d
+              JOIN actions AS a ON a.id = d.action_id
+              JOIN plans AS p ON p.id = a.plan_id
+             WHERE p.run_id = ?
+             ORDER BY d.action_id, d.depends_on_action_id
+            """,
+            (run_id,),
+        )
+        approvals = _all(
+            connection,
+            """
+            SELECT ap.id, ap.action_id, ap.status
+              FROM approvals AS ap
+              JOIN actions AS a ON a.id = ap.action_id
+              JOIN plans AS p ON p.id = a.plan_id
+             WHERE p.run_id = ?
+             ORDER BY ap.approved_at_ms
+            """,
+            (run_id,),
+        )
+        attempts = _all(
+            connection,
+            """
+            SELECT ea.id, ap.action_id, ea.status, ea.attempt_no
+              FROM execution_attempts AS ea
+              JOIN approvals AS ap ON ap.id = ea.approval_id
+              JOIN actions AS a ON a.id = ap.action_id
+              JOIN plans AS p ON p.id = a.plan_id
+             WHERE p.run_id = ?
+             ORDER BY ea.started_at_ms
+            """,
+            (run_id,),
+        )
+        verifications = _all(
+            connection,
+            """
+            SELECT v.id, ap.action_id, v.status, v.verification_no
+              FROM verifications AS v
+              JOIN execution_attempts AS ea ON ea.id = v.execution_attempt_id
+              JOIN approvals AS ap ON ap.id = ea.approval_id
+              JOIN actions AS a ON a.id = ap.action_id
+              JOIN plans AS p ON p.id = a.plan_id
+             WHERE p.run_id = ?
+             ORDER BY v.verified_at_ms
+            """,
+            (run_id,),
+        )
+        messages = _all(
+            connection,
+            "SELECT id, role, content FROM messages WHERE run_id = ? ORDER BY created_at_ms, id",
+            (run_id,),
+        )
+        workflow_binding = _one(
+            connection,
+            """
+            SELECT workflow_key, langgraph_thread_id, graph_profile, graph_version
+              FROM workflow_bindings
+             WHERE run_id = ?
+            """,
+            (run_id,),
+        )
+        audit_events = _all(
+            connection,
+            """
+            SELECT event_type, outcome, action_id
+              FROM audit_events
+             WHERE run_id = ?
+             ORDER BY id
+            """,
+            (run_id,),
+        )
+        run_count = cast(int, connection.execute("SELECT COUNT(*) FROM runs").fetchone()[0])
+        command_count = cast(
+            int,
+            connection.execute("SELECT COUNT(*) FROM command_receipts").fetchone()[0],
+        )
+    return {
+        "run": run,
+        "plans": plans,
+        "actions": actions,
+        "action_dependencies": dependencies,
+        "approvals": approvals,
+        "execution_attempts": attempts,
+        "verifications": verifications,
+        "messages": messages,
+        "workflow_binding": workflow_binding,
+        "audit_events": audit_events,
+        "run_count": run_count,
+        "command_count": command_count,
+        "mcp_events": _mcp_events(),
+        "llm_invocations": [
+            {
+                "kind": item.get("kind"),
+                "prompt_id": item.get("prompt_id"),
+                "scenario": item.get("scenario"),
+                "has_confirmation_response": _has_confirmation_response(item),
+            }
+            for item in _TRANSPORT.invocations
+        ],
+    }
+
+
+def _has_confirmation_response(invocation: Mapping[str, object]) -> bool:
+    prompt_input = invocation.get("prompt_input")
+    return isinstance(prompt_input, Mapping) and "confirmation_response" in prompt_input
+
+
+def _one(connection: Any, query: str, parameters: tuple[object, ...]) -> dict[str, object]:
+    row = connection.execute(query, parameters).fetchone()
+    if row is None:
+        return {}
+    return dict(row)
+
+
+def _all(
+    connection: Any, query: str, parameters: tuple[object, ...]
+) -> list[dict[str, object]]:
+    return [dict(row) for row in connection.execute(query, parameters).fetchall()]
+
+
+def _mcp_events() -> list[dict[str, object]]:
+    if not _MCP_EVENTS_PATH.is_file():
+        return []
+    return [
+        cast(dict[str, object], json.loads(line))
+        for line in _MCP_EVENTS_PATH.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+app = _build_app()
+
+
+def main() -> None:
+    Server(
+        Config(
+            app,
+            host=_HOST,
+            port=_PORT,
+            access_log=False,
+            proxy_headers=False,
+            server_header=False,
+            date_header=False,
+        )
+    ).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fakes/langgraph_e2e_mcp_server.py
+++ b/tests/fakes/langgraph_e2e_mcp_server.py
@@ -219,6 +219,8 @@ def _tool_payload(tool_name: str, arguments: dict[str, object]) -> dict[str, obj
                 ).values()
                 if query in json.dumps(item, sort_keys=True)
             ]
+            if not items and tool_name == "gmail_search_threads":
+                items = [_read_fixture(tool_name, arguments)]
             _save_state(state)
             return {"items": items, "next_page_token": None}
         _save_state(state)
@@ -276,7 +278,12 @@ def _read_fixture(tool_name: str, arguments: dict[str, object]) -> dict[str, obj
             {"title": "E2E task", "status": "needsAction"},
         )
     if tool_name == "calendar_list_calendars":
-        return _snapshot("calendar", "calendar-e2e", None, {"title": "E2E Calendar"})
+        return _snapshot(
+            "calendar",
+            "calendar-e2e",
+            None,
+            {"summary": "E2E Calendar", "primary": True},
+        )
     return _snapshot(
         "calendar_event",
         "event-read-e2e",

--- a/tests/integration/api/test_application_wiring.py
+++ b/tests/integration/api/test_application_wiring.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from google_work_agent.adapters.persistence.connection import connect_sqlite
+from google_work_agent.adapters.persistence.migration import apply_migrations
+from google_work_agent.adapters.persistence.sqlite.unit_of_work import (
+    sqlite_unit_of_work_factory,
+)
+from google_work_agent.api.dependencies.conversations import (
+    ConversationRouteDependencies,
+    get_conversation_route_dependencies,
+)
+from google_work_agent.api.routes import conversations as conversation_routes
+from google_work_agent.application.use_cases.conversation.create_conversation import (
+    CreateConversationHandler,
+)
+from google_work_agent.application.use_cases.conversation.get_conversation_history import (
+    GetConversationHistoryHandler,
+)
+from google_work_agent.application.use_cases.conversation.list_conversations import (
+    ListConversationsHandler,
+)
+
+
+def test_conversation_route__uses_application_handlers__and_matches_frontend_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "api-application-wiring.db"
+    with connect_sqlite(database_path) as connection:
+        apply_migrations(connection, now_ms=lambda: 1)
+        connection.execute(
+            "INSERT INTO google_accounts VALUES ('account-1', 'u@example.com', NULL, 1, NULL);"
+        )
+        connection.commit()
+
+    factory = sqlite_unit_of_work_factory(database_path, now_ms=lambda: 10)
+    dependencies = ConversationRouteDependencies(
+        api_contract_version="1",
+        unit_of_work_factory=factory,
+        create_conversation_handler=CreateConversationHandler(
+            unit_of_work_factory=factory,
+            now_ms=lambda: 10,
+        ),
+        list_conversations_handler=ListConversationsHandler(unit_of_work_factory=factory),
+        get_conversation_history_handler=GetConversationHistoryHandler(
+            unit_of_work_factory=factory
+        ),
+        current_account_id=lambda: "account-1",
+        new_id=lambda: "conversation-1",
+    )
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def add_request_id(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        request.state.request_id = "request-1"
+        return await call_next(request)
+
+    app.include_router(conversation_routes.router)
+    app.dependency_overrides[get_conversation_route_dependencies] = lambda: dependencies
+    monkeypatch.setattr(conversation_routes, "enforce_access", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        conversation_routes,
+        "enforce_runtime_operation",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/conversations",
+            json={"schema_version": 1, "command_id": "create-1", "title": "R2"},
+        )
+        listed = client.get("/api/v1/conversations?page_size=50")
+
+    expected_item = {
+        "schema_version": 1,
+        "conversation_id": "conversation-1",
+        "title": "R2",
+        "latest_message_at_ms": None,
+        "open_run_id": None,
+    }
+    assert created.status_code == 201
+    assert created.json() == expected_item
+    assert listed.status_code == 200
+    assert listed.json() == {
+        "schema_version": 1,
+        "items": [expected_item],
+        "next_cursor": None,
+    }
+    with connect_sqlite(database_path) as connection:
+        facts = connection.execute(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM conversations WHERE id='conversation-1'),
+                (SELECT status FROM command_receipts WHERE command_id='create-1');
+            """
+        ).fetchone()
+    assert tuple(facts) == (1, "APPLIED")

--- a/tests/integration/connectors/test_application_port_wiring.py
+++ b/tests/integration/connectors/test_application_port_wiring.py
@@ -1,0 +1,605 @@
+from __future__ import annotations
+
+from json import dumps
+from pathlib import Path
+from typing import cast
+
+from google_work_agent.adapters.connectors.google.workspace.composition import (
+    GOOGLE_WORKSPACE_CONNECTOR_ID,
+    google_workspace_internal_read_binding,
+)
+from google_work_agent.adapters.connectors.runtime.connector_runtime_registry import (
+    ConnectorRuntimeRegistry,
+)
+from google_work_agent.adapters.connectors.runtime.mcp_connector_read import (
+    McpConnectorReadAdapter,
+)
+from google_work_agent.adapters.connectors.runtime.mcp_connector_write import (
+    McpConnectorWriteAdapter,
+)
+from google_work_agent.adapters.langgraph.registry.node_registry import NodeRegistry
+from google_work_agent.adapters.langgraph.registry.resume_target_registry import (
+    ResumeTargetRegistry,
+)
+from google_work_agent.adapters.persistence.connection import connect_sqlite
+from google_work_agent.adapters.persistence.migration import apply_migrations
+from google_work_agent.adapters.persistence.sqlite.unit_of_work import (
+    sqlite_unit_of_work_factory,
+)
+from google_work_agent.adapters.system.memory.run_retrieval_cache import (
+    InMemoryRunRetrievalCache,
+)
+from google_work_agent.application.agents.retrieval.contracts.query_plan import (
+    SourceFetchPlanV1,
+)
+from google_work_agent.application.agents.retrieval.execute_read import execute_read
+from google_work_agent.application.tool_registry.load_signed_tool_registry import (
+    load_signed_tool_registry,
+)
+from google_work_agent.application.tool_registry.signed_tool_registry import SignedToolRegistry
+from google_work_agent.application.use_cases.claim.build_claim_context import ClaimContextV2
+from google_work_agent.application.use_cases.execution_attempt.dispatch_connector_write import (
+    DispatchConnectorWriteCommandV1,
+    DispatchConnectorWriteHandler,
+)
+from google_work_agent.application.use_cases.execution_attempt.recover_existing_result import (
+    RecoverExistingResultCommand,
+    RecoverExistingResultHandler,
+)
+from google_work_agent.application.use_cases.execution_attempt.store_success import (
+    StoreSuccessCommand,
+    StoreSuccessHandler,
+)
+from google_work_agent.application.use_cases.recovery.lookup_unknown_result import (
+    LookupUnknownResultHandler,
+)
+from google_work_agent.application.use_cases.resource_ref.resolve_resource_ref import (
+    ResolveResourceRefHandler,
+)
+from google_work_agent.application.use_cases.run.begin_verification import (
+    BeginVerificationCommand,
+    BeginVerificationHandler,
+)
+from google_work_agent.application.use_cases.verification.store_verification import (
+    StoreVerificationCommand,
+    StoreVerificationHandler,
+)
+from google_work_agent.application.use_cases.verification.verify_effect import (
+    VerifyEffectHandler,
+)
+from google_work_agent.domain.canonical import calculate_canonical_json_hash
+from google_work_agent.ports.connector.contracts.google_workspace import (
+    ResourceSnapshot,
+    ResourceType,
+)
+from google_work_agent.ports.connector.mcp_client_port import (
+    MCPRestartResultV1,
+    MCPRuntimeMetadata,
+    MCPToolCallResultV1,
+    MCPToolDescriptorV1,
+)
+from google_work_agent.ports.system.checkpoint_port import CheckpointPort
+from google_work_agent.ports.system.contracts.checkpoint import GraphCheckpointEnvelopeV1
+from google_work_agent.ports.system.contracts.workflow_binding import WorkflowBindingV1
+
+_ARGUMENTS: dict[str, object] = {
+    "task_list_id": "list-1",
+    "payload": {"title": "Task"},
+}
+_ARGUMENTS_HASH = calculate_canonical_json_hash(_ARGUMENTS)
+_RECOVERY_FINGERPRINT = "e" * 64
+
+
+class _RuntimeHandle:
+    def runtime_metadata(self) -> MCPRuntimeMetadata:
+        return MCPRuntimeMetadata("RUNNING", "1", "1", "1", 0, None, 0, "mcp-1")
+
+    def list_tools(self) -> list[MCPToolDescriptorV1]:
+        return []
+
+    def call_tool(self, tool_id: str, arguments: object, timeout_ms: int) -> MCPToolCallResultV1:
+        raise AssertionError((tool_id, arguments, timeout_ms))
+
+    def restart_once(self) -> MCPRestartResultV1:
+        return MCPRestartResultV1(1, False, None)
+
+    def close(self) -> None:
+        return None
+
+
+class _DeterministicMcpClient:
+    process_instance_id = "mcp-1"
+
+    def __init__(self, descriptors: list[MCPToolDescriptorV1]) -> None:
+        self._descriptors = descriptors
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def sign_claim_context(self, payload: dict[str, object]) -> str:
+        del payload
+        return "signature-1"
+
+    def list_tools(self, connector_id: str) -> list[MCPToolDescriptorV1]:
+        assert connector_id == GOOGLE_WORKSPACE_CONNECTOR_ID
+        return self._descriptors
+
+    def call_tool(
+        self,
+        connector_id: str,
+        tool_id: str,
+        arguments: object,
+        timeout_ms: int,
+    ) -> MCPToolCallResultV1:
+        assert connector_id == GOOGLE_WORKSPACE_CONNECTOR_ID
+        assert timeout_ms == 30_000
+        assert isinstance(arguments, dict)
+        call_arguments = cast(dict[str, object], arguments)
+        self.calls.append((tool_id, call_arguments))
+        if tool_id == "gmail_search_threads":
+            payload = {"request_id": "read-1", "items": [], "total_count": 0}
+        elif tool_id == "tasks_create_task":
+            payload = {
+                "request_id": "write-1",
+                "item": {
+                    "fixture_snapshot_id": "snapshot-1",
+                    "resource_type": "task",
+                    "resource_id": "task-1",
+                    "parent_id": "list-1",
+                    "version": "1",
+                    "recovery_fingerprint": _RECOVERY_FINGERPRINT,
+                    "payload": {"title": "Task"},
+                },
+            }
+        elif tool_id == "tasks_get_task":
+            payload = {
+                "request_id": "verify-1",
+                "item": {
+                    "resource_type": "task",
+                    "resource_id": call_arguments["task_id"],
+                    "parent_id": "list-1",
+                    "payload": {"title": "Task", "status": "needsAction"},
+                },
+            }
+        elif tool_id == "search_by_recovery_fingerprint":
+            payload = {
+                "request_id": "recovery-1",
+                "items": [
+                    {
+                        "resource_id": "task-recovered",
+                        "recovery_fingerprint": _RECOVERY_FINGERPRINT,
+                    }
+                ],
+            }
+        else:
+            raise AssertionError(f"unexpected MCP tool: {tool_id}")
+        return MCPToolCallResultV1(1, tool_id, "OK", payload, None)
+
+    def restart_once(self, connector_id: str) -> MCPRestartResultV1:
+        assert connector_id == GOOGLE_WORKSPACE_CONNECTOR_ID
+        return MCPRestartResultV1(1, False, None)
+
+
+class _CheckpointFacts:
+    def __init__(self) -> None:
+        self.binding = WorkflowBindingV1(
+            1,
+            "workflow-1",
+            "run-1",
+            "thread-1",
+            "SIX_ROLE_BASELINE",
+            "graph-v1",
+            "AUTO",
+            1,
+        )
+        self.checkpoint = GraphCheckpointEnvelopeV1(
+            1,
+            "checkpoint-1",
+            1,
+            "run-1",
+            "thread-1",
+            "SIX_ROLE_BASELINE",
+            "graph-v1",
+            "MAIN",
+            None,
+            None,
+            None,
+            None,
+            None,
+            (),
+            1,
+            b"checkpoint",
+        )
+
+    def load_workflow_binding(self, run_id: str) -> WorkflowBindingV1 | None:
+        return self.binding if run_id == "run-1" else None
+
+    def load_same_run_checkpoint(
+        self, run_id: str, thread_id: str
+    ) -> GraphCheckpointEnvelopeV1 | None:
+        if (run_id, thread_id) == ("run-1", "thread-1"):
+            return self.checkpoint
+        return None
+
+    def store_same_run_checkpoint(self, checkpoint: GraphCheckpointEnvelopeV1) -> None:
+        self.checkpoint = checkpoint
+
+
+def _connector_ports() -> tuple[
+    SignedToolRegistry,
+    _DeterministicMcpClient,
+    McpConnectorReadAdapter,
+    McpConnectorWriteAdapter,
+]:
+    registry = load_signed_tool_registry()
+    client = _DeterministicMcpClient(
+        registry.descriptor_expectations(GOOGLE_WORKSPACE_CONNECTOR_ID)
+    )
+    runtime_registry = ConnectorRuntimeRegistry()
+    runtime_registry.register(GOOGLE_WORKSPACE_CONNECTOR_ID, _RuntimeHandle())
+    read_port = McpConnectorReadAdapter(
+        runtime_registry=runtime_registry,
+        mcp_client=client,
+        internal_bindings=(
+            google_workspace_internal_read_binding("search_by_recovery_fingerprint"),
+        ),
+    )
+    return (
+        registry,
+        client,
+        read_port,
+        McpConnectorWriteAdapter(runtime_registry=runtime_registry, mcp_client=client),
+    )
+
+
+def _seed_write_state(database_path: Path, *, unknown: bool) -> None:
+    action_status = "UNKNOWN_RESULT" if unknown else "EXECUTING"
+    attempt_status = "UNKNOWN_RESULT" if unknown else "EXECUTING"
+    action_version = 3 if unknown else 2
+    attempt_version = 2 if unknown else 1
+    with connect_sqlite(database_path) as connection:
+        apply_migrations(connection, now_ms=lambda: 1)
+        connection.execute(
+            "INSERT INTO google_accounts VALUES ('account-1', 'u@example.com', NULL, 1, NULL);"
+        )
+        connection.execute(
+            "INSERT INTO conversations VALUES ('conversation-1', 'account-1', 'Test', 1, 1);"
+        )
+        connection.execute(
+            """
+            INSERT INTO runs (
+                id, conversation_id, entry_mode, status, langgraph_thread_id,
+                requested_mode, budget_json, version, started_at_ms
+            ) VALUES ('run-1', 'conversation-1', 'AGENT_SEARCH', 'WAITING_APPROVAL',
+                      'thread-1', 'AUTO', '{}', 0, 1);
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO plans (
+                id, run_id, revision_no, status, summary_text, created_at_ms,
+                review_status, review_version, review_disposition
+            ) VALUES ('plan-1', 'run-1', 1, 'WAITING_APPROVAL', 'Plan', 1,
+                      'PASSED', 1, 'PASS');
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO actions (
+                id, plan_id, connector_id, position, tool_name, effect_type,
+                approval_requirement, verification_policy, recovery_policy, status,
+                arguments_json, arguments_hash, expected_json, version,
+                created_at_ms, updated_at_ms
+            ) VALUES ('action-1', 'plan-1', 'google_workspace', 1, 'tasks_create_task',
+                      'CREATE', 'REQUIRED', 'GET_COMPARE', 'RESOURCE_SEARCH', ?,
+                      ?, ?, ?, ?, 1, 1);
+            """,
+            (
+                action_status,
+                dumps(_ARGUMENTS, sort_keys=True),
+                _ARGUMENTS_HASH,
+                dumps({"payload": {"title": "Task"}}, sort_keys=True),
+                action_version,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO approvals (
+                id, action_id, approval_no, action_version, status,
+                approved_by_account_id, arguments_snapshot_json,
+                canonical_arguments_hash, source_snapshot_json, source_snapshot_hash,
+                policy_version, tool_schema_version, idempotency_key,
+                recovery_fingerprint, approved_at_ms, expires_at_ms, consumed_at_ms
+            ) VALUES ('approval-1', 'action-1', 1, 1, 'CONSUMED', 'account-1',
+                      ?, ?, '{}', ?, 'policy-v1', 'schema-v1', ?, ?, 1, 100, 2);
+            """,
+            (
+                dumps(_ARGUMENTS, sort_keys=True),
+                _ARGUMENTS_HASH,
+                "b" * 64,
+                "c" * 64,
+                _RECOVERY_FINGERPRINT,
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO execution_attempts (
+                id, approval_id, attempt_no, status, version, started_at_ms
+            ) VALUES ('attempt-1', 'approval-1', 1, ?, ?, 2);
+            """,
+            (attempt_status, attempt_version),
+        )
+        if not unknown:
+            connection.execute(
+                """
+                INSERT INTO command_receipts (
+                    command_id, command_type, request_hash, aggregate_type, aggregate_id,
+                    status, result_code, result_version, response_json,
+                    created_at_ms, completed_at_ms
+                ) VALUES ('begin-execution-attempt:attempt-1', 'BeginExecutionAttempt', ?,
+                          'ExecutionAttempt', 'attempt-1', 'APPLIED',
+                          'TRANSITION_APPLIED', 1, ?, 2, 3);
+                """,
+                (
+                    "d" * 64,
+                    dumps(
+                        {
+                            "applied": True,
+                            "attempt_id": "attempt-1",
+                            "attempt_status": "EXECUTING",
+                        },
+                        sort_keys=True,
+                    ),
+                ),
+            )
+        connection.commit()
+
+
+def _snapshot(resource_id: str) -> ResourceSnapshot:
+    return ResourceSnapshot(
+        fixture_snapshot_id=f"snapshot-{resource_id}",
+        resource_type=ResourceType.TASK,
+        resource_id=resource_id,
+        parent_id="list-1",
+        related_resource_ids=("list-1",),
+        version="1",
+        recovery_fingerprint=_RECOVERY_FINGERPRINT,
+        payload={"title": "Task", "status": "needsAction"},
+    )
+
+
+def _verify_and_store(
+    database_path: Path,
+    *,
+    registry: SignedToolRegistry,
+    read_port: McpConnectorReadAdapter,
+    action_version: int,
+    suffix: str,
+) -> None:
+    factory = sqlite_unit_of_work_factory(database_path, now_ms=lambda: 20)
+    checkpoint = _CheckpointFacts()
+    begin = BeginVerificationHandler(
+        unit_of_work_factory=factory,
+        checkpoint_port=cast(CheckpointPort, checkpoint),
+        now_ms=lambda: 20,
+        resume_target_registry=ResumeTargetRegistry(
+            node_registry=NodeRegistry("graph-v1"),
+            graph_version="graph-v1",
+        ),
+    )(
+        BeginVerificationCommand(
+            f"begin-verification-{suffix}",
+            "f" * 64,
+            "run-1",
+            "action-1",
+            "attempt-1",
+        )
+    )
+    assert begin.applied is True
+    verifier = VerifyEffectHandler(
+        connector_read=read_port,
+        tool_registry=registry,
+        unit_of_work_factory=factory,
+        resolve_resource_ref=ResolveResourceRefHandler(unit_of_work_factory=factory),
+    )
+    verification = verifier(
+        verifier.project_persisted_query(
+            run_id="run-1",
+            action_id="action-1",
+            execution_attempt_id="attempt-1",
+        )
+    )
+    assert verification.status == "VERIFIED"
+    stored = StoreVerificationHandler(unit_of_work_factory=factory, now_ms=lambda: 21)(
+        StoreVerificationCommand(
+            f"store-verification-{suffix}",
+            "9" * 64,
+            f"verification-{suffix}",
+            "run-1",
+            "action-1",
+            "attempt-1",
+            action_version,
+            verification,
+        )
+    )
+    assert stored.applied is True
+    assert stored.action_status == "VERIFIED"
+
+
+def test_retrieval_application__uses_connector_read_adapter__through_mcp_port() -> None:
+    registry, client, read_port, _write_port = _connector_ports()
+    binding = registry.bind_required(GOOGLE_WORKSPACE_CONNECTOR_ID, "gmail_search_threads", "READ")
+    plan = cast(
+        SourceFetchPlanV1,
+        {
+            "schema_version": 1,
+            "route_id": "route-1",
+            "connector_id": GOOGLE_WORKSPACE_CONNECTOR_ID,
+            "resource_type": binding.resource_type,
+            "operation_kind": "INITIAL",
+            "effective_constraints": [],
+            "query_identity_hash": "a" * 64,
+            "prior_read_result_handle": None,
+            "detail_candidate_ref": None,
+        },
+    )
+
+    result = execute_read(
+        plan=plan,
+        run_id="run-1",
+        binding=binding,
+        tool_arguments={"query": "budget"},
+        connector_reader=read_port,
+        read_result_cache=InMemoryRunRetrievalCache(),
+        read_result_handle="read-result-1",
+    )
+
+    assert result.status == "COMPLETE"
+    assert result.provider_called is True
+    assert client.calls == [("gmail_search_threads", {"query": "budget"})]
+
+
+def test_write_success__crosses_connector_port__then_verifies_with_read_port(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "write-verification-wiring.db"
+    _seed_write_state(database_path, unknown=False)
+    registry, client, read_port, write_port = _connector_ports()
+    claim = ClaimContextV2(
+        2,
+        "service-1",
+        "mcp-1",
+        "action-1",
+        "approval-1",
+        "attempt-1",
+        "tasks_create_task",
+        _ARGUMENTS_HASH,
+        _ARGUMENTS_HASH,
+        2,
+        100,
+        "nonce-1",
+        "signature-1",
+    )
+    factory = sqlite_unit_of_work_factory(database_path, now_ms=lambda: 10)
+
+    dispatched = DispatchConnectorWriteHandler(
+        unit_of_work_factory=factory,
+        tool_registry=registry,
+        connector_write_port=write_port,
+    )(
+        DispatchConnectorWriteCommandV1(
+            "action-1",
+            "approval-1",
+            "attempt-1",
+            "tasks_create_task",
+            _ARGUMENTS,
+            claim,
+        )
+    )
+    assert dispatched.connector_result.success is True
+    assert "claim_context" in client.calls[0][1]
+    stored = StoreSuccessHandler(
+        unit_of_work_factory=factory,
+        now_ms=lambda: 11,
+        tool_registry=registry,
+    )(
+        StoreSuccessCommand(
+            "store-success-1",
+            "8" * 64,
+            "action-1",
+            "attempt-1",
+            2,
+            1,
+            _snapshot("task-1"),
+        )
+    )
+    assert stored.action_status == "EXECUTED"
+
+    _verify_and_store(
+        database_path,
+        registry=registry,
+        read_port=read_port,
+        action_version=stored.action_version,
+        suffix="success",
+    )
+
+    assert [tool_id for tool_id, _arguments in client.calls] == [
+        "tasks_create_task",
+        "tasks_get_task",
+    ]
+    with connect_sqlite(database_path) as connection:
+        facts = connection.execute(
+            """
+            SELECT
+                (SELECT status FROM actions WHERE id='action-1'),
+                (SELECT status FROM runs WHERE id='run-1'),
+                (SELECT status FROM verifications WHERE id='verification-success');
+            """
+        ).fetchone()
+    assert tuple(facts) == ("VERIFIED", "VERIFYING", "VERIFIED")
+
+
+def test_unknown_result__uses_read_only_lookup__then_recovers_and_verifies(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "unknown-recovery-wiring.db"
+    _seed_write_state(database_path, unknown=True)
+    registry, client, read_port, _write_port = _connector_ports()
+    factory = sqlite_unit_of_work_factory(database_path, now_ms=lambda: 30)
+    lookup_handler = LookupUnknownResultHandler(
+        connector_read=read_port,
+        tool_registry=registry,
+        recovery_search_binding=google_workspace_internal_read_binding(
+            "search_by_recovery_fingerprint"
+        ),
+        unit_of_work_factory=factory,
+        now_ms=lambda: 30,
+    )
+    projected = lookup_handler.project_persisted_query(
+        run_id="run-1",
+        action_id="action-1",
+        execution_attempt_id="attempt-1",
+        effect="CREATE",
+    )
+    lookup = lookup_handler(projected.query)
+    assert lookup.disposition == "MUTATION_FOUND"
+    assert lookup.candidate_resource_refs == ["task-recovered"]
+
+    recovered = RecoverExistingResultHandler(
+        unit_of_work_factory=factory,
+        now_ms=lambda: 31,
+        tool_registry=registry,
+    )(
+        RecoverExistingResultCommand(
+            "recover-existing-1",
+            "7" * 64,
+            "action-1",
+            "attempt-1",
+            3,
+            2,
+            _snapshot("task-recovered"),
+        )
+    )
+    assert recovered.action_status == "EXECUTED"
+
+    _verify_and_store(
+        database_path,
+        registry=registry,
+        read_port=read_port,
+        action_version=recovered.action_version,
+        suffix="recovery",
+    )
+
+    assert [tool_id for tool_id, _arguments in client.calls] == [
+        "search_by_recovery_fingerprint",
+        "tasks_get_task",
+    ]
+    with connect_sqlite(database_path) as connection:
+        facts = connection.execute(
+            """
+            SELECT
+                (SELECT status FROM actions WHERE id='action-1'),
+                (SELECT status FROM execution_attempts WHERE id='attempt-1'),
+                (SELECT status FROM command_receipts
+                 WHERE command_id LIKE 'system:lookup-unknown-result:%');
+            """
+        ).fetchone()
+    assert tuple(facts) == ("VERIFIED", "SUCCEEDED", "APPLIED")

--- a/tests/integration/langgraph/test_application_wiring.py
+++ b/tests/integration/langgraph/test_application_wiring.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from google_work_agent.adapters.langgraph.main.nodes.initialize_node import initialize_node
+from google_work_agent.adapters.persistence.connection import connect_sqlite
+from google_work_agent.adapters.persistence.migration import apply_migrations
+from google_work_agent.adapters.persistence.sqlite.unit_of_work import (
+    sqlite_unit_of_work_factory,
+)
+from google_work_agent.application.use_cases.run.start_analysis import (
+    StartAnalysisCommand,
+    StartAnalysisHandler,
+    StartAnalysisResult,
+)
+
+
+def test_initialize_node__calls_application_handler__and_persists_run_transition(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "langgraph-application-wiring.db"
+    with connect_sqlite(database_path) as connection:
+        apply_migrations(connection, now_ms=lambda: 1)
+        connection.execute(
+            "INSERT INTO google_accounts VALUES ('account-1', 'u@example.com', NULL, 1, NULL);"
+        )
+        connection.execute(
+            "INSERT INTO conversations VALUES ('conversation-1', 'account-1', 'Test', 1, 1);"
+        )
+        connection.execute(
+            """
+            INSERT INTO runs (
+                id, conversation_id, entry_mode, status, langgraph_thread_id,
+                requested_mode, budget_json, version, started_at_ms
+            ) VALUES ('run-1', 'conversation-1', 'AGENT_SEARCH', 'CREATED',
+                      'thread-1', 'AUTO', '{}', 0, 1);
+            """
+        )
+        connection.commit()
+
+    handler = StartAnalysisHandler(
+        unit_of_work_factory=sqlite_unit_of_work_factory(database_path, now_ms=lambda: 10),
+        now_ms=lambda: 10,
+    )
+
+    def start_analysis(run_id: str) -> StartAnalysisResult:
+        return handler(
+            StartAnalysisCommand(
+                run_id=run_id,
+                expected_version=0,
+                command_id="start-analysis-1",
+                request_hash="a" * 64,
+            )
+        )
+
+    result = initialize_node(
+        {"run_id": "run-1"},
+        start_analysis=start_analysis,
+        request_node="request_understanding",
+    )
+
+    assert result == {
+        "workflow_phase": "REQUEST_ANALYSIS",
+        "__logical_target__": "request_understanding",
+        "__target__": "request_understanding",
+    }
+    with connect_sqlite(database_path) as connection:
+        facts = connection.execute(
+            """
+            SELECT
+                (SELECT status FROM runs WHERE id='run-1'),
+                (SELECT status FROM command_receipts WHERE command_id='start-analysis-1'),
+                (SELECT COUNT(*) FROM audit_events WHERE event_type='RUN_ANALYSIS_STARTED');
+            """
+        ).fetchone()
+    assert tuple(facts) == ("ANALYZING", "APPLIED", 1)

--- a/tests/support/fakes/langgraph_e2e.py
+++ b/tests/support/fakes/langgraph_e2e.py
@@ -256,6 +256,7 @@ def _scenario(value: object) -> str:
         "VERIFICATION_MISMATCH",
         "CONTEXT_ADJUSTMENT",
         "PARTIAL_APPROVAL",
+        "CALENDAR_WRITE",
         "REVIEW_BACK_EDGE",
         "RESTART_RESUME",
         "UNKNOWN_RESULT",
@@ -299,7 +300,7 @@ def _route_semantics(scenario: str) -> tuple[list[str], list[str], list[str]]:
         return ["CALENDAR"], [], []
     if scenario == "PARTIAL_APPROVAL":
         return ["TASK", "CALENDAR"], ["TASK", "CALENDAR"], ["CREATE", "CREATE"]
-    if scenario in {"VERIFICATION_MISMATCH", "RECOVERY"}:
+    if scenario in {"CALENDAR_WRITE", "VERIFICATION_MISMATCH", "RECOVERY"}:
         return ["CALENDAR"], ["CALENDAR"], ["CREATE"]
     return ["TASK"], ["TASK"], ["CREATE"]
 

--- a/tests/unit/adapters/system/test_boundary_foundation_adapters.py
+++ b/tests/unit/adapters/system/test_boundary_foundation_adapters.py
@@ -139,25 +139,25 @@ def test_component_circuit__opens_at_threshold__and_success_resets() -> None:
     assert reset.consecutive_technical_failures == 0
 
 
-def test_sse_buffer__sanitizes_replays_expires__cursor_and_clears() -> None:
+def test_sse_buffer__preserves_typed_events_replays_expires__cursor_and_clears() -> None:
     buffer = InMemorySseEventBuffer(service_instance_id="service-1", capacity_per_run=2)
     for index in range(3):
         buffer.append(
             RunSseEventV1(
-                1,
-                "caller-value-is-replaced",
-                "run-1",
-                None,
-                index,
-                "RUN_EVENT",
-                {"index": index, "access_token": "secret"},
-                1,
+                schema_version=1,
+                event_id="caller-value-is-replaced",
+                run_id="run-1",
+                action_id=None,
+                occurred_at_ms=index,
+                event_type="run_status",
+                payload={"status": "ANALYZING", "snapshot_version": index},
+                projection_version=1,
             )
         )
 
     page = buffer.list_after("run-1", None, 10)
     assert [event.event_id for event in page.events] == ["service-1:2", "service-1:3"]
-    assert "access_token" not in page.events[0].payload
+    assert page.events[0].payload.snapshot_version == 1
     assert buffer.list_after("run-1", "service-1:1", 10).cursor_status == "OK"
     assert buffer.list_after("run-1", "other:1", 10).cursor_status == "CURSOR_EXPIRED"
     buffer.clear_run("run-1")

--- a/tests/unit/adapters/system/test_boundary_foundation_adapters.py
+++ b/tests/unit/adapters/system/test_boundary_foundation_adapters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -35,7 +36,10 @@ from google_work_agent.ports.system.contracts.external_llm_transfer_scope import
     ExternalLlmTransferScopeV1,
 )
 from google_work_agent.ports.system.run_retrieval_cache_port import RunRetrievalCacheEntryV1
-from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RunSseEventV1,
+    RunStatusSsePayloadV1,
+)
 
 
 @dataclass(frozen=True)
@@ -150,14 +154,17 @@ def test_sse_buffer__preserves_typed_events_replays_expires__cursor_and_clears()
                 action_id=None,
                 occurred_at_ms=index,
                 event_type="run_status",
-                payload={"status": "ANALYZING", "snapshot_version": index},
+                payload=RunStatusSsePayloadV1(
+                    status="ANALYZING", snapshot_version=index
+                ),
                 projection_version=1,
             )
         )
 
     page = buffer.list_after("run-1", None, 10)
     assert [event.event_id for event in page.events] == ["service-1:2", "service-1:3"]
-    assert page.events[0].payload.snapshot_version == 1
+    payload = cast(RunStatusSsePayloadV1, page.events[0].payload)
+    assert payload.snapshot_version == 1
     assert buffer.list_after("run-1", "service-1:1", 10).cursor_status == "OK"
     assert buffer.list_after("run-1", "other:1", 10).cursor_status == "CURSOR_EXPIRED"
     buffer.clear_run("run-1")

--- a/tests/unit/adapters/system/test_workflow_outcome_projector.py
+++ b/tests/unit/adapters/system/test_workflow_outcome_projector.py
@@ -1,0 +1,42 @@
+from google_work_agent.adapters.system.workflow_outcome_projector import (
+    WorkflowOutcomeProjector,
+)
+from google_work_agent.application.use_cases.sse_event.project_run_event import (
+    ProjectRunEventCommand,
+)
+from google_work_agent.ports.system.contracts.workflow_execution import WorkflowOutcome
+
+
+def test_waiting_approval_without_action_projection__publishes_run_status__for_snapshot_refresh(
+) -> None:
+    published: list[ProjectRunEventCommand] = []
+    projector = WorkflowOutcomeProjector(
+        require_recovery=lambda _command: None,  # type: ignore[arg-type]
+        project_run_event=published.append,  # type: ignore[arg-type]
+        now_ms=lambda: 10,
+        id_factory=lambda: "event-1",
+        recovery_target=lambda _run_id: None,
+    )
+
+    projector.handle_result(
+        "run-1",
+        WorkflowOutcome.ACCEPTED,
+        {
+            "phase": "WAITING_APPROVAL",
+            "run_status": "WAITING_APPROVAL",
+            "user_interrupt": {
+                "interrupt_kind": "APPROVAL",
+                "run_id": "run-1",
+                "plan_id": "plan-1",
+            },
+        },
+        4,
+    )
+
+    assert len(published) == 1
+    event = published[0]
+    assert event.event_type == "run_status"
+    assert event.payload == {
+        "status": "WAITING_APPROVAL",
+        "snapshot_version": 4,
+    }

--- a/tests/unit/api/test_schema_ownership.py
+++ b/tests/unit/api/test_schema_ownership.py
@@ -16,7 +16,6 @@ from google_work_agent.api.schemas.health_checks.get_readiness import ReadyRespo
 from google_work_agent.api.schemas.resources.list_resources import ResourceListResponse
 from google_work_agent.api.schemas.runs.cancel_run import CancelRunRequestV2
 from google_work_agent.api.schemas.runs.confirm_run import ConfirmationResponseV1
-from google_work_agent.api.schemas.runs.list_run_events import RunSseEventResponseV1
 from google_work_agent.api.schemas.runs.recovery import (
     ActionRecoveryTargetV1,
     RecoveryUiProjectionV1,
@@ -52,7 +51,6 @@ def test_run_transport__contracts_live__in_operation_modules() -> None:
 def test_other_plural__resource_contracts_live__in_operation_modules() -> None:
     assert StageAttachmentRequest.__module__.endswith(".attachments.stage_attachment")
     assert CreateConversationRequestV1.__module__.endswith(".conversations.create_conversation")
-    assert RunSseEventResponseV1.__module__.endswith(".runs.list_run_events")
     assert ResourceListResponse.__module__.endswith(".resources.list_resources")
     assert PatchSettingsRequest.__module__.endswith(".settings.update_settings")
     assert RuntimeDetailResponseV1.__module__.endswith(".runtime_summaries.get_runtime_summary")

--- a/tests/unit/application/test_event_publisher.py
+++ b/tests/unit/application/test_event_publisher.py
@@ -3,7 +3,16 @@ from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
 
 
 def _event(*, event_id: str, occurred_at_ms: int) -> RunSseEventV1:
-    return RunSseEventV1(1, event_id, "run-1", None, occurred_at_ms, "RUN_UPDATED", {}, 1)
+    return RunSseEventV1(
+        schema_version=1,
+        event_id=event_id,
+        run_id="run-1",
+        action_id=None,
+        occurred_at_ms=occurred_at_ms,
+        event_type="run_status",
+        payload={"status": "ANALYZING", "snapshot_version": occurred_at_ms},
+        projection_version=1,
+    )
 
 
 def test_in_memory_event__buffer_assigns_monotonic__ids_and_lists() -> None:

--- a/tests/unit/application/test_event_publisher.py
+++ b/tests/unit/application/test_event_publisher.py
@@ -1,5 +1,8 @@
 from google_work_agent.adapters.system.memory.sse_event_buffer import InMemorySseEventBuffer
-from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RunSseEventV1,
+    RunStatusSsePayloadV1,
+)
 
 
 def _event(*, event_id: str, occurred_at_ms: int) -> RunSseEventV1:
@@ -10,7 +13,9 @@ def _event(*, event_id: str, occurred_at_ms: int) -> RunSseEventV1:
         action_id=None,
         occurred_at_ms=occurred_at_ms,
         event_type="run_status",
-        payload={"status": "ANALYZING", "snapshot_version": occurred_at_ms},
+        payload=RunStatusSsePayloadV1(
+            status="ANALYZING", snapshot_version=occurred_at_ms
+        ),
         projection_version=1,
     )
 

--- a/tests/unit/application/use_cases/action/test_cancel_pending_action.py
+++ b/tests/unit/application/use_cases/action/test_cancel_pending_action.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.action.cancel_pending_action import (
+    CancelPendingActionHandler,
+)
+
+
+def test_cancel_pending_action__has_exact__application_owner() -> None:
+    assert (
+        CancelPendingActionHandler.__module__
+        == "google_work_agent.application.use_cases.action.cancel_pending_action"
+    )
+    assert CancelPendingActionHandler.__name__ == "CancelPendingActionHandler"

--- a/tests/unit/application/use_cases/action/test_modify_action.py
+++ b/tests/unit/application/use_cases/action/test_modify_action.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.action.modify_action import ModifyActionHandler
+
+
+def test_modify_action__has_exact__application_owner() -> None:
+    assert (
+        ModifyActionHandler.__module__
+        == "google_work_agent.application.use_cases.action.modify_action"
+    )
+    assert ModifyActionHandler.__name__ == "ModifyActionHandler"

--- a/tests/unit/application/use_cases/action/test_prepare_write_retry.py
+++ b/tests/unit/application/use_cases/action/test_prepare_write_retry.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.action.prepare_write_retry import (
+    PrepareWriteRetryHandler,
+)
+
+
+def test_prepare_write_retry__has_exact__application_owner() -> None:
+    assert (
+        PrepareWriteRetryHandler.__module__
+        == "google_work_agent.application.use_cases.action.prepare_write_retry"
+    )
+    assert PrepareWriteRetryHandler.__name__ == "PrepareWriteRetryHandler"

--- a/tests/unit/application/use_cases/action/test_refresh_expired_action.py
+++ b/tests/unit/application/use_cases/action/test_refresh_expired_action.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.action.refresh_expired_action import (
+    RefreshExpiredActionHandler,
+)
+
+
+def test_refresh_expired_action__has_exact__application_owner() -> None:
+    assert (
+        RefreshExpiredActionHandler.__module__
+        == "google_work_agent.application.use_cases.action.refresh_expired_action"
+    )
+    assert RefreshExpiredActionHandler.__name__ == "RefreshExpiredActionHandler"

--- a/tests/unit/application/use_cases/action/test_reject_action.py
+++ b/tests/unit/application/use_cases/action/test_reject_action.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.action.reject_action import RejectActionHandler
+
+
+def test_reject_action__has_exact__application_owner() -> None:
+    assert (
+        RejectActionHandler.__module__
+        == "google_work_agent.application.use_cases.action.reject_action"
+    )
+    assert RejectActionHandler.__name__ == "RejectActionHandler"

--- a/tests/unit/application/use_cases/action/test_validate_action_arguments.py
+++ b/tests/unit/application/use_cases/action/test_validate_action_arguments.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.action.validate_action_arguments import (
+    ValidateActionArgumentsHandler,
+)
+
+
+def test_validate_action_arguments__has_exact__application_owner() -> None:
+    assert (
+        ValidateActionArgumentsHandler.__module__
+        == "google_work_agent.application.use_cases.action.validate_action_arguments"
+    )
+    assert ValidateActionArgumentsHandler.__name__ == "ValidateActionArgumentsHandler"

--- a/tests/unit/application/use_cases/approval/test_expire_approval.py
+++ b/tests/unit/application/use_cases/approval/test_expire_approval.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.approval.expire_approval import ExpireApprovalHandler
+
+
+def test_expire_approval__has_exact__application_owner() -> None:
+    assert (
+        ExpireApprovalHandler.__module__
+        == "google_work_agent.application.use_cases.approval.expire_approval"
+    )
+    assert ExpireApprovalHandler.__name__ == "ExpireApprovalHandler"

--- a/tests/unit/application/use_cases/backup/test_create_backup.py
+++ b/tests/unit/application/use_cases/backup/test_create_backup.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.backup.create_backup import CreateBackupHandler
+
+
+def test_create_backup__has_exact__application_owner() -> None:
+    assert (
+        CreateBackupHandler.__module__
+        == "google_work_agent.application.use_cases.backup.create_backup"
+    )
+    assert CreateBackupHandler.__name__ == "CreateBackupHandler"

--- a/tests/unit/application/use_cases/backup/test_list_backups.py
+++ b/tests/unit/application/use_cases/backup/test_list_backups.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.backup.list_backups import ListBackupsHandler
+
+
+def test_list_backups__has_exact__application_owner() -> None:
+    assert (
+        ListBackupsHandler.__module__
+        == "google_work_agent.application.use_cases.backup.list_backups"
+    )
+    assert ListBackupsHandler.__name__ == "ListBackupsHandler"

--- a/tests/unit/application/use_cases/backup/test_restore_backup.py
+++ b/tests/unit/application/use_cases/backup/test_restore_backup.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.backup.restore_backup import RestoreBackupHandler
+
+
+def test_restore_backup__has_exact__application_owner() -> None:
+    assert (
+        RestoreBackupHandler.__module__
+        == "google_work_agent.application.use_cases.backup.restore_backup"
+    )
+    assert RestoreBackupHandler.__name__ == "RestoreBackupHandler"

--- a/tests/unit/application/use_cases/claim/test_claim_execution.py
+++ b/tests/unit/application/use_cases/claim/test_claim_execution.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.claim.claim_execution import ClaimExecutionHandler
+
+
+def test_claim_execution__has_exact__application_owner() -> None:
+    assert (
+        ClaimExecutionHandler.__module__
+        == "google_work_agent.application.use_cases.claim.claim_execution"
+    )
+    assert ClaimExecutionHandler.__name__ == "ClaimExecutionHandler"

--- a/tests/unit/application/use_cases/connection/test_get_connection_status.py
+++ b/tests/unit/application/use_cases/connection/test_get_connection_status.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.connection.get_connection_status import (
+    GetConnectionStatusHandler,
+)
+
+
+def test_get_connection_status__has_exact__application_owner() -> None:
+    assert (
+        GetConnectionStatusHandler.__module__
+        == "google_work_agent.application.use_cases.connection.get_connection_status"
+    )
+    assert GetConnectionStatusHandler.__name__ == "GetConnectionStatusHandler"

--- a/tests/unit/application/use_cases/connection/test_revoke_connection.py
+++ b/tests/unit/application/use_cases/connection/test_revoke_connection.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.connection.revoke_connection import (
+    RevokeConnectionHandler,
+)
+
+
+def test_revoke_connection__has_exact__application_owner() -> None:
+    assert (
+        RevokeConnectionHandler.__module__
+        == "google_work_agent.application.use_cases.connection.revoke_connection"
+    )
+    assert RevokeConnectionHandler.__name__ == "RevokeConnectionHandler"

--- a/tests/unit/application/use_cases/connection/test_start_authorization.py
+++ b/tests/unit/application/use_cases/connection/test_start_authorization.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.connection.start_authorization import (
+    StartAuthorizationHandler,
+)
+
+
+def test_start_authorization__has_exact__application_owner() -> None:
+    assert (
+        StartAuthorizationHandler.__module__
+        == "google_work_agent.application.use_cases.connection.start_authorization"
+    )
+    assert StartAuthorizationHandler.__name__ == "StartAuthorizationHandler"

--- a/tests/unit/application/use_cases/diagnostic_bundle/test_create_diagnostic_bundle.py
+++ b/tests/unit/application/use_cases/diagnostic_bundle/test_create_diagnostic_bundle.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.diagnostic_bundle.create_diagnostic_bundle import (
+    CreateDiagnosticBundleHandler,
+)
+
+
+def test_create_diagnostic_bundle__has_exact__application_owner() -> None:
+    assert (
+        CreateDiagnosticBundleHandler.__module__
+        == "google_work_agent.application.use_cases.diagnostic_bundle.create_diagnostic_bundle"
+    )
+    assert CreateDiagnosticBundleHandler.__name__ == "CreateDiagnosticBundleHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_abort_claimed_execution.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_abort_claimed_execution.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.abort_claimed_execution import (
+    AbortClaimedExecutionHandler,
+)
+
+
+def test_abort_claimed_execution__has_exact__application_owner() -> None:
+    assert (
+        AbortClaimedExecutionHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.abort_claimed_execution"
+    )
+    assert AbortClaimedExecutionHandler.__name__ == "AbortClaimedExecutionHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_begin_execution_attempt.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_begin_execution_attempt.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.begin_execution_attempt import (
+    BeginExecutionAttemptHandler,
+)
+
+
+def test_begin_execution_attempt__has_exact__application_owner() -> None:
+    assert (
+        BeginExecutionAttemptHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.begin_execution_attempt"
+    )
+    assert BeginExecutionAttemptHandler.__name__ == "BeginExecutionAttemptHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_mark_failed.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_mark_failed.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.execution_attempt.mark_failed import MarkFailedHandler
+
+
+def test_mark_failed__has_exact__application_owner() -> None:
+    assert (
+        MarkFailedHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.mark_failed"
+    )
+    assert MarkFailedHandler.__name__ == "MarkFailedHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_mark_unknown_result.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_mark_unknown_result.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.mark_unknown_result import (
+    MarkUnknownResultHandler,
+)
+
+
+def test_mark_unknown_result__has_exact__application_owner() -> None:
+    assert (
+        MarkUnknownResultHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.mark_unknown_result"
+    )
+    assert MarkUnknownResultHandler.__name__ == "MarkUnknownResultHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_recover_existing_result.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_recover_existing_result.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.recover_existing_result import (
+    RecoverExistingResultHandler,
+)
+
+
+def test_recover_existing_result__has_exact__application_owner() -> None:
+    assert (
+        RecoverExistingResultHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.recover_existing_result"
+    )
+    assert RecoverExistingResultHandler.__name__ == "RecoverExistingResultHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_resolve_as_failed.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_resolve_as_failed.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.resolve_as_failed import (
+    ResolveAsFailedHandler,
+)
+
+
+def test_resolve_as_failed__has_exact__application_owner() -> None:
+    assert (
+        ResolveAsFailedHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.resolve_as_failed"
+    )
+    assert ResolveAsFailedHandler.__name__ == "ResolveAsFailedHandler"

--- a/tests/unit/application/use_cases/execution_attempt/test_store_success.py
+++ b/tests/unit/application/use_cases/execution_attempt/test_store_success.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.execution_attempt.store_success import (
+    StoreSuccessHandler,
+)
+
+
+def test_store_success__has_exact__application_owner() -> None:
+    assert (
+        StoreSuccessHandler.__module__
+        == "google_work_agent.application.use_cases.execution_attempt.store_success"
+    )
+    assert StoreSuccessHandler.__name__ == "StoreSuccessHandler"

--- a/tests/unit/application/use_cases/llm_credential/test_delete_llm_credential.py
+++ b/tests/unit/application/use_cases/llm_credential/test_delete_llm_credential.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.llm_credential.delete_llm_credential import (
+    DeleteLlmCredentialHandler,
+)
+
+
+def test_delete_llm_credential__has_exact__application_owner() -> None:
+    assert (
+        DeleteLlmCredentialHandler.__module__
+        == "google_work_agent.application.use_cases.llm_credential.delete_llm_credential"
+    )
+    assert DeleteLlmCredentialHandler.__name__ == "DeleteLlmCredentialHandler"

--- a/tests/unit/application/use_cases/llm_credential/test_get_llm_credential_status.py
+++ b/tests/unit/application/use_cases/llm_credential/test_get_llm_credential_status.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.llm_credential.get_llm_credential_status import (
+    GetLlmCredentialStatusHandler,
+)
+
+
+def test_get_llm_credential_status__has_exact__application_owner() -> None:
+    assert (
+        GetLlmCredentialStatusHandler.__module__
+        == "google_work_agent.application.use_cases.llm_credential.get_llm_credential_status"
+    )
+    assert GetLlmCredentialStatusHandler.__name__ == "GetLlmCredentialStatusHandler"

--- a/tests/unit/application/use_cases/llm_credential/test_store_llm_credential.py
+++ b/tests/unit/application/use_cases/llm_credential/test_store_llm_credential.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.llm_credential.store_llm_credential import (
+    StoreLlmCredentialHandler,
+)
+
+
+def test_store_llm_credential__has_exact__application_owner() -> None:
+    assert (
+        StoreLlmCredentialHandler.__module__
+        == "google_work_agent.application.use_cases.llm_credential.store_llm_credential"
+    )
+    assert StoreLlmCredentialHandler.__name__ == "StoreLlmCredentialHandler"

--- a/tests/unit/application/use_cases/plan/test_publish_plan.py
+++ b/tests/unit/application/use_cases/plan/test_publish_plan.py
@@ -1,0 +1,8 @@
+from google_work_agent.application.use_cases.plan.publish_plan import PublishPlanHandler
+
+
+def test_publish_plan__has_exact__application_owner() -> None:
+    assert (
+        PublishPlanHandler.__module__ == "google_work_agent.application.use_cases.plan.publish_plan"
+    )
+    assert PublishPlanHandler.__name__ == "PublishPlanHandler"

--- a/tests/unit/application/use_cases/recovery/test_lookup_unknown_result.py
+++ b/tests/unit/application/use_cases/recovery/test_lookup_unknown_result.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.recovery.lookup_unknown_result import (
+    LookupUnknownResultHandler,
+)
+
+
+def test_lookup_unknown_result__has_exact__application_owner() -> None:
+    assert (
+        LookupUnknownResultHandler.__module__
+        == "google_work_agent.application.use_cases.recovery.lookup_unknown_result"
+    )
+    assert LookupUnknownResultHandler.__name__ == "LookupUnknownResultHandler"

--- a/tests/unit/application/use_cases/resource/test_get_resource_count.py
+++ b/tests/unit/application/use_cases/resource/test_get_resource_count.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.resource.get_resource_count import (
+    GetResourceCountHandler,
+)
+
+
+def test_get_resource_count__has_exact__application_owner() -> None:
+    assert (
+        GetResourceCountHandler.__module__
+        == "google_work_agent.application.use_cases.resource.get_resource_count"
+    )
+    assert GetResourceCountHandler.__name__ == "GetResourceCountHandler"

--- a/tests/unit/application/use_cases/resource/test_get_resource_detail.py
+++ b/tests/unit/application/use_cases/resource/test_get_resource_detail.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.resource.get_resource_detail import (
+    GetResourceDetailHandler,
+)
+
+
+def test_get_resource_detail__has_exact__application_owner() -> None:
+    assert (
+        GetResourceDetailHandler.__module__
+        == "google_work_agent.application.use_cases.resource.get_resource_detail"
+    )
+    assert GetResourceDetailHandler.__name__ == "GetResourceDetailHandler"

--- a/tests/unit/application/use_cases/run/test_begin_retrieval.py
+++ b/tests/unit/application/use_cases/run/test_begin_retrieval.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.begin_retrieval import BeginRetrievalHandler
+
+
+def test_begin_retrieval__has_exact__application_owner() -> None:
+    assert (
+        BeginRetrievalHandler.__module__
+        == "google_work_agent.application.use_cases.run.begin_retrieval"
+    )
+    assert BeginRetrievalHandler.__name__ == "BeginRetrievalHandler"

--- a/tests/unit/application/use_cases/run/test_begin_verification.py
+++ b/tests/unit/application/use_cases/run/test_begin_verification.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.begin_verification import BeginVerificationHandler
+
+
+def test_begin_verification__has_exact__application_owner() -> None:
+    assert (
+        BeginVerificationHandler.__module__
+        == "google_work_agent.application.use_cases.run.begin_verification"
+    )
+    assert BeginVerificationHandler.__name__ == "BeginVerificationHandler"

--- a/tests/unit/application/use_cases/run/test_block_run.py
+++ b/tests/unit/application/use_cases/run/test_block_run.py
@@ -1,0 +1,6 @@
+from google_work_agent.application.use_cases.run.block_run import BlockRunHandler
+
+
+def test_block_run__has_exact__application_owner() -> None:
+    assert BlockRunHandler.__module__ == "google_work_agent.application.use_cases.run.block_run"
+    assert BlockRunHandler.__name__ == "BlockRunHandler"

--- a/tests/unit/application/use_cases/run/test_complete_answer_only_run.py
+++ b/tests/unit/application/use_cases/run/test_complete_answer_only_run.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.run.complete_answer_only_run import (
+    CompleteAnswerOnlyRunHandler,
+)
+
+
+def test_complete_answer_only_run__has_exact__application_owner() -> None:
+    assert (
+        CompleteAnswerOnlyRunHandler.__module__
+        == "google_work_agent.application.use_cases.run.complete_answer_only_run"
+    )
+    assert CompleteAnswerOnlyRunHandler.__name__ == "CompleteAnswerOnlyRunHandler"

--- a/tests/unit/application/use_cases/run/test_complete_write_run.py
+++ b/tests/unit/application/use_cases/run/test_complete_write_run.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.complete_write_run import CompleteWriteRunHandler
+
+
+def test_complete_write_run__has_exact__application_owner() -> None:
+    assert (
+        CompleteWriteRunHandler.__module__
+        == "google_work_agent.application.use_cases.run.complete_write_run"
+    )
+    assert CompleteWriteRunHandler.__name__ == "CompleteWriteRunHandler"

--- a/tests/unit/application/use_cases/run/test_finalize_cancel.py
+++ b/tests/unit/application/use_cases/run/test_finalize_cancel.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.finalize_cancel import FinalizeCancelHandler
+
+
+def test_finalize_cancel__has_exact__application_owner() -> None:
+    assert (
+        FinalizeCancelHandler.__module__
+        == "google_work_agent.application.use_cases.run.finalize_cancel"
+    )
+    assert FinalizeCancelHandler.__name__ == "FinalizeCancelHandler"

--- a/tests/unit/application/use_cases/run/test_project_external_llm_transfer_scope.py
+++ b/tests/unit/application/use_cases/run/test_project_external_llm_transfer_scope.py
@@ -7,6 +7,9 @@ from google_work_agent.application.use_cases.run.project_external_llm_transfer_s
     ProjectExternalLlmTransferScopeHandler,
     ProjectExternalLlmTransferScopeQueryV1,
 )
+from google_work_agent.application.use_cases.trace_event.emit_trace_event import (
+    EmitTraceEventCommand,
+)
 from google_work_agent.ports.system.contracts.external_llm_transfer_scope import (
     ExternalLlmTransferScopeV1,
 )
@@ -30,15 +33,17 @@ class _Checkpoint:
 
 
 @dataclass
-class _Events:
+class _TraceEvents:
     calls: list[str]
     fail: bool = False
 
-    def __call__(self, command: object) -> None:
-        del command
-        self.calls.append("event")
+    commands: list[EmitTraceEventCommand] = field(default_factory=list)
+
+    def __call__(self, command: EmitTraceEventCommand) -> None:
+        self.commands.append(command)
+        self.calls.append("trace")
         if self.fail:
-            raise RuntimeError("SSE_UNAVAILABLE")
+            raise RuntimeError("TRACE_UNAVAILABLE")
 
 
 def test_external_llm_transfer__scope_uses_exact__canonical_list_contract() -> None:
@@ -104,14 +109,14 @@ def test_project_external_llm__transfer_scope_changes__hash_and_revision() -> No
     assert second.scope_hash != first.scope_hash
 
 
-def test_scope_checkpoint__remains_durable_when__sse_append_fails() -> None:
+def test_scope_checkpoint__remains_durable_when__trace_append_fails() -> None:
     checkpoint = _Checkpoint()
     handler = ProjectExternalLlmTransferScopeHandler(
         checkpoint,  # type: ignore[arg-type]
-        _Events(checkpoint.calls, fail=True),  # type: ignore[arg-type]
+        _TraceEvents(checkpoint.calls, fail=True),  # type: ignore[arg-type]
     )
 
-    with pytest.raises(RuntimeError, match="SSE_UNAVAILABLE"):
+    with pytest.raises(RuntimeError, match="TRACE_UNAVAILABLE"):
         handler(
             ProjectExternalLlmTransferScopeQueryV1(
                 1,
@@ -122,15 +127,16 @@ def test_scope_checkpoint__remains_durable_when__sse_append_fails() -> None:
             )
         )
 
-    assert checkpoint.calls == ["store", "flush", "event"]
+    assert checkpoint.calls == ["store", "flush", "trace"]
     assert checkpoint.scope is not None
 
 
-def test_scope_checkpoint__is_flushed__before_sse_append() -> None:
+def test_scope_checkpoint__is_flushed__before_trace_append() -> None:
     checkpoint = _Checkpoint()
+    trace = _TraceEvents(checkpoint.calls)
     handler = ProjectExternalLlmTransferScopeHandler(
         checkpoint,  # type: ignore[arg-type]
-        _Events(checkpoint.calls),  # type: ignore[arg-type]
+        trace,  # type: ignore[arg-type]
     )
 
     handler(
@@ -143,14 +149,21 @@ def test_scope_checkpoint__is_flushed__before_sse_append() -> None:
         )
     )
 
-    assert checkpoint.calls == ["store", "flush", "event"]
+    assert checkpoint.calls == ["store", "flush", "trace"]
+    assert trace.commands[0].event_name == "EXTERNAL_LLM_SCOPE_PUBLISHED"
+    assert trace.commands[0].attributes == {
+        "scope_revision": 1,
+        "scope_hash": checkpoint.scope.scope_hash,  # type: ignore[union-attr]
+        "source_kinds": ["USER_REQUEST"],
+        "data_classes": ["USER_REQUEST"],
+    }
 
 
-def test_scope_event_is__retried_after_checkpoint_first__crash_without_rewriting_scope() -> None:
+def test_scope_trace_is__retried_after_checkpoint_first__crash_without_rewriting_scope() -> None:
     checkpoint = _Checkpoint()
     failing_handler = ProjectExternalLlmTransferScopeHandler(
         checkpoint,  # type: ignore[arg-type]
-        _Events(checkpoint.calls, fail=True),  # type: ignore[arg-type]
+        _TraceEvents(checkpoint.calls, fail=True),  # type: ignore[arg-type]
     )
     query = ProjectExternalLlmTransferScopeQueryV1(
         1,
@@ -160,14 +173,14 @@ def test_scope_event_is__retried_after_checkpoint_first__crash_without_rewriting
         occurred_at_ms=1,
     )
 
-    with pytest.raises(RuntimeError, match="SSE_UNAVAILABLE"):
+    with pytest.raises(RuntimeError, match="TRACE_UNAVAILABLE"):
         failing_handler(query)
 
     recovered_handler = ProjectExternalLlmTransferScopeHandler(
         checkpoint,  # type: ignore[arg-type]
-        _Events(checkpoint.calls),  # type: ignore[arg-type]
+        _TraceEvents(checkpoint.calls),  # type: ignore[arg-type]
     )
     recovered = recovered_handler(query)
 
     assert recovered == checkpoint.scope
-    assert checkpoint.calls == ["store", "flush", "event", "event"]
+    assert checkpoint.calls == ["store", "flush", "trace", "trace"]

--- a/tests/unit/application/use_cases/run/test_reconcile_retrieval_cache_restart.py
+++ b/tests/unit/application/use_cases/run/test_reconcile_retrieval_cache_restart.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.run.reconcile_retrieval_cache_restart import (
+    ReconcileRetrievalCacheRestartHandler,
+)
+
+
+def test_reconcile_retrieval_cache_restart__has_exact__application_owner() -> None:
+    assert (
+        ReconcileRetrievalCacheRestartHandler.__module__
+        == "google_work_agent.application.use_cases.run.reconcile_retrieval_cache_restart"
+    )
+    assert ReconcileRetrievalCacheRestartHandler.__name__ == "ReconcileRetrievalCacheRestartHandler"

--- a/tests/unit/application/use_cases/run/test_request_confirmation.py
+++ b/tests/unit/application/use_cases/run/test_request_confirmation.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.run.request_confirmation import (
+    RequestConfirmationHandler,
+)
+
+
+def test_request_confirmation__has_exact__application_owner() -> None:
+    assert (
+        RequestConfirmationHandler.__module__
+        == "google_work_agent.application.use_cases.run.request_confirmation"
+    )
+    assert RequestConfirmationHandler.__name__ == "RequestConfirmationHandler"

--- a/tests/unit/application/use_cases/run/test_require_reauth.py
+++ b/tests/unit/application/use_cases/run/test_require_reauth.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.require_reauth import RequireReauthHandler
+
+
+def test_require_reauth__has_exact__application_owner() -> None:
+    assert (
+        RequireReauthHandler.__module__
+        == "google_work_agent.application.use_cases.run.require_reauth"
+    )
+    assert RequireReauthHandler.__name__ == "RequireReauthHandler"

--- a/tests/unit/application/use_cases/run/test_resume_after_reauth.py
+++ b/tests/unit/application/use_cases/run/test_resume_after_reauth.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.resume_after_reauth import ResumeAfterReauthHandler
+
+
+def test_resume_after_reauth__has_exact__application_owner() -> None:
+    assert (
+        ResumeAfterReauthHandler.__module__
+        == "google_work_agent.application.use_cases.run.resume_after_reauth"
+    )
+    assert ResumeAfterReauthHandler.__name__ == "ResumeAfterReauthHandler"

--- a/tests/unit/application/use_cases/run/test_resume_confirmation.py
+++ b/tests/unit/application/use_cases/run/test_resume_confirmation.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.run.resume_confirmation import (
+    ResumeConfirmationHandler,
+)
+
+
+def test_resume_confirmation__has_exact__application_owner() -> None:
+    assert (
+        ResumeConfirmationHandler.__module__
+        == "google_work_agent.application.use_cases.run.resume_confirmation"
+    )
+    assert ResumeConfirmationHandler.__name__ == "ResumeConfirmationHandler"

--- a/tests/unit/application/use_cases/run/test_start_analysis.py
+++ b/tests/unit/application/use_cases/run/test_start_analysis.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.run.start_analysis import StartAnalysisHandler
+
+
+def test_start_analysis__has_exact__application_owner() -> None:
+    assert (
+        StartAnalysisHandler.__module__
+        == "google_work_agent.application.use_cases.run.start_analysis"
+    )
+    assert StartAnalysisHandler.__name__ == "StartAnalysisHandler"

--- a/tests/unit/application/use_cases/runtime_status/test_get_runtime_status.py
+++ b/tests/unit/application/use_cases/runtime_status/test_get_runtime_status.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.runtime_status.get_runtime_status import (
+    GetRuntimeStatusHandler,
+)
+
+
+def test_get_runtime_status__has_exact__application_owner() -> None:
+    assert (
+        GetRuntimeStatusHandler.__module__
+        == "google_work_agent.application.use_cases.runtime_status.get_runtime_status"
+    )
+    assert GetRuntimeStatusHandler.__name__ == "GetRuntimeStatusHandler"

--- a/tests/unit/application/use_cases/setting/test_get_settings.py
+++ b/tests/unit/application/use_cases/setting/test_get_settings.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.setting.get_settings import GetSettingsHandler
+
+
+def test_get_settings__has_exact__application_owner() -> None:
+    assert (
+        GetSettingsHandler.__module__
+        == "google_work_agent.application.use_cases.setting.get_settings"
+    )
+    assert GetSettingsHandler.__name__ == "GetSettingsHandler"

--- a/tests/unit/application/use_cases/setting/test_update_settings.py
+++ b/tests/unit/application/use_cases/setting/test_update_settings.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.setting.update_settings import UpdateSettingsHandler
+
+
+def test_update_settings__has_exact__application_owner() -> None:
+    assert (
+        UpdateSettingsHandler.__module__
+        == "google_work_agent.application.use_cases.setting.update_settings"
+    )
+    assert UpdateSettingsHandler.__name__ == "UpdateSettingsHandler"

--- a/tests/unit/application/use_cases/shutdown/test_request_shutdown.py
+++ b/tests/unit/application/use_cases/shutdown/test_request_shutdown.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.shutdown.request_shutdown import RequestShutdownHandler
+
+
+def test_request_shutdown__has_exact__application_owner() -> None:
+    assert (
+        RequestShutdownHandler.__module__
+        == "google_work_agent.application.use_cases.shutdown.request_shutdown"
+    )
+    assert RequestShutdownHandler.__name__ == "RequestShutdownHandler"

--- a/tests/unit/application/use_cases/sse_event/test_list_run_events.py
+++ b/tests/unit/application/use_cases/sse_event/test_list_run_events.py
@@ -11,6 +11,19 @@ from google_work_agent.application.use_cases.sse_event.list_run_events import (
 from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
 
 
+def _event(run_id: str, occurred_at_ms: int) -> RunSseEventV1:
+    return RunSseEventV1(
+        schema_version=1,
+        event_id="",
+        run_id=run_id,
+        action_id=None,
+        occurred_at_ms=occurred_at_ms,
+        event_type="run_status",
+        payload={"status": "ANALYZING", "snapshot_version": occurred_at_ms},
+        projection_version=1,
+    )
+
+
 def _handler(tmp_path: Path) -> tuple[ListRunEventsHandler, InMemorySseEventBuffer]:
     database_path = tmp_path / "events.db"
     with connect_sqlite(database_path) as connection:
@@ -33,7 +46,7 @@ def _handler(tmp_path: Path) -> tuple[ListRunEventsHandler, InMemorySseEventBuff
 def test_lists_bounded__events_and__projects_cursor_expiry(tmp_path: Path) -> None:
     handler, buffer = _handler(tmp_path)
     for index in range(1, 4):
-        buffer.append(RunSseEventV1(1, "", "run-1", None, index, "RUN_UPDATED", {}, 1))
+        buffer.append(_event("run-1", index))
     current = handler(ListRunEventsQuery("run-1", "svc:2"))
     expired = handler(ListRunEventsQuery("run-1", "invalid"))
     assert [event.event_id for event in current.events] == ["svc:3"]
@@ -43,7 +56,7 @@ def test_lists_bounded__events_and__projects_cursor_expiry(tmp_path: Path) -> No
 
 def test_missing_run__never_exposes__buffer_content(tmp_path: Path) -> None:
     handler, buffer = _handler(tmp_path)
-    buffer.append(RunSseEventV1(1, "", "missing", None, 1, "RUN_UPDATED", {}, 1))
+    buffer.append(_event("missing", 1))
     result = handler(ListRunEventsQuery("missing"))
     assert result.run_exists is False
     assert result.events == ()

--- a/tests/unit/application/use_cases/sse_event/test_list_run_events.py
+++ b/tests/unit/application/use_cases/sse_event/test_list_run_events.py
@@ -8,7 +8,10 @@ from google_work_agent.application.use_cases.sse_event.list_run_events import (
     ListRunEventsHandler,
     ListRunEventsQuery,
 )
-from google_work_agent.ports.system.sse_event_buffer_port import RunSseEventV1
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RunSseEventV1,
+    RunStatusSsePayloadV1,
+)
 
 
 def _event(run_id: str, occurred_at_ms: int) -> RunSseEventV1:
@@ -19,7 +22,9 @@ def _event(run_id: str, occurred_at_ms: int) -> RunSseEventV1:
         action_id=None,
         occurred_at_ms=occurred_at_ms,
         event_type="run_status",
-        payload={"status": "ANALYZING", "snapshot_version": occurred_at_ms},
+        payload=RunStatusSsePayloadV1(
+            status="ANALYZING", snapshot_version=occurred_at_ms
+        ),
         projection_version=1,
     )
 

--- a/tests/unit/application/use_cases/sse_event/test_project_run_event.py
+++ b/tests/unit/application/use_cases/sse_event/test_project_run_event.py
@@ -13,6 +13,7 @@ from google_work_agent.ports.system.sse_event_buffer_port import (
     SSE_PAYLOAD_TYPE_BY_EVENT_V1,
     RunSseEventTypeV1,
     RunSseEventV1,
+    SseEventPageV1,
     SsePayloadV1,
 )
 
@@ -51,7 +52,9 @@ class _Buffer:
     def append(self, event: RunSseEventV1) -> None:
         self.events.append(event)
 
-    def list_after(self, run_id: str, last_event_id: str | None, limit: int) -> object:
+    def list_after(
+        self, run_id: str, last_event_id: str | None, limit: int
+    ) -> SseEventPageV1:
         raise NotImplementedError
 
     def clear_run(self, run_id: str) -> None:

--- a/tests/unit/application/use_cases/sse_event/test_project_run_event.py
+++ b/tests/unit/application/use_cases/sse_event/test_project_run_event.py
@@ -1,0 +1,152 @@
+from collections.abc import Mapping
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from google_work_agent.application.use_cases.sse_event.project_run_event import (
+    ProjectRunEventCommand,
+    ProjectRunEventHandler,
+)
+from google_work_agent.ports.system.sse_event_buffer_port import (
+    RUN_SSE_EVENT_TYPES_V1,
+    SSE_PAYLOAD_TYPE_BY_EVENT_V1,
+    RunSseEventTypeV1,
+    RunSseEventV1,
+    SsePayloadV1,
+)
+
+VALID_PAYLOADS: Mapping[str, dict[str, object]] = {
+    "run_status": {"status": "ANALYZING", "snapshot_version": 2},
+    "phase_changed": {"phase": "TOOL_ROUTING"},
+    "tool_routing": {"route_revision": 3, "input_route_count": 2, "output_mode": "ACTION"},
+    "retrieval_progress": {"coverage": "PARTIAL", "completed_sources": 1, "total_sources": 2},
+    "confirmation_required": {
+        "interrupt_id": "i-1",
+        "question": "계속할까요?",
+        "options": ["예", "아니요"],
+    },
+    "analysis_progress": {"completed_stage": "WORK_ANALYSIS"},
+    "plan_updated": {"plan_id": "p-1", "revision_no": 4},
+    "approval_required": {"action_ids": ["a-1"]},
+    "action_status": {"action_id": "a-1", "status": "APPROVED"},
+    "verification_result": {"action_id": "a-1", "outcome": "VERIFIED"},
+    "reauth_required": {"connector_id": "google"},
+    "recovery_required": {
+        "recovery": {
+            "reason_code": "CHECKPOINT_MISMATCH",
+            "target": {"target_kind": "RUN"},
+            "allowed_resolution_kinds": ["RECHECK", "CANCEL", "FAIL"],
+        }
+    },
+    "completed": {"status": "COMPLETED", "result_kind": "SUCCESS"},
+    "error": {"error_code": "INTERNAL_ERROR", "recoverable": False},
+}
+
+
+class _Buffer:
+    def __init__(self) -> None:
+        self.events: list[RunSseEventV1] = []
+
+    def append(self, event: RunSseEventV1) -> None:
+        self.events.append(event)
+
+    def list_after(self, run_id: str, last_event_id: str | None, limit: int) -> object:
+        raise NotImplementedError
+
+    def clear_run(self, run_id: str) -> None:
+        raise NotImplementedError
+
+
+def _command(event_type: str, payload: dict[str, object]) -> ProjectRunEventCommand:
+    return ProjectRunEventCommand(
+        run_id="run-1",
+        occurred_at_ms=10,
+        event_type=cast(RunSseEventTypeV1, event_type),
+        payload=payload,
+    )
+
+
+@pytest.mark.parametrize(("event_type", "payload"), VALID_PAYLOADS.items())
+def test_canonical_event__projects_once__through_handler(
+    event_type: str, payload: dict[str, object]
+) -> None:
+    buffer = _Buffer()
+    event = ProjectRunEventHandler(buffer)(_command(event_type, payload))
+    assert event.event_type == event_type
+    assert type(event.payload) is SSE_PAYLOAD_TYPE_BY_EVENT_V1[event_type]
+    assert buffer.events == [event]
+
+
+def test_contract__has_exact_event__and_envelope_sets() -> None:
+    assert set(SSE_PAYLOAD_TYPE_BY_EVENT_V1) == RUN_SSE_EVENT_TYPES_V1
+    assert set(VALID_PAYLOADS) == RUN_SSE_EVENT_TYPES_V1
+    assert set(RunSseEventV1.model_fields) == {
+        "schema_version",
+        "event_id",
+        "run_id",
+        "action_id",
+        "occurred_at_ms",
+        "event_type",
+        "payload",
+        "projection_version",
+    }
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload_type"),
+    list(zip(VALID_PAYLOADS, [*list(VALID_PAYLOADS)[1:], next(iter(VALID_PAYLOADS))], strict=True)),
+)
+def test_event_type__rejects_mismatched__payload_model(
+    event_type: str, payload_type: str
+) -> None:
+    buffer = _Buffer()
+    with pytest.raises(ValidationError):
+        ProjectRunEventHandler(buffer)(_command(event_type, VALID_PAYLOADS[payload_type]))
+    assert buffer.events == []
+
+
+@pytest.mark.parametrize("event_type", ["UNKNOWN", "RUN_UPDATED", "EXTERNAL_LLM_SCOPE_PUBLISHED"])
+def test_unknown_non_sse__event_types_fail__before_append(event_type: str) -> None:
+    buffer = _Buffer()
+    with pytest.raises(ValidationError):
+        ProjectRunEventHandler(buffer)(_command(event_type, VALID_PAYLOADS["run_status"]))
+    assert buffer.events == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ("run_status", {"status": "CREATED"}),
+        ("run_status", {"status": "CREATED", "snapshot_version": 1, "prompt": "raw"}),
+        ("phase_changed", {"status": "CREATED", "snapshot_version": 1}),
+    ],
+)
+def test_malformed_raw__authority_fields_fail__closed(
+    value: tuple[str, dict[str, object]],
+) -> None:
+    buffer = _Buffer()
+    with pytest.raises(ValidationError):
+        ProjectRunEventHandler(buffer)(_command(*value))
+    assert buffer.events == []
+
+
+@pytest.mark.parametrize(("field", "value"), [("checkpoint_blob", {}), ("schema_version", 2)])
+def test_envelope__rejects_undeclared__fields(field: str, value: object) -> None:
+    event = {
+        "schema_version": 1,
+        "event_id": "1",
+        "run_id": "run-1",
+        "action_id": None,
+        "occurred_at_ms": 1,
+        "event_type": "run_status",
+        "payload": VALID_PAYLOADS["run_status"],
+        "projection_version": 1,
+    }
+    event[field] = value
+    with pytest.raises(ValidationError):
+        RunSseEventV1.model_validate(event)
+
+
+def test_payload_union__has_no_arbitrary__dict_fallback() -> None:
+    assert dict not in getattr(SsePayloadV1, "__args__", ())

--- a/tests/unit/application/use_cases/trace_event/test_emit_trace_event.py
+++ b/tests/unit/application/use_cases/trace_event/test_emit_trace_event.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.trace_event.emit_trace_event import (
+    EmitTraceEventHandler,
+)
+
+
+def test_emit_trace_event__has_exact__application_owner() -> None:
+    assert (
+        EmitTraceEventHandler.__module__
+        == "google_work_agent.application.use_cases.trace_event.emit_trace_event"
+    )
+    assert EmitTraceEventHandler.__name__ == "EmitTraceEventHandler"

--- a/tests/unit/application/use_cases/verification/test_store_verification.py
+++ b/tests/unit/application/use_cases/verification/test_store_verification.py
@@ -1,0 +1,11 @@
+from google_work_agent.application.use_cases.verification.store_verification import (
+    StoreVerificationHandler,
+)
+
+
+def test_store_verification__has_exact__application_owner() -> None:
+    assert (
+        StoreVerificationHandler.__module__
+        == "google_work_agent.application.use_cases.verification.store_verification"
+    )
+    assert StoreVerificationHandler.__name__ == "StoreVerificationHandler"

--- a/tests/unit/application/use_cases/verification/test_verify_effect.py
+++ b/tests/unit/application/use_cases/verification/test_verify_effect.py
@@ -1,0 +1,9 @@
+from google_work_agent.application.use_cases.verification.verify_effect import VerifyEffectHandler
+
+
+def test_verify_effect__has_exact__application_owner() -> None:
+    assert (
+        VerifyEffectHandler.__module__
+        == "google_work_agent.application.use_cases.verification.verify_effect"
+    )
+    assert VerifyEffectHandler.__name__ == "VerifyEffectHandler"

--- a/tests/unit/launcher/test_acquire_single_instance.py
+++ b/tests/unit/launcher/test_acquire_single_instance.py
@@ -1,0 +1,6 @@
+from launcher.acquire_single_instance import acquire_single_instance
+
+
+def test_acquire_single_instance__has_exact__launcher_owner() -> None:
+    assert acquire_single_instance.__module__ == "launcher.acquire_single_instance"
+    assert acquire_single_instance.__name__ == "acquire_single_instance"

--- a/tests/unit/launcher/test_allocate_dynamic_port.py
+++ b/tests/unit/launcher/test_allocate_dynamic_port.py
@@ -1,0 +1,6 @@
+from launcher.allocate_dynamic_port import allocate_dynamic_port
+
+
+def test_allocate_dynamic_port__has_exact__launcher_owner() -> None:
+    assert allocate_dynamic_port.__module__ == "launcher.allocate_dynamic_port"
+    assert allocate_dynamic_port.__name__ == "allocate_dynamic_port"

--- a/tests/unit/launcher/test_create_service_instance_id.py
+++ b/tests/unit/launcher/test_create_service_instance_id.py
@@ -1,0 +1,6 @@
+from launcher.create_service_instance_id import create_service_instance_id
+
+
+def test_create_service_instance_id__has_exact__launcher_owner() -> None:
+    assert create_service_instance_id.__module__ == "launcher.create_service_instance_id"
+    assert create_service_instance_id.__name__ == "create_service_instance_id"

--- a/tests/unit/launcher/test_entrypoint.py
+++ b/tests/unit/launcher/test_entrypoint.py
@@ -1,0 +1,6 @@
+from launcher.entrypoint import main
+
+
+def test_entrypoint__has_exact__launcher_owner() -> None:
+    assert main.__module__ == "launcher.entrypoint"
+    assert main.__name__ == "main"

--- a/tests/unit/launcher/test_open_product_ui.py
+++ b/tests/unit/launcher/test_open_product_ui.py
@@ -1,0 +1,6 @@
+from launcher.open_product_ui import open_product_ui
+
+
+def test_open_product_ui__has_exact__launcher_owner() -> None:
+    assert open_product_ui.__module__ == "launcher.open_product_ui"
+    assert open_product_ui.__name__ == "open_product_ui"

--- a/tests/unit/launcher/test_prepare_data_directory.py
+++ b/tests/unit/launcher/test_prepare_data_directory.py
@@ -1,0 +1,6 @@
+from launcher.prepare_data_directory import prepare_data_directory
+
+
+def test_prepare_data_directory__has_exact__launcher_owner() -> None:
+    assert prepare_data_directory.__module__ == "launcher.prepare_data_directory"
+    assert prepare_data_directory.__name__ == "prepare_data_directory"

--- a/tests/unit/launcher/test_readiness.py
+++ b/tests/unit/launcher/test_readiness.py
@@ -1,0 +1,6 @@
+from launcher.readiness import wait_for_service_ready
+
+
+def test_readiness__has_exact__launcher_owner() -> None:
+    assert wait_for_service_ready.__module__ == "launcher.readiness"
+    assert wait_for_service_ready.__name__ == "wait_for_service_ready"

--- a/tests/unit/launcher/test_release_build_config.py
+++ b/tests/unit/launcher/test_release_build_config.py
@@ -1,0 +1,6 @@
+from launcher.release_build_config import SignedBuildConfigV1, load_signed_build_config
+
+
+def test_release_build_config__has_exact__launcher_owner() -> None:
+    assert SignedBuildConfigV1.__module__ == "launcher.release_build_config"
+    assert load_signed_build_config.__module__ == "launcher.release_build_config"

--- a/tests/unit/launcher/test_request_existing_instance_ui.py
+++ b/tests/unit/launcher/test_request_existing_instance_ui.py
@@ -1,0 +1,6 @@
+from launcher.request_existing_instance_ui import request_existing_instance_ui
+
+
+def test_request_existing_instance_ui__has_exact__launcher_owner() -> None:
+    assert request_existing_instance_ui.__module__ == "launcher.request_existing_instance_ui"
+    assert request_existing_instance_ui.__name__ == "request_existing_instance_ui"

--- a/tests/unit/launcher/test_serve_instance_control.py
+++ b/tests/unit/launcher/test_serve_instance_control.py
@@ -1,0 +1,6 @@
+from launcher.serve_instance_control import serve_instance_control
+
+
+def test_serve_instance_control__has_exact__launcher_owner() -> None:
+    assert serve_instance_control.__module__ == "launcher.serve_instance_control"
+    assert serve_instance_control.__name__ == "serve_instance_control"

--- a/tests/unit/launcher/test_shutdown_service.py
+++ b/tests/unit/launcher/test_shutdown_service.py
@@ -1,0 +1,6 @@
+from launcher.shutdown_service import shutdown_service
+
+
+def test_shutdown_service__has_exact__launcher_owner() -> None:
+    assert shutdown_service.__module__ == "launcher.shutdown_service"
+    assert shutdown_service.__name__ == "shutdown_service"

--- a/tests/unit/launcher/test_start_service.py
+++ b/tests/unit/launcher/test_start_service.py
@@ -1,0 +1,6 @@
+from launcher.start_service import start_service
+
+
+def test_start_service__has_exact__launcher_owner() -> None:
+    assert start_service.__module__ == "launcher.start_service"
+    assert start_service.__name__ == "start_service"

--- a/tests/unit/launcher/test_verify_installation.py
+++ b/tests/unit/launcher/test_verify_installation.py
@@ -1,0 +1,6 @@
+from launcher.verify_installation import verify_installation
+
+
+def test_verify_installation__has_exact__launcher_owner() -> None:
+    assert verify_installation.__module__ == "launcher.verify_installation"
+    assert verify_installation.__name__ == "verify_installation"


### PR DESCRIPTION
## Summary
- close the canonical R1 SSE contract, R2 integration boundaries, R3 production graph components, and R4 test ownership
- add Playwright Product E2E coverage for the 8 core browser journeys using the React production build and FastAPI same-origin serving
- keep real Application, LangGraph, Domain, SQLite, registry, connector core, and SSE code while faking only external LLM/MCP boundaries
- fix only Product E2E defects: approval snapshot projection, persisted evidence identity collision, and concurrent action-command UI gating

## Verification
- Product Browser E2E: 8 passed
- Existing Python E2E: 51 passed
- Architecture: 372 passed
- Unit: 1566 passed
- Contract: 17 passed
- Integration: 155 passed
- Component: 28 passed
- Frontend: 164 passed
- typecheck, lint, production build, ruff, mypy, compileall: passed
- canonical documentation changes: 0