### PR TITLE
test(e2e): validate failure and restart recovery

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
-    "test:e2e": "npm run build && playwright test --config=playwright.config.ts"
+    "test:e2e": "npm run build && playwright test --config=playwright.config.ts",
+    "test:e2e:failure": "npm run build && playwright test --config=playwright.config.ts --grep ^F_E2E"
   },
   "dependencies": {
     "react": "18.3.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,8 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const port = 18765;
+const controlPort = 18766;
 const baseURL = `http://127.0.0.1:${port}`;
 const runtimeRoot = mkdtempSync(join(tmpdir(), "gwa-product-e2e-"));
+process.env.GWA_BROWSER_E2E_STORAGE_STATE_PATH = join(
+  runtimeRoot,
+  "browser-storage-state.json",
+);
 const python = process.platform === "win32"
   ? ".\\.venv\\Scripts\\python.exe"
   : "./.venv/bin/python";
@@ -19,6 +24,7 @@ export default defineConfig({
   expect: { timeout: 20_000 },
   reporter: [["list"]],
   outputDir: "test-results/product-e2e",
+  globalTeardown: "./tests/product-e2e/global_teardown.ts",
   use: {
     baseURL,
     trace: "retain-on-failure",
@@ -32,15 +38,16 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `${python} -m tests.e2e.browser_product_server`,
+    command: `${python} -m tests.e2e.browser_product_supervisor`,
     cwd: "..",
     env: {
       ...process.env,
       GWA_ARCHITECTURE_FINAL_CUTOVER: "1",
       GWA_BROWSER_E2E_PORT: String(port),
+      GWA_BROWSER_E2E_CONTROL_PORT: String(controlPort),
       GWA_BROWSER_E2E_RUNTIME_ROOT: runtimeRoot,
     },
-    url: `${baseURL}/health/live`,
+    url: `http://127.0.0.1:${controlPort}/health/live`,
     reuseExistingServer: false,
     timeout: 120_000,
     stdout: "pipe",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -80,6 +80,7 @@ function AuthenticatedWorkspace({ initial }: { initial: StartupFlowContext }): J
     handleResolveRecovery,
   } = conversation;
   const restoredOpenRunRef = useRef(false);
+  const reauthConnectionCheckRef = useRef<string | null>(null);
   const reauthResumeAttemptRef = useRef<string | null>(null);
   const operationalCommandIds = useRef(new Map<string, string>());
 
@@ -151,16 +152,32 @@ function AuthenticatedWorkspace({ initial }: { initial: StartupFlowContext }): J
   }, []);
 
   useEffect(() => {
-    if (google.connection_status !== "CONNECTED" || runSnapshot?.run.status !== "REAUTH_REQUIRED") {
+    if (runSnapshot?.run.status !== "REAUTH_REQUIRED") {
+      reauthConnectionCheckRef.current = null;
       reauthResumeAttemptRef.current = null;
       return;
     }
     const identity = `${runSnapshot.run.run_id}:${runSnapshot.run.version}`;
-    if (reauthResumeAttemptRef.current === identity) return;
-    reauthResumeAttemptRef.current = identity;
-    void handleResumeAfterReauth().catch((error: unknown) => {
-      setStatusLine(error instanceof ApiClientError ? error.message : "Google 재인증 후 작업을 재개하지 못했습니다.");
-    });
+    const resumeAfterFreshConnection = (): void => {
+      if (reauthResumeAttemptRef.current === identity) return;
+      reauthResumeAttemptRef.current = identity;
+      void handleResumeAfterReauth().catch((error: unknown) => {
+        setStatusLine(error instanceof ApiClientError ? error.message : "Google 재인증 후 작업을 재개하지 못했습니다.");
+      });
+    };
+    if (reauthConnectionCheckRef.current !== identity) {
+      reauthConnectionCheckRef.current = identity;
+      void getGoogleConnection().then((freshConnection) => {
+        setGoogle(freshConnection);
+        if (freshConnection.connection_status === "CONNECTED") {
+          resumeAfterFreshConnection();
+        }
+      }).catch((error: unknown) => {
+        setStatusLine(error instanceof ApiClientError ? error.message : "Google 재인증 상태를 확인하지 못했습니다.");
+      });
+      return;
+    }
+    if (google.connection_status === "CONNECTED") resumeAfterFreshConnection();
   }, [google.connection_status, handleResumeAfterReauth, runSnapshot]);
 
   useEffect(() => {

--- a/frontend/tests/app/app_integration.test.tsx
+++ b/frontend/tests/app/app_integration.test.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { App } from "../../src/app/App";
+import type { GoogleConnection } from "../../src/features/settings";
 
 type MockResponse = {
   status?: number;
@@ -3171,11 +3172,29 @@ test("renders snapshot context/disclosure and sends a context adjustment command
 });
 
 test("resumes a REAUTH_REQUIRED run after the Google connection is restored", async () => {
-  const requests = installUiContractFetch({ status: "REAUTH_REQUIRED" });
+  const requests = installUiContractFetch({
+    googleConnectionStates: ["CONNECTED", "CONNECTED"],
+    status: "REAUTH_REQUIRED",
+  });
   render(<App />);
   await waitFor(() => expect(requests.some((request) => request.path === "/api/v1/runs/run-1/resume")).toBe(true));
+  expect(
+    requests.filter((request) => request.path === "/api/v1/connections/google/status"),
+  ).toHaveLength(2);
   const request = requests.find((item) => item.path === "/api/v1/runs/run-1/resume");
   expect(JSON.parse(String(request?.init?.body))).toMatchObject({ resume_kind: "REAUTH_COMPLETED" });
+});
+
+test("does not resume a REAUTH_REQUIRED run from a stale connected projection", async () => {
+  const requests = installUiContractFetch({
+    googleConnectionStates: ["CONNECTED", "REAUTH_REQUIRED"],
+    status: "REAUTH_REQUIRED",
+  });
+  render(<App />);
+  await waitFor(() => expect(
+    requests.filter((request) => request.path === "/api/v1/connections/google/status"),
+  ).toHaveLength(2));
+  expect(requests.some((request) => request.path === "/api/v1/runs/run-1/resume")).toBe(false);
 });
 
 function installUiContractFetch(options: {
@@ -3200,6 +3219,7 @@ function installUiContractFetch(options: {
   gmailCount?: number;
   gmailCountError?: boolean;
   gmailCountResponse?: Promise<Response>;
+  googleConnectionStates?: Array<GoogleConnection["connection_status"]>;
   historyMessages?: Array<{ id: string; run_id: string | null; role: string; content: string; created_at_ms: number }>;
   historyRuns?: Array<{ run_id: string; status: string; started_at_ms: number; finished_at_ms: number | null }>;
   run?: boolean;
@@ -3235,13 +3255,24 @@ function installUiContractFetch(options: {
   let firstTaskPageRequests = 0;
   let completedTaskResponseIndex = 0;
   let accountResponseIndex = 0;
+  let googleConnectionStateIndex = 0;
   globalThis.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
     const path = String(input);
     requests.push({ path, init });
     if (path === "/health/live") return jsonFetchResponse(liveResponse());
     if (path === "/health/ready") return jsonFetchResponse(readyResponse());
     if (path === "/api/v1/runtime") return jsonFetchResponse({ summary: runtimeSummary(options.run === false ? [] : ["run-1"], { llm: {} }), api_contract_version: "1" });
-    if (path === "/api/v1/connections/google/status") return jsonFetchResponse(googleConnection());
+    if (path === "/api/v1/connections/google/status") {
+      const states = options.googleConnectionStates;
+      const state = states?.[
+        Math.min(googleConnectionStateIndex++, Math.max((states?.length ?? 1) - 1, 0))
+      ] ?? "CONNECTED";
+      return jsonFetchResponse(googleConnection({
+        account_id: state === "CONNECTED" ? "account-1" : null,
+        connection_status: state,
+        display_email: state === "CONNECTED" ? "user@example.com" : null,
+      }));
+    }
     if (path === "/api/v1/identity/google-account") {
       const account = options.accountResponses && accountResponseIndex < options.accountResponses.length
         ? options.accountResponses[accountResponseIndex++]
@@ -3824,7 +3855,7 @@ function llmConnectionPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function googleConnection() {
+function googleConnection(overrides: Partial<GoogleConnection> = {}): GoogleConnection {
   return {
     schema_version: 1,
     connector_id: "google-workspace",
@@ -3833,6 +3864,7 @@ function googleConnection() {
     connection_status: "CONNECTED",
     granted_scopes: ["gmail.readonly"],
     missing_required_scopes: [],
+    ...overrides,
   };
 }
 

--- a/frontend/tests/product-e2e/core_product_journeys.spec.ts
+++ b/frontend/tests/product-e2e/core_product_journeys.spec.ts
@@ -1,71 +1,23 @@
-import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+import {
+  BrowserProductHarness,
+  type ProductRow,
+  type ProductState,
+  type StartedRun,
+} from "./support/browser_product_harness";
 
-type ProductRow = Record<string, unknown>;
-
-type ProductState = {
-  run: ProductRow;
-  plans: ProductRow[];
-  actions: ProductRow[];
-  action_dependencies: ProductRow[];
-  approvals: ProductRow[];
-  execution_attempts: ProductRow[];
-  verifications: ProductRow[];
-  messages: ProductRow[];
-  workflow_binding: ProductRow;
-  audit_events: ProductRow[];
-  run_count: number;
-  command_count: number;
-  mcp_events: ProductRow[];
-  llm_invocations: ProductRow[];
-};
-
-type StartedRun = {
-  runId: string;
-  requestPayload: Record<string, unknown>;
-};
-
-const baseURL = "http://127.0.0.1:18765";
-const writeTools = new Set([
-  "calendar_create_event",
-  "gmail_create_draft",
-  "gmail_send_message",
-  "tasks_create_task",
-]);
-
-let context: BrowserContext;
+let harness: BrowserProductHarness;
 let page: Page;
 
 test.describe.configure({ mode: "serial" });
 
 test.beforeAll(async ({ browser }, testInfo) => {
-  testInfo.setTimeout(120_000);
-  context = await browser.newContext();
-  page = await context.newPage();
-  await page.goto(
-    "/#bootstrap_secret=browser-product-e2e-bootstrap-secret"
-      + "&service_instance_id=browser-product-e2e-service",
-  );
-
-  await expect(page.getByRole("main").getByRole("heading", { name: "Google Work Agent 시작하기" })).toBeVisible();
-  await expect(page.getByText("설정 상태를 확인하고 있습니다.", { exact: true })).toHaveCount(0);
-  const consent = page.getByLabel("외부 LLM으로 요청 컨텍스트를 전송하는 데 동의합니다.");
-  await consent.check();
-  await expect(consent).toBeChecked();
-  await page.getByRole("button", { name: "동의 저장" }).click();
-  await expect(page.getByText("완료 · 개인정보·외부 LLM 전송 동의")).toBeVisible();
-  await page.getByLabel("API Key").fill("browser-product-e2e-gemini-key");
-  await page.getByLabel("저장 방식").selectOption("SESSION_ONLY");
-  await page.getByRole("button", { name: "저장하고 연결 검사" }).click();
-  await expect(page.getByText("완료 · API LLM 연결")).toBeVisible();
-  const completeSetup = page.getByRole("button", { name: "설정 완료하고 시작" });
-  await expect(completeSetup).toBeEnabled();
-  await completeSetup.click();
-  await expect(page.getByRole("textbox", { name: /선택한 .*업무를 요청하세요/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /새 대화/ })).toBeVisible();
+  harness = await BrowserProductHarness.create(browser, testInfo);
+  page = harness.page;
 });
 
 test.afterAll(async () => {
-  await context.close();
+  await harness.close();
 });
 
 test("E2E_001_ANSWER_ONLY_PASS", async () => {
@@ -268,85 +220,49 @@ test("E2E_008_REFRESH_SSE_RECOVERY_PASS", async () => {
 });
 
 async function beginNewConversation(): Promise<void> {
-  await page.getByRole("button", { name: /새 대화/ }).click();
-  await expect(page.getByRole("region", { name: "Action Plan" })).toHaveCount(0);
+  await harness.beginNewConversation();
 }
 
 async function startNewRun(requestText: string): Promise<StartedRun> {
-  await beginNewConversation();
-  return startRun(requestText);
+  return harness.startNewRun(requestText);
 }
 
 async function startRun(requestText: string): Promise<StartedRun> {
-  const composer = page.getByRole("textbox", { name: /선택한 .*업무를 요청하세요/ });
-  await composer.fill(requestText);
-  const responsePromise = page.waitForResponse((response) => (
-    response.request().method() === "POST"
-      && new URL(response.url()).pathname === "/api/v1/runs"
-  ));
-  await page.getByRole("button", { name: "보내기", exact: true }).click();
-  const response = await responsePromise;
-  expect(response.status()).toBe(202);
-  const payload = await response.json() as { run_id: string };
-  const requestPayload = response.request().postDataJSON() as Record<string, unknown>;
-  return { runId: payload.run_id, requestPayload };
+  return harness.startRun(requestText);
 }
 
 async function productState(runId: string): Promise<ProductState> {
-  const response = await context.request.get(
-    `${baseURL}/__e2e__/state/${encodeURIComponent(runId)}`,
-  );
-  expect(response.ok()).toBe(true);
-  return await response.json() as ProductState;
+  return harness.productState(runId);
 }
 
 async function waitForRunStatus(runId: string, status: string): Promise<ProductState> {
-  let current = await productState(runId);
-  await expect.poll(async () => {
-    current = await productState(runId);
-    return current.run.status;
-  }).toBe(status);
-  return current;
+  return harness.waitForRunStatus(runId, status);
 }
 
 async function actionCard(toolName: string) {
-  const card = page
-    .getByRole("region", { name: "Action Plan" })
-    .getByRole("article")
-    .filter({ hasText: toolName });
-  await expect(card).toBeVisible();
-  return card;
+  return harness.actionCard(toolName);
 }
 
 async function approve(card: Awaited<ReturnType<typeof actionCard>>): Promise<void> {
-  const acknowledgements = card.getByRole("checkbox");
-  for (let index = 0; index < await acknowledgements.count(); index += 1) {
-    await acknowledgements.nth(index).check();
-  }
-  await card.getByRole("button", {
-    name: /^(승인|확인하고 승인|충돌을 알고도 진행|그래도 새로 만들기)$/,
-  }).click();
+  await harness.approve(card);
 }
 
 async function assertCompletedUi(answer?: string): Promise<void> {
-  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toBeVisible();
-  let assistantMessage = page.getByRole("article").filter({ hasText: "에이전트 응답" });
-  if (answer) assistantMessage = assistantMessage.filter({ hasText: answer });
-  await expect(assistantMessage).toBeVisible();
+  await harness.assertCompletedUi(answer);
 }
 
 function toolCount(state: ProductState, toolName: string): number {
-  return state.mcp_events.filter((event) => event.tool_name === toolName).length;
+  return harness.toolCount(state, toolName);
 }
 
 function writeCount(state: ProductState): number {
-  return state.mcp_events.filter((event) => writeTools.has(String(event.tool_name))).length;
+  return harness.writeCount(state);
 }
 
 function auditTypes(state: ProductState): unknown[] {
-  return state.audit_events.map((event) => event.event_type);
+  return harness.auditTypes(state);
 }
 
 function assistantMessages(state: ProductState): ProductRow[] {
-  return state.messages.filter((message) => message.role === "ASSISTANT");
+  return harness.assistantMessages(state);
 }

--- a/frontend/tests/product-e2e/failure_restart_recovery.spec.ts
+++ b/frontend/tests/product-e2e/failure_restart_recovery.spec.ts
@@ -1,0 +1,293 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  BrowserProductHarness,
+  type ProductRow,
+} from "./support/browser_product_harness";
+
+let harness: BrowserProductHarness;
+let page: Page;
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async ({ browser }, testInfo) => {
+  harness = await BrowserProductHarness.create(browser, testInfo);
+  page = harness.page;
+});
+
+test.afterAll(async () => {
+  if (harness) await harness.close();
+});
+
+test("F_E2E_001_UNKNOWN_RESULT_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:UNKNOWN_RESULT_RECOVERY 외부 응답 유실 태스크를 만들어줘",
+  );
+  const waiting = await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(runId, "COMPLETED");
+
+  // Canonical recovery performs the bounded existing-result lookup before it
+  // promotes the Run to RECOVERY_REQUIRED. A single durable match therefore
+  // recovers and verifies in the same workflow continuation.
+  await harness.assertCompletedUi();
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.actions.map((action) => action.status)).toEqual(["VERIFIED"]);
+  expect(completed.execution_attempts.map((attempt) => attempt.status)).toEqual([
+    "SUCCEEDED",
+  ]);
+  expect(harness.writeCount(completed) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(completed) - harness.effectCount(baseline)).toBe(1);
+  expect(
+    harness.toolCount(completed, "search_by_recovery_fingerprint")
+      - harness.toolCount(baseline, "search_by_recovery_fingerprint"),
+  ).toBe(1);
+  expect(harness.auditTypes(completed)).toEqual(
+    expect.arrayContaining(["WRITE_UNKNOWN_RESULT", "WRITE_RECOVERED"]),
+  );
+  expect(waiting.actions[0].id).toBe(completed.actions[0].id);
+});
+
+test("F_E2E_002_RESPONSE_LOSS_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:RESPONSE_LOSS 성공 응답이 유실되는 태스크를 만들어줘",
+  );
+  await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(runId, "COMPLETED");
+
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(harness.writeCount(completed) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(completed) - harness.effectCount(baseline)).toBe(1);
+  expect(
+    harness.toolCount(completed, "search_by_recovery_fingerprint")
+      - harness.toolCount(baseline, "search_by_recovery_fingerprint"),
+  ).toBe(1);
+  expect(completed.execution_attempts.map((attempt) => attempt.status)).toEqual([
+    "SUCCEEDED",
+  ]);
+});
+
+test("F_E2E_003_PROCESS_RESTART_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const started = await harness.startNewRun(
+    "E2E:PROCESS_RESTART durable checkpoint 이후 태스크를 만들어줘",
+  );
+  await harness.waitForPrompt(started.runId, "retrieval.select_evidence");
+  const interrupted = await harness.waitForRunStatus(started.runId, "RETRIEVING");
+  const originalThreadId = interrupted.workflow_binding.langgraph_thread_id;
+  const originalCheckpointGeneration = Number(interrupted.checkpoint.checkpoint_generation);
+  const originalRunCount = interrupted.run_count;
+  const startCommandId = String(started.requestPayload.command_id);
+
+  await harness.restartBackend();
+  await harness.restoreSessionAfterRestart();
+  const restored = await harness.waitForRunStatus(started.runId, "WAITING_APPROVAL");
+
+  expect(restored.run_count).toBe(originalRunCount);
+  expect(restored.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(restored.checkpoint.langgraph_thread_id).toBe(originalThreadId);
+  expect(Number(restored.checkpoint.checkpoint_generation)).toBeGreaterThanOrEqual(
+    originalCheckpointGeneration,
+  );
+  expect(
+    restored.command_receipts.filter((receipt) => receipt.command_id === startCommandId),
+  ).toHaveLength(1);
+  expect(uniqueValues(restored.workflow_handoffs, "handoff_id")).toHaveLength(
+    restored.workflow_handoffs.length,
+  );
+  expect(harness.writeCount(restored) - harness.writeCount(baseline)).toBe(0);
+
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(started.runId, "COMPLETED");
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(harness.writeCount(completed) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(completed) - harness.effectCount(baseline)).toBe(1);
+  expect(completed.verifications.map((verification) => verification.status)).toEqual([
+    "VERIFIED",
+  ]);
+});
+
+test("F_E2E_004_CONFIRMATION_RESTART_PASS", async () => {
+  const started = await harness.startNewRun(
+    "E2E:RESTART_RESUME restart 후 모호한 태스크를 처리해줘",
+  );
+  const interrupted = await harness.waitForRunStatus(started.runId, "WAITING_CONFIRMATION");
+  const originalSnapshot = await harness.runSnapshot(started.runId);
+  const originalInterrupt = requiredRow(originalSnapshot.pending_interrupt);
+  const originalThreadId = interrupted.workflow_binding.langgraph_thread_id;
+  const originalRunCount = interrupted.run_count;
+
+  await harness.restartBackend();
+  await harness.restoreSessionAfterRestart();
+  const restored = await harness.waitForRunStatus(started.runId, "WAITING_CONFIRMATION");
+  const restoredSnapshot = await harness.runSnapshot(started.runId);
+  const restoredInterrupt = requiredRow(restoredSnapshot.pending_interrupt);
+
+  expect(restored.run_count).toBe(originalRunCount);
+  expect(restored.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(restoredInterrupt.interrupt_id).toBe(originalInterrupt.interrupt_id);
+  await expect(confirmationCard()).toBeVisible();
+  await confirmationCard().getByRole("textbox", { name: "확인 응답" }).fill(
+    "E2E Tasks 목록을 사용해줘.",
+  );
+  await confirmationCard().getByRole("button", { name: "응답 보내기" }).click();
+  const waiting = await harness.waitForRunStatus(started.runId, "WAITING_APPROVAL");
+  expect(
+    harness.auditTypes(waiting).filter((eventType) => eventType === "RUN_ANALYSIS_STARTED"),
+  ).toHaveLength(1);
+
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(started.runId, "COMPLETED");
+  expect(completed.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+});
+
+test("F_E2E_005_APPROVAL_RESTART_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:APPROVED_WRITE approval restart 태스크를 만들어줘",
+  );
+  const waiting = await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  const originalPlanId = waiting.plans[0].id;
+  const originalActionId = waiting.actions[0].id;
+  const originalThreadId = waiting.workflow_binding.langgraph_thread_id;
+  expect(harness.writeCount(waiting) - harness.writeCount(baseline)).toBe(0);
+
+  await harness.restartBackend();
+  await harness.restoreSessionAfterRestart();
+  const restored = await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+
+  expect(restored.plans[0].id).toBe(originalPlanId);
+  expect(restored.actions[0].id).toBe(originalActionId);
+  expect(restored.workflow_binding.langgraph_thread_id).toBe(originalThreadId);
+  expect(harness.writeCount(restored) - harness.writeCount(baseline)).toBe(0);
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(runId, "COMPLETED");
+  expect(completed.actions[0].id).toBe(originalActionId);
+  expect(harness.writeCount(completed) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(completed) - harness.effectCount(baseline)).toBe(1);
+  expect(completed.verifications.map((verification) => verification.status)).toEqual([
+    "VERIFIED",
+  ]);
+});
+
+test("F_E2E_006_REAUTH_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:REAUTH 재인증 후 태스크를 만들어줘",
+  );
+  const waiting = await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  const originalPlanId = waiting.plans[0].id;
+  const originalActionId = waiting.actions[0].id;
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const reauth = await harness.waitForRunStatus(runId, "REAUTH_REQUIRED");
+
+  expect(reauth.plans[0].id).toBe(originalPlanId);
+  expect(reauth.actions[0].id).toBe(originalActionId);
+  expect(harness.effectCount(reauth) - harness.effectCount(baseline)).toBe(0);
+  await expect(page.getByText("REAUTH_REQUIRED", { exact: true })).toBeVisible();
+
+  await harness.completeReauthFault();
+  const resumed = await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  expect(resumed.plans[0].id).toBe(originalPlanId);
+  expect(resumed.actions[0].id).toBe(originalActionId);
+  expect(resumed.actions[0].status).toBe("FAILED");
+  await (await harness.actionCard("tasks_create_task"))
+    .getByRole("button", { name: "다시 준비" })
+    .click();
+  await harness.waitForActionCommand(runId, "APPROVE_ACTION");
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const completed = await harness.waitForRunStatus(runId, "COMPLETED");
+
+  expect(completed.run.terminal_result_kind).toBe("SUCCESS");
+  expect(completed.actions[0].id).toBe(originalActionId);
+  expect(harness.effectCount(completed) - harness.effectCount(baseline)).toBe(1);
+  expect(harness.writeCount(completed) - harness.writeCount(baseline)).toBe(2);
+  expect(completed.verifications.map((verification) => verification.status)).toEqual([
+    "VERIFIED",
+  ]);
+});
+
+test("F_E2E_007_VERIFICATION_MISMATCH_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:VERIFICATION_MISMATCH 검증 불일치 일정을 만들어줘",
+  );
+  await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  await harness.approve(await harness.actionCard("calendar_create_event"));
+  const recovery = await harness.waitForRunStatus(runId, "RECOVERY_REQUIRED");
+  const snapshot = await harness.runSnapshot(runId);
+  const recoveryProjection = requiredRow(snapshot.recovery);
+
+  expect(recovery.actions.map((action) => action.status)).toEqual(["MISMATCH"]);
+  expect(recovery.verifications.map((verification) => verification.status)).toEqual([
+    "MISMATCH",
+  ]);
+  expect(recovery.recovery.reason).toBe("VERIFICATION_MISMATCH");
+  expect(harness.writeCount(recovery) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(recovery) - harness.effectCount(baseline)).toBe(1);
+  expect(recoveryProjection.allowed_resolution_kinds).toEqual([
+    "RECHECK",
+    "ACCEPT_PARTIAL",
+    "CREATE_CORRECTIVE_PLAN",
+    "FAIL",
+  ]);
+  await expect(recoveryCard()).toContainText("VERIFICATION_MISMATCH");
+  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toHaveCount(0);
+
+  await recoveryCard().getByRole("button", { name: "현재 결과 수용" }).click();
+  const completed = await harness.waitForRunStatus(runId, "COMPLETED");
+  expect(completed.run.terminal_result_kind).toBe("PARTIAL");
+  await expect(page.getByText("일부 작업은 완료되었고 나머지는 취소되었습니다.")).toBeVisible();
+});
+
+test("F_E2E_008_MCP_FAILURE_PASS", async () => {
+  const baseline = await harness.productState("missing-run");
+  const { runId } = await harness.startNewRun(
+    "E2E:MCP_FAILURE MCP process 장애 태스크를 만들어줘",
+  );
+  await harness.waitForRunStatus(runId, "WAITING_APPROVAL");
+  await harness.approve(await harness.actionCard("tasks_create_task"));
+  const failed = await harness.waitForActionStatus(runId, "FAILED");
+
+  expect(failed.run.status).toBe("WAITING_APPROVAL");
+  expect(failed.actions.map((action) => action.status)).toEqual(["FAILED"]);
+  expect(failed.execution_attempts.map((attempt) => attempt.status)).toEqual(["FAILED"]);
+  expect(failed.recovery).toEqual({});
+  expect(harness.writeCount(failed) - harness.writeCount(baseline)).toBe(1);
+  expect(harness.effectCount(failed) - harness.effectCount(baseline)).toBe(0);
+  expect(
+    harness.toolCount(failed, "search_by_recovery_fingerprint")
+      - harness.toolCount(baseline, "search_by_recovery_fingerprint"),
+  ).toBe(1);
+  expect(
+    harness.mcpProcessStartCount(failed) - harness.mcpProcessStartCount(baseline),
+  ).toBe(1);
+  expect(uniqueValues(failed.workflow_handoffs, "handoff_id")).toHaveLength(
+    failed.workflow_handoffs.length,
+  );
+  expect(harness.auditTypes(failed)).toEqual(
+    expect.arrayContaining(["WRITE_UNKNOWN_RESULT", "WRITE_RECOVERY_RESOLVED_FAILED"]),
+  );
+  await expect(page.getByText("FAILED", { exact: true })).toBeVisible();
+  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toHaveCount(0);
+});
+
+function recoveryCard() {
+  return page.getByRole("article").filter({ hasText: "Recovery" });
+}
+
+function confirmationCard() {
+  return page.getByRole("article").filter({ hasText: "추가 확인" });
+}
+
+function requiredRow(value: ProductRow | null | undefined): ProductRow {
+  expect(value).toBeTruthy();
+  return value as ProductRow;
+}
+
+function uniqueValues(rows: ProductRow[], key: string): unknown[] {
+  return [...new Set(rows.map((row) => row[key]))];
+}

--- a/frontend/tests/product-e2e/global_teardown.ts
+++ b/frontend/tests/product-e2e/global_teardown.ts
@@ -1,0 +1,7 @@
+export default async function globalTeardown(): Promise<void> {
+  try {
+    await fetch("http://127.0.0.1:18766/shutdown", { method: "POST" });
+  } catch {
+    // The supervisor may already be gone after a deliberate process-failure test.
+  }
+}

--- a/frontend/tests/product-e2e/support/browser_product_harness.ts
+++ b/frontend/tests/product-e2e/support/browser_product_harness.ts
@@ -1,0 +1,331 @@
+import {
+  expect,
+  type Browser,
+  type BrowserContext,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import { existsSync } from "node:fs";
+
+export type ProductRow = Record<string, unknown>;
+
+export type ProductState = {
+  run: ProductRow;
+  plans: ProductRow[];
+  actions: ProductRow[];
+  action_dependencies: ProductRow[];
+  approvals: ProductRow[];
+  execution_attempts: ProductRow[];
+  verifications: ProductRow[];
+  messages: ProductRow[];
+  workflow_binding: ProductRow;
+  workflow_handoffs: ProductRow[];
+  checkpoint: ProductRow;
+  recovery: ProductRow;
+  audit_events: ProductRow[];
+  run_count: number;
+  command_count: number;
+  command_receipts: ProductRow[];
+  mcp_events: ProductRow[];
+  mcp_state: ProductRow;
+  mcp_runtime_events: ProductRow[];
+  llm_invocations: ProductRow[];
+};
+
+export type StartedRun = {
+  runId: string;
+  requestPayload: Record<string, unknown>;
+};
+
+export type RunSnapshot = ProductRow & {
+  run: ProductRow;
+  actions: ProductRow[];
+  pending_interrupt?: ProductRow | null;
+  recovery?: ProductRow | null;
+};
+
+export const baseURL = "http://127.0.0.1:18765";
+const controlURL = "http://127.0.0.1:18766";
+const requestHeaders = {
+  Origin: baseURL,
+  "Sec-Fetch-Site": "same-origin",
+  "Sec-Fetch-Mode": "cors",
+  "Sec-Fetch-Dest": "empty",
+};
+const writeTools = new Set([
+  "calendar_create_event",
+  "gmail_create_draft",
+  "gmail_send_message",
+  "tasks_create_task",
+]);
+
+export class BrowserProductHarness {
+  readonly context: BrowserContext;
+  readonly page: Page;
+  private restartCredentialSequence = 0;
+
+  private constructor(context: BrowserContext, page: Page) {
+    this.context = context;
+    this.page = page;
+  }
+
+  static async create(browser: Browser, testInfo: TestInfo): Promise<BrowserProductHarness> {
+    testInfo.setTimeout(120_000);
+    const storageStatePath = process.env.GWA_BROWSER_E2E_STORAGE_STATE_PATH;
+    const hasStorageState = storageStatePath !== undefined && existsSync(storageStatePath);
+    const context = await browser.newContext(
+      hasStorageState ? { storageState: storageStatePath } : undefined,
+    );
+    const page = await context.newPage();
+    const harness = new BrowserProductHarness(context, page);
+    await harness.openAndBootstrap(!hasStorageState);
+    if (storageStatePath !== undefined) {
+      await context.storageState({ path: storageStatePath });
+    }
+    return harness;
+  }
+
+  async close(): Promise<void> {
+    const storageStatePath = process.env.GWA_BROWSER_E2E_STORAGE_STATE_PATH;
+    if (storageStatePath !== undefined) {
+      await this.context.storageState({ path: storageStatePath });
+    }
+    await this.context.close();
+  }
+
+  async openAndBootstrap(useBootstrapSecret = true): Promise<void> {
+    const entryPath = useBootstrapSecret
+      ? "/#bootstrap_secret=browser-product-e2e-bootstrap-secret"
+        + "&service_instance_id=browser-product-e2e-service"
+      : "/";
+    await this.page.goto(entryPath);
+    const onboarding = this.page
+      .getByRole("main")
+      .getByRole("heading", { name: "Google Work Agent 시작하기" });
+    const composer = this.page.getByRole("textbox", {
+      name: /선택한 .*업무를 요청하세요/,
+    });
+    await expect.poll(async () => (
+      await onboarding.count() + await composer.count()
+    )).toBeGreaterThan(0);
+    if (await composer.isVisible()) {
+      await this.expectMainUi();
+      return;
+    }
+    await expect(onboarding).toBeVisible();
+    await expect(
+      this.page.getByText("설정 상태를 확인하고 있습니다.", { exact: true }),
+    ).toHaveCount(0);
+    const consent = this.page.getByLabel(
+      "외부 LLM으로 요청 컨텍스트를 전송하는 데 동의합니다.",
+    );
+    if (await consent.isVisible()) {
+      await consent.check();
+      await this.page.getByRole("button", { name: "동의 저장" }).click();
+    }
+    await expect(this.page.getByText("완료 · 개인정보·외부 LLM 전송 동의")).toBeVisible();
+    const apiKey = this.page.getByLabel("API Key");
+    if (await apiKey.isVisible()) {
+      await apiKey.fill("browser-product-e2e-gemini-key");
+      await this.page.getByLabel("저장 방식").selectOption("SESSION_ONLY");
+      await this.page.getByRole("button", { name: "저장하고 연결 검사" }).click();
+    }
+    await expect(this.page.getByText("완료 · API LLM 연결")).toBeVisible();
+    const completeSetup = this.page.getByRole("button", { name: "설정 완료하고 시작" });
+    await expect(completeSetup).toBeEnabled();
+    await completeSetup.click();
+    await this.expectMainUi();
+  }
+
+  async beginNewConversation(): Promise<void> {
+    await this.page.getByRole("button", { name: /새 대화/ }).click();
+    await expect(this.page.getByRole("region", { name: "Action Plan" })).toHaveCount(0);
+  }
+
+  async startNewRun(requestText: string): Promise<StartedRun> {
+    await this.beginNewConversation();
+    return this.startRun(requestText);
+  }
+
+  async startRun(requestText: string): Promise<StartedRun> {
+    const composer = this.page.getByRole("textbox", {
+      name: /선택한 .*업무를 요청하세요/,
+    });
+    await composer.fill(requestText);
+    const responsePromise = this.page.waitForResponse((response) => (
+      response.request().method() === "POST"
+        && new URL(response.url()).pathname === "/api/v1/runs"
+    ));
+    await this.page.getByRole("button", { name: "보내기", exact: true }).click();
+    const response = await responsePromise;
+    expect(response.status()).toBe(202);
+    const payload = await response.json() as { run_id: string };
+    return {
+      runId: payload.run_id,
+      requestPayload: response.request().postDataJSON() as Record<string, unknown>,
+    };
+  }
+
+  async productState(runId: string): Promise<ProductState> {
+    const response = await this.context.request.get(
+      `${baseURL}/__e2e__/state/${encodeURIComponent(runId)}`,
+    );
+    expect(response.ok()).toBe(true);
+    return await response.json() as ProductState;
+  }
+
+  async runSnapshot(runId: string): Promise<RunSnapshot> {
+    const response = await this.context.request.get(
+      `${baseURL}/api/v1/runs/${encodeURIComponent(runId)}`,
+      { headers: { ...requestHeaders, "X-API-Contract-Version": "1" } },
+    );
+    expect(response.ok()).toBe(true);
+    return await response.json() as RunSnapshot;
+  }
+
+  async waitForRunStatus(runId: string, status: string): Promise<ProductState> {
+    let current = await this.productState(runId);
+    await expect.poll(async () => {
+      current = await this.productState(runId);
+      return current.run.status;
+    }).toBe(status);
+    return current;
+  }
+
+  async waitForActionStatus(runId: string, status: string): Promise<ProductState> {
+    let current = await this.productState(runId);
+    await expect.poll(async () => {
+      current = await this.productState(runId);
+      return current.actions.some((action) => action.status === status);
+    }).toBe(true);
+    return current;
+  }
+
+  async waitForActionCommand(runId: string, command: string): Promise<ProductState> {
+    await expect.poll(async () => {
+      const snapshot = await this.runSnapshot(runId);
+      return snapshot.actions.some((action) => (
+        Array.isArray(action.next_allowed_commands)
+          && action.next_allowed_commands.includes(command)
+      ));
+    }).toBe(true);
+    return this.productState(runId);
+  }
+
+  async waitForPrompt(runId: string, promptId: string): Promise<ProductState> {
+    let current = await this.productState(runId);
+    await expect.poll(async () => {
+      current = await this.productState(runId);
+      return current.llm_invocations.some((item) => item.prompt_id === promptId);
+    }).toBe(true);
+    return current;
+  }
+
+  async actionCard(toolName: string): Promise<Locator> {
+    const card = this.page
+      .getByRole("region", { name: "Action Plan" })
+      .getByRole("article")
+      .filter({ hasText: toolName });
+    await expect(card).toBeVisible();
+    return card;
+  }
+
+  async approve(card: Locator): Promise<void> {
+    const acknowledgements = card.getByRole("checkbox");
+    for (let index = 0; index < await acknowledgements.count(); index += 1) {
+      await acknowledgements.nth(index).check();
+    }
+    await card.getByRole("button", {
+      name: /^(승인|확인하고 승인|충돌을 알고도 진행|그래도 새로 만들기)$/,
+    }).click();
+  }
+
+  async assertCompletedUi(answer?: string): Promise<void> {
+    await expect(this.page.getByText("작업을 완료했습니다.", { exact: true })).toBeVisible();
+    let assistantMessage = this.page.getByRole("article").filter({ hasText: "에이전트 응답" });
+    if (answer) assistantMessage = assistantMessage.filter({ hasText: answer });
+    await expect(assistantMessage).toBeVisible();
+  }
+
+  async restartBackend(): Promise<Record<string, unknown>> {
+    const response = await this.context.request.post(`${controlURL}/restart`, {
+      data: { disable_crash: true },
+    });
+    expect(response.ok()).toBe(true);
+    return await response.json() as Record<string, unknown>;
+  }
+
+  async restoreSessionAfterRestart(): Promise<void> {
+    const bootstrap = await this.context.request.post(`${baseURL}/api/v1/session/bootstrap`, {
+      headers: requestHeaders,
+      data: {
+        schema_version: 1,
+        bootstrap_secret: "browser-product-e2e-bootstrap-secret",
+        frontend_api_contract_version: "1",
+      },
+    });
+    expect(bootstrap.ok()).toBe(true);
+    this.restartCredentialSequence += 1;
+    const credential = await this.context.request.put(
+      `${baseURL}/api/v1/credentials/llm/gemini`,
+      {
+        headers: requestHeaders,
+        data: {
+          schema_version: 1,
+          command_id: `browser-e2e-restart-credential-${this.restartCredentialSequence}`,
+          api_key: "browser-product-e2e-gemini-key",
+          storage_mode: "SESSION_ONLY",
+        },
+      },
+    );
+    expect(credential.ok()).toBe(true);
+    await this.page.reload();
+    await this.expectMainUi();
+  }
+
+  async completeReauthFault(): Promise<void> {
+    const response = await this.context.request.post(
+      `${baseURL}/__e2e__/fault/reauth-complete`,
+    );
+    expect(response.ok()).toBe(true);
+    await this.page.reload();
+    await this.expectMainUi();
+  }
+
+  toolCount(state: ProductState, toolName: string): number {
+    return state.mcp_events.filter((event) => event.tool_name === toolName).length;
+  }
+
+  writeCount(state: ProductState): number {
+    return state.mcp_events.filter((event) => writeTools.has(String(event.tool_name))).length;
+  }
+
+  effectCount(state: ProductState): number {
+    const resources = state.mcp_state.resources;
+    return resources && typeof resources === "object"
+      ? Object.keys(resources).length
+      : 0;
+  }
+
+  mcpProcessStartCount(state: ProductState): number {
+    return state.mcp_runtime_events.filter(
+      (event) => event.event_type === "PROCESS_STARTED",
+    ).length;
+  }
+
+  auditTypes(state: ProductState): unknown[] {
+    return state.audit_events.map((event) => event.event_type);
+  }
+
+  assistantMessages(state: ProductState): ProductRow[] {
+    return state.messages.filter((message) => message.role === "ASSISTANT");
+  }
+
+  private async expectMainUi(): Promise<void> {
+    await expect(this.page.getByRole("textbox", {
+      name: /선택한 .*업무를 요청하세요/,
+    })).toBeVisible();
+    await expect(this.page.getByRole("button", { name: /새 대화/ })).toBeVisible();
+  }
+}

--- a/src/google_work_agent/adapters/system/workflow_outcome_projector.py
+++ b/src/google_work_agent/adapters/system/workflow_outcome_projector.py
@@ -7,6 +7,10 @@ from collections.abc import Callable, Mapping
 from google_work_agent.application.use_cases.execution_attempt.write_execution_contracts import (
     WriteRunResponse,
 )
+from google_work_agent.application.use_cases.recovery.project_recovery_options import (
+    ProjectRecoveryOptionsQueryV1,
+    ProjectRecoveryOptionsResultV1,
+)
 from google_work_agent.application.use_cases.recovery.require_recovery import (
     RequireRecoveryCommand,
     RequireRecoveryHandler,
@@ -16,7 +20,7 @@ from google_work_agent.application.use_cases.sse_event.project_run_event import 
     ProjectRunEventHandler,
 )
 from google_work_agent.domain.canonical import calculate_canonical_json_hash
-from google_work_agent.domain.recovery.model import RECOVERY_RESOLUTION_MATRIX, RecoveryReasonV1
+from google_work_agent.domain.recovery.model import RecoveryReasonV1
 from google_work_agent.domain.run.model import RunStatusV1
 from google_work_agent.ports.system.contracts.workflow_execution import WorkflowOutcome
 from google_work_agent.ports.system.contracts.workflow_handoff import (
@@ -36,12 +40,16 @@ class WorkflowOutcomeProjector:
         now_ms: Callable[[], int],
         id_factory: Callable[[], str],
         recovery_target: Callable[[str], RegisteredResumeTargetRefV2 | None],
+        project_recovery_options: Callable[
+            [ProjectRecoveryOptionsQueryV1], ProjectRecoveryOptionsResultV1
+        ],
     ) -> None:
         self._require_recovery = require_recovery
         self._project_run_event = project_run_event
         self._now_ms = now_ms
         self._id_factory = id_factory
         self._recovery_target = recovery_target
+        self._project_recovery_options = project_recovery_options
 
     def publish_cancel_response(self, response: WriteRunResponse) -> None:
         if response.run_status == RunStatusV1.CANCELLED.value:
@@ -73,7 +81,7 @@ class WorkflowOutcomeProjector:
                 expected_version=expected_version,
                 reason="CHECKPOINT_MISMATCH",
             )
-            self._publish(run_id, "recovery_required", _recovery_payload("CHECKPOINT_MISMATCH"))
+            self._publish(run_id, "recovery_required", self._recovery_payload(run_id))
             return
         if outcome is WorkflowOutcome.FAILED:
             self._require_recovery_result(
@@ -88,7 +96,11 @@ class WorkflowOutcomeProjector:
             WorkflowOutcome.RECOVERY_REQUIRED: "recovery_required",
             WorkflowOutcome.FAILED: "error",
         }[outcome]
-        event_payload = _canonical_payload(event_type, payload, expected_version)
+        event_payload = (
+            self._recovery_payload(run_id)
+            if event_type == "recovery_required"
+            else _canonical_payload(event_type, payload, expected_version)
+        )
         if event_payload is not None:
             self._publish(run_id, event_type, event_payload)
 
@@ -141,6 +153,16 @@ class WorkflowOutcomeProjector:
         )
         if not result.applied:
             raise RuntimeError(result.conflict_detail or "RequireRecovery was not applied")
+
+    def _recovery_payload(self, run_id: str) -> dict[str, object]:
+        projection = self._project_recovery_options(ProjectRecoveryOptionsQueryV1(run_id))
+        return {
+            "recovery": {
+                "reason_code": projection.reason_code,
+                "target": projection.target,
+                "allowed_resolution_kinds": list(projection.allowed_resolution_kinds),
+            }
+        }
 
 
 def accepted_event_type(payload: dict[str, object]) -> RunSseEventTypeV1:
@@ -199,15 +221,3 @@ def _canonical_payload(
         if isinstance(action_ids, list) and all(isinstance(item, str) for item in action_ids):
             return {"action_ids": action_ids}
     return None
-
-
-def _recovery_payload(reason: RecoveryReasonV1) -> dict[str, object]:
-    return {
-        "recovery": {
-            "reason_code": reason,
-            "target": {"target_kind": "RUN"},
-            "allowed_resolution_kinds": [
-                item.value for item in RECOVERY_RESOLUTION_MATRIX[reason]
-            ],
-        }
-    }

--- a/src/google_work_agent/api/composition.py
+++ b/src/google_work_agent/api/composition.py
@@ -2438,6 +2438,7 @@ def build_production_runtime(
         now_ms=clock.now_ms,
         id_factory=id_generator.new_uuid,
         recovery_target=_workflow_recovery_target,
+        project_recovery_options=project_recovery_options,
     )
 
     def _start_request(admission: WorkflowExecutionAdmissionV1) -> WorkflowStartRequest:

--- a/tests/e2e/browser_product_server.py
+++ b/tests/e2e/browser_product_server.py
@@ -30,10 +30,21 @@ _PORT = int(os.environ.get("GWA_BROWSER_E2E_PORT", "18765"))
 _RUNTIME_ROOT = Path(os.environ["GWA_BROWSER_E2E_RUNTIME_ROOT"]).resolve()
 _DATABASE_PATH = _RUNTIME_ROOT / "data" / "google_work_agent.db"
 _MCP_EVENTS_PATH = _RUNTIME_ROOT / "cache" / "langgraph-e2e-mcp-events.jsonl"
-_TRANSPORT = LangGraphE2EGeminiTransport()
+_MCP_STATE_PATH = _RUNTIME_ROOT / "cache" / "langgraph-e2e-mcp-state.json"
+_MCP_RUNTIME_EVENTS_PATH = (
+    _RUNTIME_ROOT / "cache" / "langgraph-e2e-mcp-runtime-events.jsonl"
+)
+_TRANSPORT = LangGraphE2EGeminiTransport(
+    crash_prompt_id=os.environ.get("GWA_BROWSER_E2E_CRASH_PROMPT_ID"),
+    crash_scenario=os.environ.get("GWA_BROWSER_E2E_CRASH_SCENARIO"),
+)
+_KEYRING_STORE = SessionMemorySecretStore()
+_KEYRING_STORE.put("DEVELOPMENT/llm-api-key/gemini", b"browser-product-e2e-gemini-key")
+_CHECKPOINT_PORT: Any | None = None
 
 
 def _build_app() -> FastAPI:
+    global _CHECKPOINT_PORT
     with patch.object(composition, "GeminiHTTPClient", return_value=_TRANSPORT):
         container = build_test_production_container(
             host=_HOST,
@@ -42,18 +53,24 @@ def _build_app() -> FastAPI:
             bootstrap_secret=_BOOTSTRAP_SECRET,
             service_instance_id=_SERVICE_INSTANCE_ID,
             mcp_module_name="tests.fakes.langgraph_e2e_mcp_server",
-            keyring_store=SessionMemorySecretStore(),
+            keyring_store=_KEYRING_STORE,
             graph_profile=GraphProfile.SIX_ROLE_BASELINE,
         )
+    _CHECKPOINT_PORT = container.checkpoint_port
     container = replace(container, client_address_resolver=lambda _request: _HOST)
     application = create_app(container)
-    application.add_api_route(
-        "/__e2e__/state/{run_id}",
-        _product_state,
-        methods=["GET"],
-        include_in_schema=False,
-    )
-    debug_route = application.router.routes.pop()
+    test_routes: list[Any] = []
+    for path, endpoint, methods in (
+        ("/__e2e__/state/{run_id}", _product_state, ["GET"]),
+        ("/__e2e__/fault/reauth-complete", _complete_reauth, ["POST"]),
+    ):
+        application.add_api_route(
+            path,
+            endpoint,
+            methods=methods,
+            include_in_schema=False,
+        )
+        test_routes.append(application.router.routes.pop())
     frontend_index = next(
         (
             index
@@ -65,7 +82,7 @@ def _build_app() -> FastAPI:
         ),
         len(application.router.routes),
     )
-    application.router.routes.insert(frontend_index, debug_route)
+    application.router.routes[frontend_index:frontend_index] = test_routes
     return application
 
 
@@ -173,10 +190,39 @@ def _product_state(run_id: str) -> dict[str, object]:
             """,
             (run_id,),
         )
+        recovery = _one(
+            connection,
+            """
+            SELECT reason, scope, action_id, execution_attempt_id, verification_id, version
+              FROM recovery_contexts
+             WHERE run_id = ?
+            """,
+            (run_id,),
+        )
+        workflow_handoffs = _all(
+            connection,
+            """
+            SELECT handoff_id, execution_kind, status, run_sequence,
+                   checkpoint_id, checkpoint_generation, applied_checkpoint_generation
+              FROM workflow_handoffs
+             WHERE run_id = ?
+             ORDER BY run_sequence
+            """,
+            (run_id,),
+        )
         run_count = cast(int, connection.execute("SELECT COUNT(*) FROM runs").fetchone()[0])
         command_count = cast(
             int,
             connection.execute("SELECT COUNT(*) FROM command_receipts").fetchone()[0],
+        )
+        command_receipts = _all(
+            connection,
+            """
+            SELECT command_id, command_type, aggregate_type, aggregate_id, status
+              FROM command_receipts
+             ORDER BY created_at_ms, command_id
+            """,
+            (),
         )
     return {
         "run": run,
@@ -188,10 +234,16 @@ def _product_state(run_id: str) -> dict[str, object]:
         "verifications": verifications,
         "messages": messages,
         "workflow_binding": workflow_binding,
+        "workflow_handoffs": workflow_handoffs,
+        "checkpoint": _checkpoint_state(run_id),
+        "recovery": recovery,
         "audit_events": audit_events,
         "run_count": run_count,
         "command_count": command_count,
+        "command_receipts": command_receipts,
         "mcp_events": _mcp_events(),
+        "mcp_state": _mcp_state(),
+        "mcp_runtime_events": _json_lines(_MCP_RUNTIME_EVENTS_PATH),
         "llm_invocations": [
             {
                 "kind": item.get("kind"),
@@ -201,6 +253,35 @@ def _product_state(run_id: str) -> dict[str, object]:
             }
             for item in _TRANSPORT.invocations
         ],
+    }
+
+
+def _complete_reauth() -> dict[str, object]:
+    state = _mcp_state()
+    state["reauth_required"] = False
+    _MCP_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = _MCP_STATE_PATH.with_suffix(".reauth.tmp")
+    temporary_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    temporary_path.replace(_MCP_STATE_PATH)
+    return {"reauth_required": False}
+
+
+def _checkpoint_state(run_id: str) -> dict[str, object]:
+    if _CHECKPOINT_PORT is None:
+        return {}
+    binding = _CHECKPOINT_PORT.load_workflow_binding(run_id)
+    if binding is None:
+        return {}
+    checkpoint = _CHECKPOINT_PORT.load_same_run_checkpoint(
+        run_id,
+        binding.langgraph_thread_id,
+    )
+    if checkpoint is None:
+        return {}
+    return {
+        "checkpoint_id": checkpoint.checkpoint_id,
+        "checkpoint_generation": checkpoint.checkpoint_generation,
+        "langgraph_thread_id": checkpoint.langgraph_thread_id,
     }
 
 
@@ -223,11 +304,24 @@ def _all(
 
 
 def _mcp_events() -> list[dict[str, object]]:
-    if not _MCP_EVENTS_PATH.is_file():
+    return _json_lines(_MCP_EVENTS_PATH)
+
+
+def _mcp_state() -> dict[str, object]:
+    if not _MCP_STATE_PATH.is_file():
+        return {}
+    return cast(
+        dict[str, object],
+        json.loads(_MCP_STATE_PATH.read_text(encoding="utf-8")),
+    )
+
+
+def _json_lines(path: Path) -> list[dict[str, object]]:
+    if not path.is_file():
         return []
     return [
         cast(dict[str, object], json.loads(line))
-        for line in _MCP_EVENTS_PATH.read_text(encoding="utf-8").splitlines()
+        for line in path.read_text(encoding="utf-8").splitlines()
         if line
     ]
 

--- a/tests/e2e/browser_product_supervisor.py
+++ b/tests/e2e/browser_product_supervisor.py
@@ -1,0 +1,200 @@
+"""Test-only child-process supervisor for Browser restart E2E."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+from urllib.error import URLError
+from urllib.request import urlopen
+
+_HOST = "127.0.0.1"
+_CONTROL_PORT = int(os.environ.get("GWA_BROWSER_E2E_CONTROL_PORT", "18766"))
+_BACKEND_PORT = int(os.environ.get("GWA_BROWSER_E2E_PORT", "18765"))
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class BackendSupervisor:
+    def __init__(self) -> None:
+        self._process: subprocess.Popen[bytes] | None = None
+        self._lock = threading.Lock()
+        self._generation = 0
+        self._crash_enabled = True
+
+    def start(self) -> None:
+        with self._lock:
+            self._start_locked()
+
+    def restart(self, *, disable_crash: bool) -> dict[str, object]:
+        with self._lock:
+            self._stop_locked()
+            if disable_crash:
+                self._crash_enabled = False
+            self._start_locked()
+            process = self._required_process()
+            return {"generation": self._generation, "pid": process.pid}
+
+    def stop(self) -> None:
+        with self._lock:
+            self._stop_locked()
+
+    def state(self) -> dict[str, object]:
+        with self._lock:
+            process = self._process
+            return {
+                "generation": self._generation,
+                "pid": None if process is None else process.pid,
+                "running": process is not None and process.poll() is None,
+                "crash_enabled": self._crash_enabled,
+            }
+
+    def is_ready(self) -> bool:
+        process = self._process
+        return (
+            process is not None
+            and process.poll() is None
+            and _backend_is_live()
+        )
+
+    def _start_locked(self) -> None:
+        child_environment = os.environ.copy()
+        if self._crash_enabled:
+            child_environment.update(
+                {
+                    "GWA_BROWSER_E2E_CRASH_PROMPT_ID": "retrieval.select_evidence",
+                    "GWA_BROWSER_E2E_CRASH_SCENARIO": "PROCESS_RESTART",
+                }
+            )
+        else:
+            child_environment.pop("GWA_BROWSER_E2E_CRASH_PROMPT_ID", None)
+            child_environment.pop("GWA_BROWSER_E2E_CRASH_SCENARIO", None)
+        creationflags = (
+            cast(int, getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0))
+            if sys.platform == "win32"
+            else 0
+        )
+        self._process = subprocess.Popen(
+            [sys.executable, "-m", "tests.e2e.browser_product_server"],
+            cwd=_REPOSITORY_ROOT,
+            env=child_environment,
+            creationflags=creationflags,
+            start_new_session=sys.platform != "win32",
+        )
+        self._generation += 1
+        self._wait_until_ready()
+
+    def _wait_until_ready(self) -> None:
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            process = self._required_process()
+            if process.poll() is not None:
+                raise RuntimeError(f"Browser Product backend exited with {process.returncode}")
+            if _backend_is_live():
+                return
+            time.sleep(0.05)
+        raise TimeoutError("Browser Product backend did not become ready")
+
+    def _stop_locked(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None or process.poll() is not None:
+            return
+        if sys.platform == "win32":
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            os.killpg(process.pid, signal.SIGKILL)
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+    def _required_process(self) -> subprocess.Popen[bytes]:
+        if self._process is None:
+            raise RuntimeError("Browser Product backend is not running")
+        return self._process
+
+
+class SupervisorHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health/live":
+            self._json_response(
+                200 if _SUPERVISOR.is_ready() else 503,
+                _SUPERVISOR.state(),
+            )
+            return
+        if self.path == "/state":
+            self._json_response(200, _SUPERVISOR.state())
+            return
+        self._json_response(404, {"error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/restart":
+            payload = self._request_json()
+            result = _SUPERVISOR.restart(
+                disable_crash=payload.get("disable_crash") is True,
+            )
+            self._json_response(200, result)
+            return
+        if self.path == "/shutdown":
+            self._json_response(202, {"status": "shutting_down"})
+            threading.Thread(target=_HTTP_SERVER.shutdown, daemon=True).start()
+            return
+        self._json_response(404, {"error": "not_found"})
+
+    def log_message(self, _format: str, *args: Any) -> None:
+        del args
+
+    def _request_json(self) -> dict[str, object]:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        if content_length == 0:
+            return {}
+        payload = json.loads(self.rfile.read(content_length))
+        if not isinstance(payload, dict):
+            raise ValueError("supervisor request body must be an object")
+        return cast(dict[str, object], payload)
+
+    def _json_response(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload, sort_keys=True).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _backend_is_live() -> bool:
+    try:
+        with urlopen(f"http://{_HOST}:{_BACKEND_PORT}/health/live", timeout=0.5) as response:
+            return cast(int, response.status) == 200
+    except (OSError, URLError):
+        return False
+
+
+_SUPERVISOR = BackendSupervisor()
+_HTTP_SERVER = ThreadingHTTPServer((_HOST, _CONTROL_PORT), SupervisorHandler)
+
+
+def main() -> None:
+    _SUPERVISOR.start()
+    try:
+        _HTTP_SERVER.serve_forever()
+    finally:
+        _SUPERVISOR.stop()
+        _HTTP_SERVER.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fakes/langgraph_e2e_mcp_server.py
+++ b/tests/fakes/langgraph_e2e_mcp_server.py
@@ -35,6 +35,7 @@ _claim_state = SimpleNamespace(
 
 
 def main() -> None:
+    _append_runtime_event({"event_type": "PROCESS_STARTED", "pid": os.getpid()})
     for line in sys.stdin:
         request = cast(dict[str, object], json.loads(line))
         request_id = str(request.get("id", ""))
@@ -144,9 +145,11 @@ def _control_payload(method: str) -> dict[str, object]:
             ]
         }
     if method == "google.connection.get":
+        state = _load_state()
+        reauth_required = bool(state.get("reauth_required"))
         return {
-            "connected": True,
-            "credential_state": "CONNECTED",
+            "connected": not reauth_required,
+            "credential_state": "REAUTH_REQUIRED" if reauth_required else "CONNECTED",
             "account_id": "e2e-google-account",
             "account_email": "e2e@example.com",
             "display_name": "E2E User",
@@ -161,7 +164,7 @@ def _control_payload(method: str) -> dict[str, object]:
                 "calendar.events.freebusy",
             ],
             "missing_scopes": [],
-            "reauth_required": False,
+            "reauth_required": reauth_required,
             "oauth_environment": "DEVELOPMENT",
             "last_checked_at_ms": 1,
         }
@@ -179,12 +182,20 @@ def _tool_payload(tool_name: str, arguments: dict[str, object]) -> dict[str, obj
     counts = cast(dict[str, int], state.setdefault("counts", {}))
     counts[tool_name] = int(counts.get(tool_name, 0)) + 1
     failure_mode = _failure_mode(arguments)
-    if failure_mode == "FAILED_RETRY" and counts[tool_name] == 1:
+    fault_counts = cast(dict[str, int], state.setdefault("fault_counts", {}))
+    fault_key = f"{failure_mode}:{tool_name}"
+    fault_counts[fault_key] = int(fault_counts.get(fault_key, 0)) + 1
+    fault_count = fault_counts[fault_key]
+    if failure_mode == "FAILED_RETRY" and fault_count == 1:
         _save_state(state)
         raise _ExternalFailure("TOOL_REJECTED", "NOT_SENT")
-    if failure_mode == "REAUTH" and counts[tool_name] == 1:
+    if failure_mode == "REAUTH" and fault_count == 1:
+        state["reauth_required"] = True
         _save_state(state)
         raise _ExternalFailure("AUTH_REQUIRED", "NOT_SENT")
+    if failure_mode == "MCP_FAILURE" and fault_count == 1:
+        _save_state(state)
+        os._exit(70)
 
     if tool_name == "search_by_recovery_fingerprint":
         fingerprint = str(arguments["recovery_fingerprint"])
@@ -230,7 +241,11 @@ def _tool_payload(tool_name: str, arguments: dict[str, object]) -> dict[str, obj
         resources = cast(dict[str, dict[str, object]], state.setdefault("resources", {}))
         resources[_resource_key(item)] = item
         _save_state(state)
-        if failure_mode == "UNKNOWN_RESULT":
+        if failure_mode in {
+            "UNKNOWN_RESULT",
+            "UNKNOWN_RESULT_RECOVERY",
+            "RESPONSE_LOSS",
+        }:
             raise _ExternalFailure("TIMEOUT", "SENT_RESPONSE_LOST")
         return {"item": item}
     if tool_name in {
@@ -374,7 +389,16 @@ def _failure_mode(arguments: dict[str, object]) -> str | None:
     payload = arguments.get("payload")
     title = payload.get("title") if isinstance(payload, dict) else None
     normalized = title.upper() if isinstance(title, str) else ""
-    for value in ("FAILED_RETRY", "UNKNOWN_RESULT", "VERIFICATION_MISMATCH", "RECOVERY", "REAUTH"):
+    for value in (
+        "UNKNOWN_RESULT_RECOVERY",
+        "VERIFICATION_MISMATCH",
+        "FAILED_RETRY",
+        "UNKNOWN_RESULT",
+        "RESPONSE_LOSS",
+        "MCP_FAILURE",
+        "RECOVERY",
+        "REAUTH",
+    ):
         if value in normalized:
             return value
     return None
@@ -401,11 +425,19 @@ def _load_state() -> dict[str, object]:
 
 def _save_state(state: dict[str, object]) -> None:
     path = _state_root() / "langgraph-e2e-mcp-state.json"
-    path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    temporary_path = path.with_suffix(f".{os.getpid()}.tmp")
+    temporary_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    temporary_path.replace(path)
 
 
 def _append_event(event: dict[str, object]) -> None:
     path = _state_root() / "langgraph-e2e-mcp-events.jsonl"
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _append_runtime_event(event: dict[str, object]) -> None:
+    path = _state_root() / "langgraph-e2e-mcp-runtime-events.jsonl"
     with path.open("a", encoding="utf-8") as stream:
         stream.write(json.dumps(event, sort_keys=True) + "\n")
 

--- a/tests/support/fakes/langgraph_e2e.py
+++ b/tests/support/fakes/langgraph_e2e.py
@@ -22,6 +22,7 @@ class LangGraphE2EGeminiTransport:
 
     invocations: list[dict[str, object]] = field(default_factory=list)
     crash_prompt_id: str | None = None
+    crash_scenario: str | None = None
     _scenario_prompt_counts: dict[tuple[str, str], int] = field(default_factory=dict)
 
     def probe(self, *, api_key: str, timeout_seconds: int) -> ProbeResult:
@@ -62,7 +63,9 @@ class LangGraphE2EGeminiTransport:
                 "api_key_length": len(api_key),
             }
         )
-        if prompt_id == self.crash_prompt_id:
+        if prompt_id == self.crash_prompt_id and (
+            self.crash_scenario is None or scenario == self.crash_scenario
+        ):
             # Simulate abrupt process loss at an external boundary. BaseException
             # intentionally bypasses Product failure/recovery translation, just
             # as an actual process termination would.
@@ -253,10 +256,14 @@ def _scenario(value: object) -> str:
     serialized = json.dumps(value, sort_keys=True, default=str).upper()
     for scenario in (
         "RETRIEVAL_CACHE_LOSS",
+        "UNKNOWN_RESULT_RECOVERY",
         "VERIFICATION_MISMATCH",
         "CONTEXT_ADJUSTMENT",
         "PARTIAL_APPROVAL",
         "CALENDAR_WRITE",
+        "PROCESS_RESTART",
+        "RESPONSE_LOSS",
+        "MCP_FAILURE",
         "REVIEW_BACK_EDGE",
         "RESTART_RESUME",
         "UNKNOWN_RESULT",

--- a/tests/unit/adapters/system/test_workflow_outcome_projector.py
+++ b/tests/unit/adapters/system/test_workflow_outcome_projector.py
@@ -1,6 +1,9 @@
 from google_work_agent.adapters.system.workflow_outcome_projector import (
     WorkflowOutcomeProjector,
 )
+from google_work_agent.application.use_cases.recovery.project_recovery_options import (
+    ProjectRecoveryOptionsResultV1,
+)
 from google_work_agent.application.use_cases.sse_event.project_run_event import (
     ProjectRunEventCommand,
 )
@@ -16,6 +19,11 @@ def test_waiting_approval_without_action_projection__publishes_run_status__for_s
         now_ms=lambda: 10,
         id_factory=lambda: "event-1",
         recovery_target=lambda _run_id: None,
+        project_recovery_options=lambda _query: ProjectRecoveryOptionsResultV1(
+            "VERIFICATION_MISMATCH",
+            {"target_kind": "ACTION", "action_id": "action-1"},
+            ("RECHECK", "ACCEPT_PARTIAL", "FAIL"),
+        ),
     )
 
     projector.handle_result(
@@ -39,4 +47,42 @@ def test_waiting_approval_without_action_projection__publishes_run_status__for_s
     assert event.payload == {
         "status": "WAITING_APPROVAL",
         "snapshot_version": 4,
+    }
+
+
+def test_recovery_outcome__publishes_domain_backed__canonical_recovery_event() -> None:
+    published: list[ProjectRunEventCommand] = []
+    projector = WorkflowOutcomeProjector(
+        require_recovery=lambda _command: None,  # type: ignore[arg-type]
+        project_run_event=published.append,  # type: ignore[arg-type]
+        now_ms=lambda: 10,
+        id_factory=lambda: "event-1",
+        recovery_target=lambda _run_id: None,
+        project_recovery_options=lambda _query: ProjectRecoveryOptionsResultV1(
+            "VERIFICATION_MISMATCH",
+            {"target_kind": "ACTION", "action_id": "action-1"},
+            ("RECHECK", "ACCEPT_PARTIAL", "CREATE_CORRECTIVE_PLAN", "FAIL"),
+        ),
+    )
+
+    projector.handle_result(
+        "run-1",
+        WorkflowOutcome.RECOVERY_REQUIRED,
+        {"run_status": "RECOVERY_REQUIRED"},
+        5,
+    )
+
+    assert len(published) == 1
+    assert published[0].event_type == "recovery_required"
+    assert published[0].payload == {
+        "recovery": {
+            "reason_code": "VERIFICATION_MISMATCH",
+            "target": {"target_kind": "ACTION", "action_id": "action-1"},
+            "allowed_resolution_kinds": [
+                "RECHECK",
+                "ACCEPT_PARTIAL",
+                "CREATE_CORRECTIVE_PLAN",
+                "FAIL",
+            ],
+        }
     }


### PR DESCRIPTION
## Summary
- validate eight canonical UNKNOWN_RESULT, response-loss, restart, confirmation, approval, reauth, verification-mismatch, and MCP-failure journeys through the production Browser E2E composition
- require a fresh Google connection read before resuming a REAUTH_REQUIRED run
- project recovery_required SSE payloads through the existing Application recovery authority
- reuse the Product E2E harness with deterministic fake LLM/MCP boundaries and durable SQLite/checkpoints

## Validation
- Browser Product + Failure E2E: 16 passed
- Architecture: 372 passed
- Unit: 1567 passed
- Contract: 17 passed
- Integration: 155 passed
- Component: 28 passed
- Python E2E: 51 passed
- Frontend Vitest: 165 passed
- typecheck, lint, production build, Ruff, mypy, compileall, diff-check: passed
- canonical docs changed: 0
- live Google / external LLM calls: 0