### PR TITLE
fix(connectors): normalize calendar verification instants

### DIFF
--- a/src/google_work_agent/application/use_cases/verification/verify_effect.py
+++ b/src/google_work_agent/application/use_cases/verification/verify_effect.py
@@ -194,9 +194,10 @@ class VerifyEffectHandler:
         raw_actual = result.output.get("item", result.output)
         if not isinstance(raw_actual, dict):
             raise TypeError("verification read result must contain an object")
+        normalizer_tool_name = _normalizer_tool_name(query.target_resource_ref)
         actual = _business_actual(
             cast(dict[str, object], raw_actual),
-            normalizer_tool_name=_normalizer_tool_name(query.target_resource_ref),
+            normalizer_tool_name=normalizer_tool_name,
         )
         if strategy == "GET_ABSENT":
             return VerificationResultV1(
@@ -207,7 +208,10 @@ class VerifyEffectHandler:
                 [result.request_id],
                 ["TARGET_STILL_PRESENT"],
             )
-        expected = _business_expected(query.expected_effect)
+        expected = _business_expected(
+            query.expected_effect,
+            normalizer_tool_name=normalizer_tool_name,
+        )
         diffs = calculate_verification_subset_diff(expected, actual)
         return VerificationResultV1(
             "VERIFIED" if not diffs else "MISMATCH",
@@ -292,10 +296,17 @@ class VerifyEffectHandler:
         raise ValueError(f"unsupported verification resource type: {target.resource_type}")
 
 
-def _business_expected(expected: dict[str, object]) -> dict[str, object]:
+def _business_expected(
+    expected: dict[str, object],
+    *,
+    normalizer_tool_name: str | None = None,
+) -> dict[str, object]:
     payload = expected.get("payload")
     business = cast(dict[str, object], payload) if isinstance(payload, dict) else expected
-    return {key: value for key, value in business.items() if key != "recovery_fingerprint"}
+    filtered = {key: value for key, value in business.items() if key != "recovery_fingerprint"}
+    if normalizer_tool_name is None:
+        return filtered
+    return _business_actual(filtered, normalizer_tool_name=normalizer_tool_name)
 
 
 def _business_actual(actual: dict[str, object], *, normalizer_tool_name: str) -> dict[str, object]:

--- a/src/google_work_agent/application/use_cases/verification/write_verification_projection.py
+++ b/src/google_work_agent/application/use_cases/verification/write_verification_projection.py
@@ -9,6 +9,7 @@ versions, etags and timestamps are deliberately absent.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from typing import cast
 
 _RECOVERY_MARKER_PREFIX = "\u200bgwa-recovery-fingerprint:"
@@ -146,6 +147,10 @@ def normalize_actual_verification_projection(
         if isinstance(notes, str):
             payload["notes"] = _strip_recovery_marker(notes)
     if tool_name in {"calendar_create_event", "calendar_update_event"}:
+        for field_name in ("start", "end"):
+            value = payload.get(field_name)
+            if isinstance(value, str):
+                payload[field_name] = _canonical_calendar_instant(value)
         description = payload.get("description")
         if isinstance(description, str):
             payload["description"] = _strip_recovery_marker(description)
@@ -153,6 +158,22 @@ def normalize_actual_verification_projection(
         if isinstance(attendees, list):
             payload["attendees"] = sorted(str(item) for item in attendees)
     return normalized
+
+
+def _canonical_calendar_instant(value: str) -> str:
+    candidate = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return value
+    if parsed.tzinfo is None:
+        return value
+    return (
+        parsed.astimezone(UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _strip_recovery_marker(value: str) -> str:

--- a/tests/unit/application/test_write_verification_projection.py
+++ b/tests/unit/application/test_write_verification_projection.py
@@ -1,10 +1,52 @@
 from __future__ import annotations
 
+from google_work_agent.application.tool_registry.load_signed_tool_registry import (
+    load_signed_tool_registry,
+)
+from google_work_agent.application.use_cases.verification.verify_effect import (
+    SelectedResourceRefV1,
+    VerifyEffectHandler,
+    VerifyEffectQueryV1,
+)
 from google_work_agent.application.use_cases.verification.write_verification_projection import (
     build_expected_verification_projection,
     calculate_verification_subset_diff,
     normalize_actual_verification_projection,
 )
+from google_work_agent.ports.connector.connector_read_port import (
+    ConnectorReadResultV1,
+    JsonValue,
+)
+from google_work_agent.ports.connector.contracts.validated_connector_tool_binding import (
+    ValidatedConnectorToolBindingV1,
+)
+
+
+class _CalendarRead:
+    def execute_read(
+        self,
+        binding: ValidatedConnectorToolBindingV1,
+        arguments: dict[str, JsonValue],
+    ) -> ConnectorReadResultV1:
+        assert binding.tool_id == "calendar_get_event"
+        assert arguments == {"calendar_id": "calendar-1", "event_id": "event-1"}
+        return ConnectorReadResultV1(
+            1,
+            "calendar_get_event",
+            "verification-read-1",
+            {
+                "item": {
+                    "resource_type": "calendar_event",
+                    "resource_id": "event-1",
+                    "parent_id": "calendar-1",
+                    "title": "Focus",
+                    "start": "2026-08-20T00:00:00.900Z",
+                    "end": "2026-08-20T01:00:00Z",
+                }
+            },
+            None,
+            None,
+        )
 
 
 def test_task_create_expected__maps_scheduled_date__to_provider_due() -> None:
@@ -97,6 +139,38 @@ def test_calendar_expected_omits__fields_current_verification__snapshot_cannot_o
             "end": "2026-08-20T10:00:00+09:00",
         }
     }
+
+
+def test_calendar_verification__with_equal_timezone_instants__is_verified() -> None:
+    result = VerifyEffectHandler(
+        connector_read=_CalendarRead(),
+        tool_registry=load_signed_tool_registry(),
+    )(
+        VerifyEffectQueryV1(
+            "run-1",
+            "action-1",
+            "attempt-1",
+            "CREATE",
+            {
+                "title": "Focus",
+                "start": "2026-08-20T09:00:00+09:00",
+                "end": "2026-08-20T10:00:00+09:00",
+            },
+            SelectedResourceRefV1(
+                1,
+                "resource-ref-1",
+                "google_workspace",
+                "calendar_event",
+                "event-1",
+                "calendar-1",
+            ),
+        )
+    )
+
+    assert result.status == "VERIFIED"
+    assert result.expected_normalized["start"] == "2026-08-20T00:00:00Z"
+    assert result.actual_normalized is not None
+    assert result.actual_normalized["start"] == "2026-08-20T00:00:00Z"
 
 
 def test_delete_expected__is_absence__only() -> None:


### PR DESCRIPTION
## 변경
- Calendar verification에서 timezone-equivalent ISO instant를 UTC 초 단위로 정규화
- expected/actual에 동일한 canonical normalizer 적용
- 실제 Live Google 응답 회귀 테스트 추가

## 검증
- Live Account A/B Gmail read PASS
- Live Task/Calendar create + verification PASS
- Browser Product/Failure E2E 16 PASS
- Python 2275 PASS
- Ruff/mypy/compileall/frontend test/typecheck/lint/build PASS