### PR TITLE
feat(ui): refine conversational run experience

### DIFF
--- a/frontend/src/features/approval/action_plan_card.tsx
+++ b/frontend/src/features/approval/action_plan_card.tsx
@@ -14,10 +14,10 @@ export function ActionPlanCard({ snapshot, busy, retryActionIds, formatTime, onA
   onRetry: (action: RunAction) => void;
   onAttachDescriptors: (action: RunAction, descriptors: StagedAttachmentDescriptor[]) => Promise<void> | void;
 }): JSX.Element | null {
-  if (!snapshot.current_plan) return null;
+  if (!snapshot.current_plan || snapshot.actions.length === 0) return null;
   return (
-    <section aria-label="Action Plan">
-      <article className="info-card"><strong>Action Plan</strong><div className="muted">{snapshot.current_plan.summary_text ?? "요약이 없습니다."}</div></article>
+    <section className="action-plan-conversation" aria-label="Action Plan">
+      {snapshot.current_plan.summary_text ? <p className="agent-status-line">계획 에이전트 · {snapshot.current_plan.summary_text}</p> : null}
       {snapshot.actions.map((action) => (
         <ActionDecisionCard key={action.action_id} action={action} approval={snapshot.approvals.find((item) => item.action_id === action.action_id)} busy={busy} canRetry={retryActionIds.has(action.action_id)} formatTime={formatTime} onApprove={onApprove} onModify={onModify} onReject={onReject} onRetry={onRetry} onAttachDescriptors={onAttachDescriptors} />
       ))}
@@ -39,9 +39,9 @@ function ActionDecisionCard({ action, approval, busy, canRetry, formatTime, onAp
   const conflict = calendarConflictDecision(action.risk);
   const feasibility = feasibilityDecision(action.risk);
   return (
-    <article className="info-card">
-      <div className="inline-row"><strong>{action.tool_name}</strong></div>
-      <div className="muted">{action.effect_type} / {action.verification_policy}</div>
+    <article className="approval-conversation" aria-label={`${actionLabel(action.tool_name)} 승인 요청`}>
+      <span className="sr-only">{action.tool_name}</span>
+      <p className="approval-question">{actionLabel(action.tool_name)} 작업을 진행할까요?</p>
       {duplicate === "SIMILAR_CANDIDATE" ? <p className="status-warn">비슷한 기존 작업이 있습니다.</p> : null}
       {duplicate === "CLEAR_DUPLICATE" ? <p className="status-warn">동일한 작업이 이미 있습니다.</p> : null}
       {conflict === "WARNING" ? <p className="status-warn">겹칠 가능성이 있거나 업무 시간 밖의 일정입니다.</p> : null}
@@ -49,19 +49,19 @@ function ActionDecisionCard({ action, approval, busy, canRetry, formatTime, onAp
       {feasibility === "RISK" ? <p className="status-warn">현재 일정 기준으로 가능한 시간이 제한적입니다.</p> : null}
       {feasibility === "INFEASIBLE" ? <p className="status-warn">현재 업무 시간과 일정 기준으로 마감 전에 필요한 연속 시간을 확보할 수 없습니다.</p> : null}
       {hasOtherRisk(action.risk) ? <p className="status-warn">서버 검증에서 확인된 위험 정보가 있습니다. 승인 전에 확인해 주세요.</p> : null}
-      <details><summary>승인 상세</summary><dl className="metadata-list"><div><dt>Action</dt><dd>{action.tool_name}</dd></div><div><dt>검증</dt><dd>{action.verification_policy}</dd></div></dl></details>
-      {approval ? <div className="muted">승인 상태 {approval.status} / 만료 {formatTime(approval.expires_at_ms)}</div> : null}
+      <details><summary>무엇을 실행하나요?</summary><dl className="metadata-list"><div><dt>작업</dt><dd>{actionLabel(action.tool_name)}</dd></div><div><dt>실행 방식</dt><dd>{effectLabel(action.effect_type)}</dd></div><div><dt>결과 확인</dt><dd>{verificationLabel(action.verification_policy)}</dd></div></dl></details>
+      {approval ? <div className="muted">{approvalStatusLabel(approval.status)} · {formatTime(approval.expires_at_ms)}까지 유효합니다.</div> : null}
       {requiredAcknowledgements.map((item) => (
         <label key={item}><input type="checkbox" checked={acknowledgements.has(item)} onChange={(event) => setAcknowledgements((current) => { const next = new Set(current); if (event.target.checked) next.add(item); else next.delete(item); return next; })} /> {item === "TASK_DUPLICATE" ? "중복 가능성을 확인했습니다." : "일정 충돌 가능성을 확인했습니다."}</label>
       ))}
       {action.next_allowed_commands.includes("MODIFY_ACTION") && editableFields.some((field) => field !== "attachments") ? (
-        <fieldset><legend>수정</legend>{editableFields.filter((field) => field !== "attachments").map((field) => <label key={field}>{field}<input value={editValues[field] ?? ""} onChange={(event) => setEditValues((current) => ({ ...current, [field]: event.target.value }))} /></label>)}<button className="button-secondary" type="button" disabled={busy !== null || Object.keys(patch).length === 0} onClick={() => onModify(action, patch)}>수정</button></fieldset>
+        <fieldset><legend>바꾸고 싶은 내용</legend>{editableFields.filter((field) => field !== "attachments").map((field) => <label key={field}>{field}<input value={editValues[field] ?? ""} onChange={(event) => setEditValues((current) => ({ ...current, [field]: event.target.value }))} /></label>)}<button className="button-secondary" type="button" disabled={busy !== null || Object.keys(patch).length === 0} onClick={() => onModify(action, patch)}>이 내용으로 바꿀게요</button></fieldset>
       ) : null}
       {action.attachment_allowed && action.next_allowed_commands.includes("MODIFY_ACTION") ? <AttachmentPicker disabled={busy !== null} onStaged={(descriptors) => onAttachDescriptors(action, descriptors)} /> : null}
       <div className="button-row">
         {action.next_allowed_commands.includes("APPROVE_ACTION") ? <button className="button-primary" type="button" disabled={busy !== null || missingAcknowledgement} onClick={() => onApprove(action, acknowledgements)}>{approvalLabel(duplicate, conflict)}</button> : null}
-        {action.next_allowed_commands.includes("REJECT_ACTION") ? <button className="button-danger" type="button" disabled={busy !== null} onClick={() => onReject(action)}>거절</button> : null}
-        {canRetry ? <button className="button-secondary" type="button" disabled={busy !== null} onClick={() => onRetry(action)}>다시 준비</button> : null}
+        {action.next_allowed_commands.includes("REJECT_ACTION") ? <button className="button-secondary" type="button" disabled={busy !== null} onClick={() => onReject(action)}>이번에는 실행하지 않을게요</button> : null}
+        {canRetry ? <button className="button-secondary" type="button" disabled={busy !== null} onClick={() => onRetry(action)}>다시 준비해 주세요</button> : null}
       </div>
       {action.status === "UNKNOWN_RESULT" ? <p className="status-warn">실제 결과를 확인하는 중입니다. 새 쓰기 실행은 잠시 막혀 있습니다.</p> : null}
     </article>
@@ -69,8 +69,27 @@ function ActionDecisionCard({ action, approval, busy, canRetry, formatTime, onAp
 }
 
 function approvalLabel(duplicate: ReturnType<typeof taskDuplicateDecision>, conflict: ReturnType<typeof calendarConflictDecision>): string {
-  if (conflict === "HARD_CONFLICT") return "충돌을 알고도 진행";
-  if (duplicate === "CLEAR_DUPLICATE") return "그래도 새로 만들기";
-  if (conflict === "WARNING" || duplicate === "SIMILAR_CANDIDATE") return "확인하고 승인";
-  return "승인";
+  if (conflict === "HARD_CONFLICT") return "충돌을 알고도 실행해 주세요";
+  if (duplicate === "CLEAR_DUPLICATE") return "그래도 새로 만들어 주세요";
+  if (conflict === "WARNING" || duplicate === "SIMILAR_CANDIDATE") return "위험을 확인하고 실행해 주세요";
+  return "네, 실행해 주세요";
+}
+
+function actionLabel(toolName: string): string {
+  if (toolName.startsWith("gmail_")) return toolName.includes("send") ? "메일 보내기" : toolName.includes("draft") ? "메일 초안 만들기" : "메일 작업";
+  if (toolName.startsWith("tasks_")) return toolName.includes("create") ? "태스크 만들기" : "태스크 변경";
+  if (toolName.startsWith("calendar_")) return toolName.includes("create") ? "일정 만들기" : "일정 변경";
+  return "요청한 작업";
+}
+
+function effectLabel(effectType: string): string {
+  return ({ CREATE: "새로 만들기", UPDATE: "내용 변경", DELETE: "삭제", SEND: "보내기" } as Record<string, string>)[effectType] ?? "요청대로 처리";
+}
+
+function verificationLabel(policy: string): string {
+  return policy === "GET_COMPARE" ? "실행 후 Google에서 다시 확인" : policy === "GET_ABSENT" ? "실행 후 삭제 여부 확인" : "실행 결과 확인";
+}
+
+function approvalStatusLabel(status: string): string {
+  return ({ ACTIVE: "승인을 기다리고 있습니다.", APPROVED: "승인이 완료됐습니다.", REJECTED: "실행하지 않기로 했습니다.", EXPIRED: "승인 시간이 지났습니다." } as Record<string, string>)[status] ?? "승인 상태를 확인하고 있습니다.";
 }

--- a/frontend/src/features/conversation/ConversationView.tsx
+++ b/frontend/src/features/conversation/ConversationView.tsx
@@ -5,7 +5,7 @@ import { ActionPlanCard } from "../approval";
 import { RecoveryCard } from "../recovery";
 import { ConfirmationCard, ContextPreviewCard, ExecutionStatusCard, ExternalLlmDisclosureCard, RequestComposer, RunProgress } from "../run";
 import type { RunSseEvent } from "../run/api/run_sse_event";
-import { DateSeparator, UserMessageBubble } from "./MessageBubble";
+import { AssistantMessageBubble, DateSeparator, UserMessageBubble } from "./MessageBubble";
 
 type RecoveryKind = NonNullable<RunSnapshot["recovery"]>["allowed_resolution_kinds"][number];
 
@@ -50,12 +50,11 @@ export function ConversationView({ children, viewModel }: ConversationViewProps)
   useEffect(() => {
     const node = timelineRef.current;
     if (node) node.scrollTop = node.scrollHeight;
-  }, [selectedConversationId, historyMessages, showTransientRequest]);
+  }, [selectedConversationId, historyMessages, latestRunEvent?.event_id, runSnapshot?.projection_version, showTransientRequest]);
   const retryActionIds = new Set(runSnapshot?.error?.actions.filter((action) => action.kind === "PREPARE_RETRY" && action.action_id).map((action) => action.action_id!) ?? []);
 
   return (
     <>
-      {runSnapshot ? <RunProgress snapshot={runSnapshot} latestEvent={latestRunEvent} busy={busyCommand} onCancel={() => void handleCancelRun()} onResume={(kind) => void handleResumeRun(kind)} /> : null}
       <div className="panel-body">
         <div className="central-scroll-area" ref={timelineRef}>
           {children}
@@ -64,19 +63,19 @@ export function ConversationView({ children, viewModel }: ConversationViewProps)
               {groupMessagesByDate(historyMessages).map(({ message, separatorLabel }) => (
                 <Fragment key={message.id}>
                   {separatorLabel ? <DateSeparator label={separatorLabel} /> : null}
-                  {message.role === "USER" ? <UserMessageBubble content={message.content} createdAtMs={message.created_at_ms} /> : <article className="info-card"><strong>{historyMessageLabel(message.role)}</strong><p>{message.content}</p></article>}
+                  {message.role === "USER" ? <UserMessageBubble content={message.content} createdAtMs={message.created_at_ms} /> : message.role === "ASSISTANT" ? <AssistantMessageBubble content={message.content} createdAtMs={message.created_at_ms} /> : <article className="info-card"><strong>시스템 메시지</strong><p>{message.content}</p></article>}
                 </Fragment>
               ))}
               {showTransientRequest ? <UserMessageBubble content={runContext!.request_text} /> : null}
+              {runSnapshot ? <RunProgress snapshot={runSnapshot} latestEvent={latestRunEvent} busy={busyCommand} onCancel={() => void handleCancelRun()} onResume={(kind) => void handleResumeRun(kind)} /> : null}
               {runSnapshot?.pending_interrupt ? <ConfirmationCard interrupt={runSnapshot.pending_interrupt} text={confirmationText} busy={busyCommand === "confirm-run"} onTextChange={setConfirmationText} onSubmit={(option) => void handleConfirmation(option)} /> : null}
-              {runSnapshot?.external_llm_transfer_scope ? <ExternalLlmDisclosureCard scope={runSnapshot.external_llm_transfer_scope} /> : null}
-              {runSnapshot?.context_preview ? <ContextPreviewCard preview={runSnapshot.context_preview} busy={busyCommand?.startsWith("adjust-context:") ?? false} onAdjust={handleAdjustContext} /> : null}
-              {runSnapshot ? <ActionPlanCard snapshot={runSnapshot} busy={busyCommand} retryActionIds={retryActionIds} formatTime={formatTime} onApprove={(action, acknowledgements) => void handleApprove(action, acknowledgements)} onModify={(action, patch) => void handleSimpleAction("modify", action, patch)} onReject={(action) => void handleSimpleAction("reject", action)} onRetry={(action) => void handleSimpleAction("retry", action)} onAttachDescriptors={(action, descriptors) => handleAttachDescriptors(action, descriptors)} /> : null}
-              {runSnapshot ? <ExecutionStatusCard snapshot={runSnapshot} /> : null}
+              {runSnapshot ? <div className="action-execution-flow"><ActionPlanCard snapshot={runSnapshot} busy={busyCommand} retryActionIds={retryActionIds} formatTime={formatTime} onApprove={(action, acknowledgements) => void handleApprove(action, acknowledgements)} onModify={(action, patch) => void handleSimpleAction("modify", action, patch)} onReject={(action) => void handleSimpleAction("reject", action)} onRetry={(action) => void handleSimpleAction("retry", action)} onAttachDescriptors={(action, descriptors) => handleAttachDescriptors(action, descriptors)} /><ExecutionStatusCard snapshot={runSnapshot} /></div> : null}
               {runSnapshot ? <RecoveryCard snapshot={runSnapshot} busy={busyCommand} onResolve={(kind) => void handleResolveRecovery(kind)} onErrorAction={(kind) => kind === "OPEN_DIAGNOSTICS" ? onOpenDiagnostics() : onOpenSettings()} /> : null}
             </section>
           </section>
         </div>
+        {runSnapshot?.external_llm_transfer_scope ? <ExternalLlmDisclosureCard scope={runSnapshot.external_llm_transfer_scope} /> : null}
+        {runSnapshot?.context_preview ? <ContextPreviewCard preview={runSnapshot.context_preview} busy={busyCommand?.startsWith("adjust-context:") ?? false} onAdjust={handleAdjustContext} /> : null}
         <RequestComposer text={composerText} error={composerError} busy={busyCommand === "start-run"} prompt={resourceContext.composerPrompt} selectedResourceLabels={resourceContext.selectedResourceLabels} setText={setComposerText} setError={setComposerError} onSubmit={handleStartRun} />
       </div>
     </>
@@ -94,8 +93,4 @@ function groupMessagesByDate(messages: ConversationMessage[]): MessageWithSepara
     lastDateKey = dateKey;
     return { message, separatorLabel };
   });
-}
-
-function historyMessageLabel(role: ConversationMessage["role"]): string {
-  return role === "ASSISTANT" ? "에이전트 응답" : role === "USER" ? "사용자 요청" : "시스템 메시지";
 }

--- a/frontend/src/features/conversation/MessageBubble.tsx
+++ b/frontend/src/features/conversation/MessageBubble.tsx
@@ -23,6 +23,21 @@ export function UserMessageBubble({
   );
 }
 
+export function AssistantMessageBubble({
+  content,
+  createdAtMs,
+}: {
+  content: string;
+  createdAtMs: number;
+}): JSX.Element {
+  return (
+    <article className="message-row message-row--assistant" aria-label="에이전트 응답">
+      <p className="message-bubble message-bubble--assistant">{content}</p>
+      <span className="message-timestamp">{formatMessageTime(createdAtMs)}</span>
+    </article>
+  );
+}
+
 function formatMessageTime(value: number): string {
   return new Date(value).toLocaleString("ko-KR", { hour: "numeric", minute: "2-digit", hour12: true });
 }

--- a/frontend/src/features/run/context_preview_card.tsx
+++ b/frontend/src/features/run/context_preview_card.tsx
@@ -11,69 +11,92 @@ type Props = {
 };
 
 export function ContextPreviewCard({ preview, busy, onAdjust }: Props): JSX.Element {
+  const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [requestedInformation, setRequestedInformation] = useState("");
   useEffect(() => {
     setSelected(new Set());
     setRequestedInformation("");
   }, [preview.retrieval_revision]);
+  useEffect(() => {
+    if (!open) return undefined;
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [open]);
 
   const canExclude = preview.adjustment_allowed
     && preview.allowed_adjustments.includes("EXCLUDE_EVIDENCE");
   const canRetrieveMore = preview.adjustment_allowed
     && preview.allowed_adjustments.includes("RETRIEVE_MORE");
+  const contextCount = preview.gmail_count + preview.tasks_count + preview.calendar_count;
 
   return (
-    <article className="info-card" aria-label="사용 컨텍스트 미리보기">
-      <strong>사용 컨텍스트</strong>
-      <p className="muted">메일 {preview.gmail_count} · 태스크 {preview.tasks_count} · 일정 {preview.calendar_count} · revision {preview.retrieval_revision}</p>
-      {preview.items.length ? (
-        <ul className="card-list">
-          {preview.items.map((item) => (
-            <li key={item.segment_id} className="inline-row">
-              {canExclude ? (
-                <input
-                  aria-label={`${item.display_label} 제외 선택`}
-                  type="checkbox"
-                  checked={selected.has(item.segment_id)}
-                  onChange={(event) => setSelected((current) => {
-                    const next = new Set(current);
-                    if (event.target.checked) next.add(item.segment_id);
-                    else next.delete(item.segment_id);
-                    return next;
-                  })}
-                />
-              ) : null}
-              <span><strong>{item.display_label}</strong> <span className="pill">{item.source}</span></span>
-              <span className="muted">{item.role}</span>
-              {item.excerpt ? <span>{item.excerpt}</span> : null}
-            </li>
-          ))}
-        </ul>
-      ) : <p className="muted">현재 선택된 컨텍스트가 없습니다.</p>}
-      {canExclude ? (
-        <button
-          className="button-secondary"
-          type="button"
-          disabled={busy || selected.size === 0}
-          onClick={() => void onAdjust("EXCLUDE_EVIDENCE", [...selected])}
-        >
-          선택한 근거 제외
-        </button>
-      ) : null}
-      {canRetrieveMore ? (
-        <div>
-          <label>추가로 필요한 정보<input value={requestedInformation} onChange={(event) => setRequestedInformation(event.target.value)} maxLength={2048} /></label>
-          <button
-            className="button-secondary"
-            type="button"
-            disabled={busy || !requestedInformation.trim()}
-            onClick={() => void onAdjust("RETRIEVE_MORE", requestedInformation.trim())}
-          >
-            추가 자료 찾기
-          </button>
+    <div className="context-preview-anchor">
+      <button className="context-preview-trigger" type="button" aria-haspopup="dialog" aria-expanded={open} onClick={() => setOpen(true)}>
+        사용 컨텍스트 <strong>{contextCount}개</strong>
+      </button>
+      {open ? (
+        <div className="context-modal-backdrop" onMouseDown={(event) => { if (event.currentTarget === event.target) setOpen(false); }}>
+          <section className="context-modal" role="dialog" aria-modal="true" aria-labelledby="context-modal-title">
+            <header>
+              <div><strong id="context-modal-title">사용 컨텍스트 {contextCount}개</strong><p className="muted">메일 {preview.gmail_count} · 태스크 {preview.tasks_count} · 일정 {preview.calendar_count}</p></div>
+              <button className="icon-button icon-button--plain" type="button" aria-label="사용 컨텍스트 닫기" onClick={() => setOpen(false)}>×</button>
+            </header>
+            {preview.items.length ? (
+              <ul className="context-item-list">
+                {preview.items.map((item) => (
+                  <li key={item.segment_id}>
+                    {canExclude ? (
+                      <input
+                        aria-label={`${item.display_label} 제외 선택`}
+                        type="checkbox"
+                        checked={selected.has(item.segment_id)}
+                        onChange={(event) => setSelected((current) => {
+                          const next = new Set(current);
+                          if (event.target.checked) next.add(item.segment_id);
+                          else next.delete(item.segment_id);
+                          return next;
+                        })}
+                      />
+                    ) : null}
+                    <span><strong>{item.display_label}</strong><span className="pill">{sourceLabel(item.source)}</span><span className="muted">{item.role}</span>{item.excerpt ? <span>{item.excerpt}</span> : null}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : <p className="muted">현재 선택된 컨텍스트가 없습니다.</p>}
+            {canExclude ? (
+              <button
+                className="button-secondary"
+                type="button"
+                disabled={busy || selected.size === 0}
+                onClick={() => void onAdjust("EXCLUDE_EVIDENCE", [...selected])}
+              >
+                선택한 근거 제외
+              </button>
+            ) : null}
+            {canRetrieveMore ? (
+              <div className="context-retrieve-more">
+                <label>추가로 필요한 정보<input value={requestedInformation} onChange={(event) => setRequestedInformation(event.target.value)} maxLength={2048} /></label>
+                <button
+                  className="button-secondary"
+                  type="button"
+                  disabled={busy || !requestedInformation.trim()}
+                  onClick={() => void onAdjust("RETRIEVE_MORE", requestedInformation.trim())}
+                >
+                  추가 자료 찾기
+                </button>
+              </div>
+            ) : null}
+          </section>
         </div>
       ) : null}
-    </article>
+    </div>
   );
+}
+
+function sourceLabel(source: ContextPreview["items"][number]["source"]): string {
+  return ({ gmail: "메일", tasks: "태스크", calendar: "일정" } as const)[source];
 }

--- a/frontend/src/features/run/execution_status_card.tsx
+++ b/frontend/src/features/run/execution_status_card.tsx
@@ -2,19 +2,48 @@ import type { RunSnapshot } from "../../api/contract";
 
 export function ExecutionStatusCard({ snapshot }: { snapshot: RunSnapshot }): JSX.Element {
   return (
-    <article className="info-card">
-      <strong>실행 및 검증 상태</strong>
+    <section className="execution-conversation" aria-label="실행 및 검증 진행">
       {snapshot.actions.map((action) => (
-        <div className="inline-row" key={action.action_id} style={{ justifyContent: "space-between" }}>
-          <span>{action.tool_name}</span><span className="pill">{action.status}</span>
-          {action.delivery_certainty ? <span className="muted">{action.delivery_certainty}</span> : null}
-        </div>
+        <p className={`agent-status-line${isActiveAction(action.status) ? " agent-status-line--active" : ""}`} data-action-status={action.status} key={action.action_id}>
+          {agentLabel(action.tool_name)} · {actionStatusLabel(action.status, action.delivery_certainty)}
+        </p>
       ))}
-      <div className="muted">Verified {snapshot.verification_summary.verified_count}</div>
-      <div className="muted">Mismatch {snapshot.verification_summary.mismatch_count}</div>
+      {snapshot.verification_summary.verified_count > 0 ? <p className="agent-status-line">검증 에이전트 · {snapshot.verification_summary.verified_count}개 작업의 결과를 확인했습니다.</p> : null}
+      {snapshot.verification_summary.mismatch_count > 0 ? <p className="agent-status-line status-warn">검증 에이전트 · {snapshot.verification_summary.mismatch_count}개 작업에서 요청과 다른 결과를 확인했습니다.</p> : null}
       {snapshot.recovery_summary.unknown_result_action_count > 0 ? (
         <p className="status-warn">결과 불명 작업 {snapshot.recovery_summary.unknown_result_action_count}건을 확인하고 있습니다.</p>
       ) : null}
-    </article>
+    </section>
   );
+}
+
+function agentLabel(toolName: string): string {
+  if (toolName.startsWith("gmail_")) return "Gmail 실행 에이전트";
+  if (toolName.startsWith("tasks_")) return "Tasks 실행 에이전트";
+  if (toolName.startsWith("calendar_")) return "Calendar 실행 에이전트";
+  return "실행 에이전트";
+}
+
+function actionStatusLabel(status: string, deliveryCertainty: RunSnapshot["actions"][number]["delivery_certainty"]): string {
+  if (status === "UNKNOWN_RESULT" && deliveryCertainty === "SENT_RESPONSE_LOST") return "응답을 받지 못해 실제 결과를 안전하게 확인하고 있습니다.";
+  return ({
+    PROPOSED: "실행 전 승인을 기다리고 있습니다.",
+    MODIFIED: "바뀐 내용을 다시 확인하고 있습니다.",
+    APPROVED: "승인을 확인하고 실행을 준비하고 있습니다.",
+    REJECTED: "사용자 선택에 따라 실행하지 않았습니다.",
+    EXPIRED: "승인 시간이 지나 다시 확인이 필요합니다.",
+    EXECUTING: "승인된 작업을 실행하고 있습니다.",
+    UNKNOWN_RESULT: "실제 결과를 안전하게 확인하고 있습니다.",
+    EXECUTED: "실행을 마치고 Google에서 결과를 확인하고 있습니다.",
+    VERIFIED: "실행 결과를 확인했습니다.",
+    FAILED: "작업을 완료하지 못했습니다.",
+    BLOCKED: "안전을 위해 작업을 실행하지 않았습니다.",
+    DEPENDENCY_BLOCKED: "먼저 필요한 작업이 없어 실행하지 않았습니다.",
+    MISMATCH: "요청 내용과 다른 결과를 확인했습니다.",
+    CANCELLED: "작업을 취소했습니다.",
+  } as Record<string, string>)[status] ?? "작업 상태를 확인하고 있습니다.";
+}
+
+function isActiveAction(status: string): boolean {
+  return ["APPROVED", "EXECUTING", "UNKNOWN_RESULT", "EXECUTED"].includes(status);
 }

--- a/frontend/src/features/run/external_llm_disclosure_card.tsx
+++ b/frontend/src/features/run/external_llm_disclosure_card.tsx
@@ -1,23 +1,26 @@
+import { useState } from "react";
 import type { ExternalLlmTransferScope } from "../../api/contract";
 
-const DATA_CLASS_LABELS: Record<ExternalLlmTransferScope["data_classes"][number], string> = {
-  USER_REQUEST: "사용자 요청",
-  RESOURCE_METADATA: "자료 메타데이터",
-  EVIDENCE_EXCERPT: "선택 근거 일부",
-  PLAN_CONTEXT: "업무 계획 컨텍스트",
-};
+const DISMISS_KEY = "gwa.external-llm-disclosure.dismissed";
 
 export function ExternalLlmDisclosureCard({ scope }: { scope: ExternalLlmTransferScope }): JSX.Element {
+  const [dismissed, setDismissed] = useState(() => (
+    typeof window !== "undefined" && window.localStorage.getItem(DISMISS_KEY) === "true"
+  ));
+  if (dismissed) return <></>;
+
+  const dismiss = (): void => {
+    window.localStorage.setItem(DISMISS_KEY, "true");
+    setDismissed(true);
+  };
+
   return (
-    <article className="info-card" aria-label="외부 LLM 전송 범위">
-      <strong>외부 API LLM 전송 안내</strong>
-      <p>이 Run의 추론을 위해 아래 범위가 외부 LLM Provider로 전송될 수 있습니다.</p>
-      <dl className="metadata-list">
-        <div><dt>자료 출처</dt><dd>{scope.source_kinds.join(", ")}</dd></div>
-        <div><dt>전송 데이터</dt><dd>{scope.data_classes.map((item) => DATA_CLASS_LABELS[item]).join(", ")}</dd></div>
-        <div><dt>목적</dt><dd>현재 요청의 분석·계획·응답 생성</dd></div>
-        <div><dt>범위 revision</dt><dd>{scope.scope_revision}</dd></div>
-      </dl>
+    <article className="llm-disclosure-snackbar" role="status" aria-label="외부 LLM 전송 안내" data-scope-revision={scope.scope_revision}>
+      <div>
+        <strong>외부 API LLM 전송 안내</strong>
+        <p>이 Run의 추론을 위해 아래 범위가 외부 LLM Provider로 전송될 수 있습니다.</p>
+      </div>
+      <button type="button" onClick={dismiss}>다시 보지 않음</button>
     </article>
   );
 }

--- a/frontend/src/features/run/run_progress.tsx
+++ b/frontend/src/features/run/run_progress.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from "react";
 import type { RunSnapshot } from "../../api/contract";
 import type { RunSseEvent } from "./api/run_sse_event";
+
+type ActivityLine = { eventId: string; label: string };
 
 export function RunProgress({ snapshot, latestEvent = null, busy, onCancel, onResume }: {
   snapshot: RunSnapshot;
@@ -8,21 +11,30 @@ export function RunProgress({ snapshot, latestEvent = null, busy, onCancel, onRe
   onCancel: () => void;
   onResume: (resumeKind: "SAFE_CHECKPOINT_RESUME") => void;
 }): JSX.Element {
+  const [activity, setActivity] = useState<{ runId: string; lines: ActivityLine[] }>({ runId: snapshot.run.run_id, lines: [] });
   const resumeAction = snapshot.error?.actions.find(
     (action) => action.kind === "RESUME_SAFE_CHECKPOINT" && action.resume_kind === "SAFE_CHECKPOINT_RESUME",
   );
-  const eventLabel = latestEvent ? eventProgressLabel(latestEvent) : null;
+  useEffect(() => {
+    if (!latestEvent) return;
+    const label = eventProgressLabel(latestEvent);
+    if (!label) return;
+    setActivity((current) => {
+      const lines = current.runId === snapshot.run.run_id ? current.lines : [];
+      if (lines.some((line) => line.eventId === latestEvent.event_id)) return { runId: snapshot.run.run_id, lines };
+      return { runId: snapshot.run.run_id, lines: [...lines, { eventId: latestEvent.event_id, label }].slice(-12) };
+    });
+  }, [latestEvent, snapshot.run.run_id]);
+  const lines = activity.runId === snapshot.run.run_id && activity.lines.length > 0
+    ? activity.lines
+    : [{ eventId: `snapshot-${snapshot.run.version}`, label: statusProgressLabel(snapshot.run.status) }];
+  const activelyWorking = ["CREATED", "ANALYZING", "RETRIEVING", "PLANNING", "EXECUTING", "VERIFYING"].includes(snapshot.run.status);
   return (
-    <div className={`panel-header run-header${snapshot.run.status === "FAILED" ? " run-header--failed" : ""}`}>
-      <div>
-        <strong>{snapshot.run.status === "FAILED" ? "실행 실패" : "실행 진행"}</strong>
-        <div className="muted">{statusLabel(snapshot.run.status)}</div>
-        <div className="muted">
-          작업 {snapshot.execution_status.terminal_action_count}/{snapshot.execution_status.action_count}
-        </div>
-        {eventLabel ? <div className="muted" data-testid="run-event-progress">{eventLabel}</div> : null}
-        {snapshot.run.status === "FAILED" ? <div className="status-warn">작업을 완료하지 못했습니다.</div> : null}
-        {snapshot.terminal_result_kind === "PARTIAL" ? <div className="status-warn">일부 작업은 완료되었고 나머지는 취소되었습니다.</div> : null}
+    <section className="agent-progress" aria-label="에이전트 진행">
+      <div className="agent-progress-lines" aria-live="polite">
+        {lines.map((line, index) => <p className={`agent-status-line${activelyWorking && index === lines.length - 1 ? " agent-status-line--active" : ""}`} data-testid={index === lines.length - 1 ? "run-event-progress" : undefined} key={line.eventId}>{line.label}</p>)}
+        {snapshot.run.status === "FAILED" ? <p className="status-warn">작업을 완료하지 못했습니다.</p> : null}
+        {snapshot.terminal_result_kind === "PARTIAL" ? <p className="status-warn">일부 작업은 완료되었고 나머지는 취소되었습니다.</p> : null}
       </div>
       <div className="button-row">
         {snapshot.run.next_allowed_commands.includes("REQUEST_CANCEL") ? (
@@ -32,19 +44,86 @@ export function RunProgress({ snapshot, latestEvent = null, busy, onCancel, onRe
           <button className="button-secondary" type="button" disabled={busy === "resume-run"} onClick={() => onResume(resumeAction.resume_kind!)}>재개</button>
         ) : null}
       </div>
-    </div>
+    </section>
   );
 }
 
 function eventProgressLabel(event: RunSseEvent): string | null {
   switch (event.event_type) {
-    case "tool_routing": return `도구 경로 ${event.payload.input_route_count}개 분석 완료`;
-    case "retrieval_progress": return `자료 확인 ${event.payload.completed_sources}/${event.payload.total_sources}`;
-    case "analysis_progress": return `분석 완료: ${event.payload.completed_stage}`;
-    default: return null;
+    case "run_status": return statusProgressLabel(event.payload.status);
+    case "phase_changed": return phaseProgressLabel(event.payload.phase);
+    case "tool_routing": return `도구 경로 에이전트 · 사용할 경로 ${event.payload.input_route_count}개를 정했습니다.`;
+    case "retrieval_progress": return `자료 검색 에이전트 · 컨텍스트 ${event.payload.completed_sources}/${event.payload.total_sources}개를 확인하고 있습니다.`;
+    case "confirmation_required": return "메인 에이전트 · 요청을 정확히 이해하기 위해 답변을 기다리고 있습니다.";
+    case "analysis_progress": return "업무 분석 에이전트 · 필요한 조건과 근거를 정리했습니다.";
+    case "plan_updated": return "계획 에이전트 · 실행할 내용을 작성했습니다.";
+    case "approval_required": return "메인 에이전트 · 실행 전 승인을 기다리고 있습니다.";
+    case "action_status": return actionProgressLabel(event.payload.status);
+    case "verification_result": return event.payload.outcome === "VERIFIED" ? "검증 에이전트 · 실행 결과를 확인했습니다." : "검증 에이전트 · 요청 내용과 다른 결과를 확인했습니다.";
+    case "reauth_required": return "메인 에이전트 · Google 계정 재연결을 기다리고 있습니다.";
+    case "recovery_required": return "복구 에이전트 · 안전하게 계속할 방법을 확인하고 있습니다.";
+    case "completed": return event.payload.status === "COMPLETED" ? "메인 에이전트 · 작업을 완료했습니다." : "메인 에이전트 · 작업을 종료했습니다.";
+    case "error": return "메인 에이전트 · 작업을 계속할 수 없는 문제를 확인했습니다.";
   }
 }
 
-function statusLabel(status: string): string {
-  return ({ SINGLE: "작업을 처리하고 있습니다.", WAITING_APPROVAL: "승인이 필요합니다.", EXECUTING: "작업을 처리하고 있습니다.", WAITING_CONFIRMATION: "추가 확인이 필요합니다.", RECOVERY_REQUIRED: "복구 결정을 기다리고 있습니다.", COMPLETED: "작업을 완료했습니다.", CANCELLED: "작업을 취소했습니다." } as Record<string, string>)[status] ?? status;
+function phaseProgressLabel(phase: string): string {
+  return ({
+    INITIALIZE: "메인 에이전트 · 작업을 준비하고 있습니다.",
+    REQUEST_ANALYSIS: "요청 이해 에이전트 · 요청의 목적을 파악하고 있습니다.",
+    TOOL_ROUTING: "도구 경로 에이전트 · 사용할 도구를 정하고 있습니다.",
+    WAITING_CONFIRMATION: "메인 에이전트 · 추가 답변을 기다리고 있습니다.",
+    CONTEXT_RETRIEVAL: "자료 검색 에이전트 · 필요한 컨텍스트를 찾고 있습니다.",
+    WORK_ANALYSIS: "업무 분석 에이전트 · 근거와 조건을 검토하고 있습니다.",
+    SOLUTION_PLANNING: "계획 에이전트 · 실행할 내용을 작성하고 있습니다.",
+    PLAN_REVIEW: "검토 에이전트 · 실행 계획을 확인하고 있습니다.",
+    DOMAIN_VALIDATION: "검토 에이전트 · 안전하게 실행할 수 있는지 확인하고 있습니다.",
+    WAITING_APPROVAL: "메인 에이전트 · 실행 전 승인을 기다리고 있습니다.",
+    PREFLIGHT: "실행 에이전트 · 승인 내용과 실행 조건을 다시 확인하고 있습니다.",
+    ACTION_EXECUTION: "실행 에이전트 · 승인된 작업을 실행하고 있습니다.",
+    READ_EXECUTION: "자료 검색 에이전트 · 요청한 자료를 읽고 있습니다.",
+    VERIFICATION: "검증 에이전트 · Google에서 결과를 다시 확인하고 있습니다.",
+    RESPONSE_SYNTHESIS: "메인 에이전트 · 답변을 정리하고 있습니다.",
+    RECOVERY: "복구 에이전트 · 안전하게 계속할 방법을 확인하고 있습니다.",
+    FINALIZE: "메인 에이전트 · 결과를 마무리하고 있습니다.",
+  } as Record<string, string>)[phase] ?? "메인 에이전트 · 작업을 처리하고 있습니다.";
+}
+
+function statusProgressLabel(status: string): string {
+  return ({
+    CREATED: "메인 에이전트 · 작업을 준비하고 있습니다.",
+    ANALYZING: "업무 분석 에이전트 · 요청을 분석하고 있습니다.",
+    RETRIEVING: "자료 검색 에이전트 · 필요한 컨텍스트를 찾고 있습니다.",
+    WAITING_CONFIRMATION: "메인 에이전트 · 추가 답변을 기다리고 있습니다.",
+    PLANNING: "계획 에이전트 · 실행할 내용을 작성하고 있습니다.",
+    WAITING_APPROVAL: "메인 에이전트 · 실행 전 승인을 기다리고 있습니다.",
+    EXECUTING: "실행 에이전트 · 승인된 작업을 실행하고 있습니다.",
+    VERIFYING: "검증 에이전트 · Google에서 결과를 다시 확인하고 있습니다.",
+    COMPLETED: "메인 에이전트 · 작업을 완료했습니다.",
+    CANCEL_REQUESTED: "메인 에이전트 · 안전하게 중단하고 있습니다.",
+    CANCELLED: "메인 에이전트 · 작업을 취소했습니다.",
+    REAUTH_REQUIRED: "메인 에이전트 · Google 계정 재연결을 기다리고 있습니다.",
+    RECOVERY_REQUIRED: "복구 에이전트 · 다음 진행 방법을 기다리고 있습니다.",
+    FAILED: "메인 에이전트 · 작업을 완료하지 못했습니다.",
+    BLOCKED: "메인 에이전트 · 안전을 위해 작업을 중단했습니다.",
+  } as Record<string, string>)[status] ?? "메인 에이전트 · 작업을 처리하고 있습니다.";
+}
+
+function actionProgressLabel(status: string): string {
+  return ({
+    PROPOSED: "계획 에이전트 · 실행할 작업을 제안했습니다.",
+    MODIFIED: "계획 에이전트 · 요청대로 실행 내용을 바꿨습니다.",
+    APPROVED: "실행 에이전트 · 승인을 확인했습니다.",
+    REJECTED: "메인 에이전트 · 실행하지 않기로 한 작업을 제외했습니다.",
+    EXPIRED: "메인 에이전트 · 승인 시간이 지나 다시 확인이 필요합니다.",
+    EXECUTING: "실행 에이전트 · 승인된 작업을 실행하고 있습니다.",
+    UNKNOWN_RESULT: "복구 에이전트 · 실제 실행 결과를 확인하고 있습니다.",
+    EXECUTED: "실행 에이전트 · 실행을 마치고 결과를 확인하고 있습니다.",
+    VERIFIED: "검증 에이전트 · 실행 결과를 확인했습니다.",
+    FAILED: "실행 에이전트 · 작업을 완료하지 못했습니다.",
+    BLOCKED: "메인 에이전트 · 안전을 위해 작업을 실행하지 않았습니다.",
+    DEPENDENCY_BLOCKED: "메인 에이전트 · 먼저 필요한 작업이 없어 실행하지 않았습니다.",
+    MISMATCH: "검증 에이전트 · 요청 내용과 다른 결과를 확인했습니다.",
+    CANCELLED: "메인 에이전트 · 작업을 취소했습니다.",
+  } as Record<string, string>)[status] ?? "메인 에이전트 · 작업 상태를 확인하고 있습니다.";
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -192,6 +192,7 @@ button {
 }
 
 main.panel .panel-body {
+  position: relative;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
@@ -557,6 +558,12 @@ main.panel .panel-header > div:first-child .muted {
   gap: 0.4rem;
 }
 
+.message-row--assistant {
+  justify-content: flex-start;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+
 .message-bubble {
   max-width: 78%;
   margin: 0;
@@ -574,6 +581,12 @@ main.panel .panel-header > div:first-child .muted {
   border-bottom-right-radius: 0.3rem;
 }
 
+.message-bubble--assistant {
+  background: color-mix(in srgb, var(--panel), var(--panel-strong) 72%);
+  color: var(--text);
+  border-bottom-left-radius: 0.3rem;
+}
+
 .message-timestamp {
   flex: 0 0 auto;
   padding-bottom: 0.15rem;
@@ -582,14 +595,163 @@ main.panel .panel-header > div:first-child .muted {
   white-space: nowrap;
 }
 
-.run-header--failed {
-  border-left: 3px solid var(--danger);
-  background: color-mix(in srgb, var(--panel), var(--danger) 6%);
+.agent-progress,
+.action-execution-flow,
+.action-plan-conversation,
+.execution-conversation {
+  display: grid;
+  gap: 0.45rem;
+  border: 0;
 }
 
-.run-header--failed strong {
-  color: var(--danger);
+.agent-progress {
+  padding: 0.35rem 0.55rem;
 }
+
+.agent-progress-lines {
+  display: grid;
+  gap: 0.32rem;
+}
+
+.agent-status-line {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.agent-status-line::before {
+  content: "";
+  display: inline-block;
+  width: 0.36rem;
+  height: 0.36rem;
+  margin-right: 0.48rem;
+  border-radius: 50%;
+  background: currentColor;
+  vertical-align: 0.08rem;
+  opacity: 0.55;
+}
+
+.agent-status-line--active {
+  animation: agent-status-pulse 1.4s ease-in-out infinite alternate;
+}
+
+@keyframes agent-status-pulse {
+  from { opacity: 0.52; }
+  to { opacity: 1; }
+}
+
+.approval-conversation {
+  display: grid;
+  gap: 0.65rem;
+  width: min(88%, 42rem);
+  padding: 0.9rem 1rem;
+  border: 0;
+  border-radius: 1rem 1rem 1rem 0.32rem;
+  background: color-mix(in srgb, var(--panel), var(--panel-strong) 68%);
+}
+
+.approval-conversation p,
+.approval-conversation dl {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.approval-question {
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.context-preview-trigger {
+  position: absolute;
+  right: 1.35rem;
+  bottom: 6.15rem;
+  z-index: 10;
+  min-height: 2.4rem;
+  padding: 0.48rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--muted);
+  box-shadow: 0 0.55rem 1.4rem color-mix(in srgb, var(--text), transparent 84%);
+}
+
+.context-preview-trigger strong { color: var(--text); }
+
+.context-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 14;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 1rem 1.25rem 6rem;
+  background: color-mix(in srgb, var(--text), transparent 93%);
+}
+
+.context-modal {
+  display: grid;
+  gap: 0.8rem;
+  width: min(27rem, 100%);
+  max-height: min(34rem, calc(100% - 1rem));
+  padding: 1rem;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--panel);
+  box-shadow: 0 1rem 2.5rem color-mix(in srgb, var(--text), transparent 72%);
+}
+
+.context-modal > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.context-modal > header p { margin: 0.25rem 0 0; }
+
+.context-item-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.context-item-list li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.55rem;
+  padding: 0.65rem 0;
+}
+
+.context-item-list input { width: auto; min-height: auto; }
+.context-item-list li > span { display: grid; gap: 0.2rem; min-width: 0; }
+.context-item-list .pill { width: max-content; }
+.context-retrieve-more { display: grid; gap: 0.55rem; }
+
+.llm-disclosure-snackbar {
+  position: fixed;
+  left: 50%;
+  bottom: 1.25rem;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  width: min(44rem, calc(100vw - 2rem));
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 0.8rem;
+  background: var(--panel);
+  box-shadow: 0 1rem 2.4rem color-mix(in srgb, var(--text), transparent 72%);
+}
+
+.llm-disclosure-snackbar strong,
+.llm-disclosure-snackbar p { display: block; margin: 0; line-height: 1.45; }
+.llm-disclosure-snackbar p { color: var(--muted); font-size: 0.82rem; }
+.llm-disclosure-snackbar button { flex: 0 0 auto; border: 0; background: transparent; color: var(--accent); font-weight: 700; }
 
 .composer-dock {
   flex: 0 0 auto;
@@ -835,4 +997,12 @@ input, select {
   .shell-grid > main { border-right: 0; }
   .resource-viewer { flex-basis: auto; min-height: 12rem; }
   .selected-resource-pills { justify-content: flex-start; max-width: none; }
+  .approval-conversation { width: 100%; }
+  .context-modal-backdrop { padding: 0.75rem 0.75rem 5.8rem; }
+  .context-preview-trigger { right: 0.9rem; }
+  .llm-disclosure-snackbar { align-items: flex-start; flex-direction: column; gap: 0.65rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-status-line--active { animation: none; }
 }

--- a/frontend/tests/app/app_integration.test.tsx
+++ b/frontend/tests/app/app_integration.test.tsx
@@ -361,7 +361,7 @@ test("starts a run in RESOURCE_SELECTED mode", async () => {
   };
   expect(body.entry_mode).toBe("RESOURCE_SELECTED");
   expect(body.selected_resource_handles).toEqual(["handle-resource-1"]);
-  expect(await screen.findByText("실행 실패")).toBeInTheDocument();
+  expect(await screen.findByText("메인 에이전트 · 작업을 완료하지 못했습니다.")).toBeInTheDocument();
   expect(screen.getByText("작업을 완료하지 못했습니다.")).toBeInTheDocument();
 });
 
@@ -370,13 +370,11 @@ test("clears the previous conversation projection when starting a new conversati
   const user = userEvent.setup();
   render(<App />);
 
-  expect(await screen.findByText("작업을 완료하지 못했습니다.")).toBeInTheDocument();
-  expect(screen.getByText("Verified 0")).toBeInTheDocument();
+  expect(await screen.findByRole("region", { name: "에이전트 진행" })).toHaveTextContent("작업을 완료하지 못했습니다.");
 
   await user.click(screen.getByRole("button", { name: "새 대화" }));
 
-  expect(screen.queryByText("작업을 완료하지 못했습니다.")).not.toBeInTheDocument();
-  expect(screen.queryByText("Verified 0")).not.toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: "에이전트 진행" })).not.toBeInTheDocument();
 });
 
 test("keeps the last selected conversation when an earlier history response arrives late", async () => {
@@ -461,7 +459,7 @@ test("restores every stored turn of a selected conversation in order", async () 
 
   const cards = await screen.findAllByText(/^(요청|응답) \d$/);
   expect(cards.map((card) => card.textContent)).toEqual(["요청 1", "응답 1", "요청 2", "응답 2", "요청 3", "응답 3"]);
-  expect(screen.getAllByText("에이전트 응답")).toHaveLength(3);
+  expect(screen.getAllByRole("article", { name: "에이전트 응답" })).toHaveLength(3);
 });
 
 test("groups the message timeline by date and shows one separator per day", async () => {
@@ -786,7 +784,7 @@ test("shows approve button for write actions and posts approve command", async (
   const user = userEvent.setup();
   render(<App />);
 
-  const approveButton = await screen.findByRole("button", { name: "승인" });
+  const approveButton = await screen.findByRole("button", { name: "네, 실행해 주세요" });
   await user.click(approveButton);
 
   await waitFor(() =>
@@ -1291,7 +1289,7 @@ test("submits cancel, resume, and retry actions while showing unknown-result rec
   await screen.findByText("결과 불명 작업 1건을 확인하고 있습니다.");
   await user.click(screen.getByRole("button", { name: "취소" }));
   await user.click(screen.getByRole("button", { name: "재개" }));
-  await user.click(screen.getByRole("button", { name: "다시 준비" }));
+  await user.click(screen.getByRole("button", { name: "다시 준비해 주세요" }));
 
   await waitFor(() =>
     expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -1485,11 +1483,11 @@ test("TST-UI-201 header shows product, connection, account, help, settings, and 
 
   await waitFor(() => expect(document.querySelector(".topbar-connection .connection-connected")).not.toBeNull());
 
-  await screen.findByText("승인이 필요합니다.");
+  await screen.findByText("메인 에이전트 · 실행 전 승인을 기다리고 있습니다.");
   expect(screen.getByText("user@example.com")).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "도움말" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "설정" })).toBeInTheDocument();
-  expect(screen.getByText("승인이 필요합니다.")).toBeInTheDocument();
+  expect(screen.getByText("메인 에이전트 · 실행 전 승인을 기다리고 있습니다.")).toBeInTheDocument();
   expect(screen.queryByText("WAITING_APPROVAL")).not.toBeInTheDocument();
 });
 
@@ -2693,7 +2691,7 @@ test("TST-UI-208 Gmail viewer and approval use only available projection fields"
   expect(await screen.findByText("실제 메일 본문입니다.")).toBeInTheDocument();
   expect(screen.getByText("김대리 <kim@example.com>")).toBeInTheDocument();
   expect(screen.getByText(/받는 사람 user@example.com/)).toBeInTheDocument();
-  expect(screen.getByText("승인 상세")).toBeInTheDocument();
+  expect(screen.getByText("무엇을 실행하나요?")).toBeInTheDocument();
   expect(screen.queryByText("Evidence")).not.toBeInTheDocument();
 });
 
@@ -2705,7 +2703,7 @@ test("Action risk follows the SSE-refreshed snapshot without rendering raw JSON"
   installUiContractFetch(options);
   render(<App />);
 
-  await screen.findByText("승인 상세");
+  await screen.findByText("무엇을 실행하나요?");
   expect(screen.queryByText(/서버 검증에서 확인된 위험 정보/)).not.toBeInTheDocument();
 
   options.actionRisk = {
@@ -2744,7 +2742,7 @@ test.each([
   expect(document.body.textContent).not.toContain("private-deadline");
   expect(document.body.textContent).not.toContain("PRIVATE_REASON");
   if (decision === "INFEASIBLE") {
-    expect(screen.queryByRole("button", { name: "승인" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "네, 실행해 주세요" })).not.toBeInTheDocument();
   }
 });
 
@@ -2763,7 +2761,7 @@ test("similar Task duplicate requires an acknowledgement without exposing resour
 
   expect(await screen.findByText("비슷한 기존 작업이 있습니다.")).toBeInTheDocument();
   await user.click(screen.getByRole("checkbox", { name: "중복 가능성을 확인했습니다." }));
-  await user.click(screen.getByRole("button", { name: "확인하고 승인" }));
+  await user.click(screen.getByRole("button", { name: "위험을 확인하고 실행해 주세요" }));
 
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
@@ -2786,9 +2784,9 @@ test("clear Task duplicate is blocked by default and offers an explicit override
   render(<App />);
 
   expect(await screen.findByText(/동일한 작업이 이미 있습니다/)).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "승인" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "네, 실행해 주세요" })).not.toBeInTheDocument();
   await user.click(screen.getByRole("checkbox", { name: "중복 가능성을 확인했습니다." }));
-  await user.click(screen.getByRole("button", { name: "그래도 새로 만들기" }));
+  await user.click(screen.getByRole("button", { name: "그래도 새로 만들어 주세요" }));
 
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
@@ -2810,7 +2808,7 @@ test("NOT_DUPLICATE shows no warning and uses ordinary approval", async () => {
   });
   render(<App />);
 
-  await user.click(await screen.findByRole("button", { name: "승인" }));
+  await user.click(await screen.findByRole("button", { name: "네, 실행해 주세요" }));
   expect(screen.queryByText(/기존 작업이 있습니다/)).not.toBeInTheDocument();
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
@@ -2836,7 +2834,7 @@ test("Calendar WARNING requires explicit acknowledgement without exposing author
     await screen.findByText("겹칠 가능성이 있거나 업무 시간 밖의 일정입니다."),
   ).toBeInTheDocument();
   await user.click(screen.getByRole("checkbox", { name: "일정 충돌 가능성을 확인했습니다." }));
-  await user.click(screen.getByRole("button", { name: "확인하고 승인" }));
+  await user.click(screen.getByRole("button", { name: "위험을 확인하고 실행해 주세요" }));
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
     calendar_conflict_acknowledged: true,
@@ -2859,9 +2857,9 @@ test("Calendar HARD_CONFLICT offers an explicit override", async () => {
   render(<App />);
 
   expect(await screen.findByText("해당 시간에 기존 일정이 있습니다.")).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "승인" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "네, 실행해 주세요" })).not.toBeInTheDocument();
   await user.click(screen.getByRole("checkbox", { name: "일정 충돌 가능성을 확인했습니다." }));
-  await user.click(screen.getByRole("button", { name: "충돌을 알고도 진행" }));
+  await user.click(screen.getByRole("button", { name: "충돌을 알고도 실행해 주세요" }));
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
     calendar_conflict_acknowledged: true,
@@ -2879,7 +2877,7 @@ test("Calendar NO_CONFLICT shows ordinary approval", async () => {
   });
   render(<App />);
 
-  await user.click(await screen.findByRole("button", { name: "승인" }));
+  await user.click(await screen.findByRole("button", { name: "네, 실행해 주세요" }));
   expect(screen.queryByText(/기존 일정/)).not.toBeInTheDocument();
   const approve = requests.find((request) => request.path.endsWith("/actions/action-1/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({
@@ -2990,13 +2988,13 @@ test("TST-UI-209 renders independent approval commands with versions and disable
   const requests = installUiContractFetch({ action: true });
   render(<App />);
 
-  await screen.findByRole("button", { name: "승인" });
-  await user.click(screen.getByRole("button", { name: "승인" }));
+  await screen.findByRole("button", { name: "네, 실행해 주세요" });
+  await user.click(screen.getByRole("button", { name: "네, 실행해 주세요" }));
   const approve = requests.find((request) => request.path.endsWith("/approve"));
   expect(JSON.parse(String(approve?.init?.body))).toMatchObject({ expected_version: 7 });
-  expect(screen.getByText("승인 상세")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "수정" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "거절" })).toBeInTheDocument();
+  expect(screen.getByText("무엇을 실행하나요?")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "이 내용으로 바꿀게요" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "이번에는 실행하지 않을게요" })).toBeInTheDocument();
 });
 
 test("approved Action can be rejected and refreshes to a non-executable rejected state", async () => {
@@ -3004,15 +3002,15 @@ test("approved Action can be rejected and refreshes to a non-executable rejected
   const requests = installUiContractFetch({ action: true, actionStatus: "APPROVED" });
   render(<App />);
 
-  await user.click(await screen.findByRole("button", { name: "거절" }));
+  await user.click(await screen.findByRole("button", { name: "이번에는 실행하지 않을게요" }));
   const reject = requests.find((request) => request.path.endsWith("/reject"));
   expect(JSON.parse(String(reject?.init?.body))).toMatchObject({
     expected_version: 7,
     reason_code: null,
   });
-  expect(await screen.findByText("REJECTED")).toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "승인" })).not.toBeInTheDocument();
-  expect(screen.queryByRole("button", { name: "거절" })).not.toBeInTheDocument();
+  expect(await screen.findByText(/사용자 선택에 따라 실행하지 않았습니다/)).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "네, 실행해 주세요" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "이번에는 실행하지 않을게요" })).not.toBeInTheDocument();
 });
 
 test("TST-UI-210 filters conversations and shows recent execution fallback", async () => {
@@ -3056,14 +3054,14 @@ test("simple Gmail focus prioritizes the viewer and only shows the run header fo
   await user.click(await screen.findByRole("button", { name: /첫 번째 자료/ }));
   expect(await screen.findByText("실제 메일 본문입니다.")).toBeInTheDocument();
   expect(screen.queryByText("새 요청")).not.toBeInTheDocument();
-  expect(screen.queryByText("작업을 처리하고 있습니다.")).not.toBeInTheDocument();
+  expect(screen.queryByText("메인 에이전트 · 작업을 처리하고 있습니다.")).not.toBeInTheDocument();
 });
 
 test("TST-UI-213 hides raw runtime status and has no native window controls", async () => {
   installUiContractFetch({ status: "SINGLE" });
   render(<App />);
 
-  await screen.findByText("작업을 처리하고 있습니다.");
+  await screen.findByText("메인 에이전트 · 작업을 처리하고 있습니다.");
   expect(screen.queryByText("SINGLE")).not.toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /최소화|최대화|닫기/ })).not.toBeInTheDocument();
 });
@@ -3166,7 +3164,8 @@ test("renders snapshot context/disclosure and sends a context adjustment command
   const user = userEvent.setup();
   render(<App />);
 
-  expect(await screen.findByRole("article", { name: "외부 LLM 전송 범위" })).toHaveTextContent("gmail");
+  expect(await screen.findByRole("status", { name: "외부 LLM 전송 안내" })).toHaveTextContent("외부 API LLM 전송 안내");
+  await user.click(screen.getByRole("button", { name: "사용 컨텍스트 1개" }));
   await user.click(screen.getByRole("checkbox", { name: "마감 메일 제외 선택" }));
   await user.click(screen.getByRole("button", { name: "선택한 근거 제외" }));
   await waitFor(() => expect(requests.some((request) => request.path === "/api/v1/runs/run-1/context-adjustments")).toBe(true));

--- a/frontend/tests/features/approval/action_plan_card.test.tsx
+++ b/frontend/tests/features/approval/action_plan_card.test.tsx
@@ -10,7 +10,8 @@ test("ActionPlanCard sends only explicit server-projected acknowledgement", asyn
   const onApprove = vi.fn();
   render(<ActionPlanCard snapshot={snapshot} busy={null} retryActionIds={new Set()} formatTime={String} onApprove={onApprove} onModify={vi.fn()} onReject={vi.fn()} onRetry={vi.fn()} onAttachDescriptors={vi.fn()} />);
   const user = userEvent.setup();
-  const approve = screen.getByRole("button", { name: "확인하고 승인" });
+  const approve = screen.getByRole("button", { name: "위험을 확인하고 실행해 주세요" });
+  expect(screen.queryByText("Action Plan")).not.toBeInTheDocument();
   expect(approve).toBeDisabled();
   await user.click(screen.getByRole("checkbox", { name: "중복 가능성을 확인했습니다." }));
   expect(approve).toBeEnabled();

--- a/frontend/tests/features/conversation/message_bubble.test.tsx
+++ b/frontend/tests/features/conversation/message_bubble.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { AssistantMessageBubble } from "../../../src/features/conversation/MessageBubble";
+
+test("assistant answers render as a left conversation bubble with a timestamp", () => {
+  render(<AssistantMessageBubble content="요청한 내용을 정리했습니다." createdAtMs={new Date(2026, 8, 3, 15, 7).getTime()} />);
+
+  const answer = screen.getByRole("article", { name: "에이전트 응답" });
+  expect(answer).toHaveClass("message-row--assistant");
+  expect(answer.querySelector(".message-bubble--assistant")).toHaveTextContent("요청한 내용을 정리했습니다.");
+  expect(answer.querySelector(".message-timestamp")).not.toBeEmptyDOMElement();
+});

--- a/frontend/tests/features/run/context_and_disclosure_cards.test.tsx
+++ b/frontend/tests/features/run/context_and_disclosure_cards.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 import { ContextPreviewCard } from "../../../src/features/run/context_preview_card";
 import { ExternalLlmDisclosureCard } from "../../../src/features/run/external_llm_disclosure_card";
+
+beforeEach(() => localStorage.clear());
 
 test("renders the canonical context preview and invokes an exclusion adjustment", async () => {
   const adjust = vi.fn().mockResolvedValue(undefined);
@@ -18,23 +20,32 @@ test("renders the canonical context preview and invokes an exclusion adjustment"
     allowed_adjustments: ["EXCLUDE_EVIDENCE", "RETRIEVE_MORE"],
   }} busy={false} onAdjust={adjust} />);
 
-  expect(screen.getByRole("article", { name: "사용 컨텍스트 미리보기" })).toHaveTextContent("마감은 금요일입니다.");
+  expect(screen.getByRole("button", { name: "사용 컨텍스트 1개" })).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: "사용 컨텍스트 1개" }));
+  expect(screen.getByRole("dialog", { name: "사용 컨텍스트 1개" })).toHaveTextContent("마감은 금요일입니다.");
   await userEvent.click(screen.getByRole("checkbox", { name: "프로젝트 메일 제외 선택" }));
   await userEvent.click(screen.getByRole("button", { name: "선택한 근거 제외" }));
   expect(adjust).toHaveBeenCalledWith("EXCLUDE_EVIDENCE", ["segment-1"]);
 });
 
-test("renders the bounded external LLM transfer disclosure from the snapshot", () => {
-  render(<ExternalLlmDisclosureCard scope={{
+test("renders a two-line external LLM snackbar and permanently dismisses it", async () => {
+  const scope = {
     schema_version: 1,
     run_id: "run-1",
     scope_revision: 2,
     scope_hash: "a".repeat(64),
     source_kinds: ["gmail", "calendar"],
     data_classes: ["USER_REQUEST", "EVIDENCE_EXCERPT"],
+  } as const;
+  render(<ExternalLlmDisclosureCard scope={{
+    ...scope,
   }} />);
 
-  expect(screen.getByRole("article", { name: "외부 LLM 전송 범위" })).toHaveTextContent("외부 API LLM 전송 안내");
-  expect(screen.getByText("gmail, calendar")).toBeInTheDocument();
-  expect(screen.getByText("사용자 요청, 선택 근거 일부")).toBeInTheDocument();
+  const snackbar = screen.getByRole("status", { name: "외부 LLM 전송 안내" });
+  expect(snackbar).toHaveTextContent("외부 API LLM 전송 안내");
+  expect(snackbar).toHaveTextContent("이 Run의 추론을 위해 아래 범위가 외부 LLM Provider로 전송될 수 있습니다.");
+  expect(snackbar).not.toHaveTextContent("gmail");
+  await userEvent.click(screen.getByRole("button", { name: "다시 보지 않음" }));
+  expect(screen.queryByRole("status", { name: "외부 LLM 전송 안내" })).not.toBeInTheDocument();
+  expect(localStorage.getItem("gwa.external-llm-disclosure.dismissed")).toBe("true");
 });

--- a/frontend/tests/features/run/execution_status_card.test.tsx
+++ b/frontend/tests/features/run/execution_status_card.test.tsx
@@ -6,7 +6,9 @@ import { ExecutionStatusCard } from "../../../src/features/run/execution_status_
 test("ExecutionStatusCard keeps UNKNOWN_RESULT non-terminal", () => {
   const snapshot = { actions: [{ action_id: "a-1", tool_name: "gmail_send", status: "UNKNOWN_RESULT", delivery_certainty: "SENT_RESPONSE_LOST" }], verification_summary: { verified_count: 0, mismatch_count: 0 }, recovery_summary: { unknown_result_action_count: 1 } } as RunSnapshot;
   render(<ExecutionStatusCard snapshot={snapshot} />);
-  expect(screen.getByText("UNKNOWN_RESULT")).toBeInTheDocument();
-  expect(screen.getByText("SENT_RESPONSE_LOST")).toBeInTheDocument();
-  expect(screen.queryByText(/성공 또는 실패/)).not.toBeInTheDocument();
+  expect(screen.getByText("Gmail 실행 에이전트 · 응답을 받지 못해 실제 결과를 안전하게 확인하고 있습니다.")).toBeInTheDocument();
+  expect(screen.getByText("결과 불명 작업 1건을 확인하고 있습니다.")).toBeInTheDocument();
+  expect(document.body.textContent).not.toContain("SENT_RESPONSE_LOST");
+  expect(document.body.textContent).not.toContain("실행 및 검증 상태");
+  expect(document.body.textContent).not.toContain("성공했습니다");
 });

--- a/frontend/tests/features/run/run_progress.test.tsx
+++ b/frontend/tests/features/run/run_progress.test.tsx
@@ -14,9 +14,9 @@ test("RunProgress exposes only server-projected cancel and resume actions", asyn
 });
 
 test.each([
-  ["tool_routing", { route_revision: 1, input_route_count: 2, output_mode: "ACTION" }, "도구 경로 2개 분석 완료"],
-  ["retrieval_progress", { coverage: "PARTIAL", completed_sources: 1, total_sources: 3 }, "자료 확인 1/3"],
-  ["analysis_progress", { completed_stage: "WORK_ANALYSIS" }, "분석 완료: WORK_ANALYSIS"],
+  ["tool_routing", { route_revision: 1, input_route_count: 2, output_mode: "ACTION" }, "도구 경로 에이전트 · 사용할 경로 2개를 정했습니다."],
+  ["retrieval_progress", { coverage: "PARTIAL", completed_sources: 1, total_sources: 3 }, "자료 검색 에이전트 · 컨텍스트 1/3개를 확인하고 있습니다."],
+  ["analysis_progress", { completed_stage: "WORK_ANALYSIS" }, "업무 분석 에이전트 · 필요한 조건과 근거를 정리했습니다."],
 ] as const)("RunProgress preserves canonical %s progress", (eventType, payload, label) => {
   const snapshot = { run: { status: "ANALYZING", next_allowed_commands: [] }, execution_status: { action_count: 0, terminal_action_count: 0 }, terminal_result_kind: "NONE" } as RunSnapshot;
   const latestEvent = {
@@ -25,4 +25,14 @@ test.each([
   } as RunSseEvent;
   render(<RunProgress snapshot={snapshot} latestEvent={latestEvent} busy={null} onCancel={vi.fn()} onResume={vi.fn()} />);
   expect(screen.getByTestId("run-event-progress")).toHaveTextContent(label);
+});
+
+test("RunProgress appends a gray line when the active agent stage changes", () => {
+  const snapshot = { run: { run_id: "run-1", version: 1, status: "ANALYZING", next_allowed_commands: [] }, execution_status: { action_count: 0, terminal_action_count: 0 }, terminal_result_kind: "NONE" } as RunSnapshot;
+  const first = { schema_version: 1, event_id: "event-1", run_id: "run-1", action_id: null, occurred_at_ms: 1, event_type: "phase_changed", payload: { phase: "REQUEST_ANALYSIS" }, projection_version: 1 } as RunSseEvent;
+  const second = { ...first, event_id: "event-2", event_type: "phase_changed", payload: { phase: "TOOL_ROUTING" }, projection_version: 2 } as RunSseEvent;
+  const rendered = render(<RunProgress snapshot={snapshot} latestEvent={first} busy={null} onCancel={vi.fn()} onResume={vi.fn()} />);
+  rendered.rerender(<RunProgress snapshot={snapshot} latestEvent={second} busy={null} onCancel={vi.fn()} onResume={vi.fn()} />);
+  expect(screen.getByText("요청 이해 에이전트 · 요청의 목적을 파악하고 있습니다.")).toBeInTheDocument();
+  expect(screen.getByText("도구 경로 에이전트 · 사용할 도구를 정하고 있습니다.")).toBeInTheDocument();
 });

--- a/frontend/tests/product-e2e/core_product_journeys.spec.ts
+++ b/frontend/tests/product-e2e/core_product_journeys.spec.ts
@@ -112,7 +112,7 @@ test("E2E_005_REJECT_WRITE_ZERO_PASS", async () => {
 
   const card = await actionCard("tasks_create_task");
   expect(writeCount(waiting) - writeCount(baseline)).toBe(0);
-  await card.getByRole("button", { name: "거절", exact: true }).click();
+  await card.getByRole("button", { name: "이번에는 실행하지 않을게요", exact: true }).click();
   const completed = await waitForRunStatus(runId, "COMPLETED");
 
   await assertCompletedUi();
@@ -172,7 +172,7 @@ test("E2E_007_PARTIAL_APPROVAL_PASS", async () => {
   expect(waiting.action_dependencies).toHaveLength(0);
   const taskCard = await actionCard("tasks_create_task");
   const calendarCard = await actionCard("calendar_create_event");
-  const rejectCalendar = calendarCard.getByRole("button", { name: "거절", exact: true });
+  const rejectCalendar = calendarCard.getByRole("button", { name: "이번에는 실행하지 않을게요", exact: true });
   await approve(taskCard);
   await expect(rejectCalendar).toBeEnabled();
   await rejectCalendar.click();

--- a/frontend/tests/product-e2e/failure_restart_recovery.spec.ts
+++ b/frontend/tests/product-e2e/failure_restart_recovery.spec.ts
@@ -235,7 +235,7 @@ test("F_E2E_007_VERIFICATION_MISMATCH_PASS", async () => {
     "FAIL",
   ]);
   await expect(recoveryCard()).toContainText("VERIFICATION_MISMATCH");
-  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("메인 에이전트 · 작업을 완료했습니다.", { exact: true })).toHaveCount(0);
 
   await recoveryCard().getByRole("button", { name: "현재 결과 수용" }).click();
   const completed = await harness.waitForRunStatus(runId, "COMPLETED");
@@ -272,7 +272,7 @@ test("F_E2E_008_MCP_FAILURE_PASS", async () => {
     expect.arrayContaining(["WRITE_UNKNOWN_RESULT", "WRITE_RECOVERY_RESOLVED_FAILED"]),
   );
   await expect(page.getByText("FAILED", { exact: true })).toBeVisible();
-  await expect(page.getByText("작업을 완료했습니다.", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("메인 에이전트 · 작업을 완료했습니다.", { exact: true })).toHaveCount(0);
 });
 
 function recoveryCard() {

--- a/frontend/tests/product-e2e/support/browser_product_harness.ts
+++ b/frontend/tests/product-e2e/support/browser_product_harness.ts
@@ -237,13 +237,13 @@ export class BrowserProductHarness {
       await acknowledgements.nth(index).check();
     }
     await card.getByRole("button", {
-      name: /^(승인|확인하고 승인|충돌을 알고도 진행|그래도 새로 만들기)$/,
+      name: /^(네, 실행해 주세요|위험을 확인하고 실행해 주세요|충돌을 알고도 실행해 주세요|그래도 새로 만들어 주세요)$/,
     }).click();
   }
 
   async assertCompletedUi(answer?: string): Promise<void> {
-    await expect(this.page.getByText("작업을 완료했습니다.", { exact: true })).toBeVisible();
-    let assistantMessage = this.page.getByRole("article").filter({ hasText: "에이전트 응답" });
+    await expect(this.page.getByText("메인 에이전트 · 작업을 완료했습니다.", { exact: true })).toBeVisible();
+    let assistantMessage = this.page.getByRole("article", { name: "에이전트 응답" });
     if (answer) assistantMessage = assistantMessage.filter({ hasText: answer });
     await expect(assistantMessage).toBeVisible();
   }


### PR DESCRIPTION
## Summary
- render assistant replies as conversational bubbles with timestamps
- move external LLM disclosure to a dismissible snackbar and context details to a modal
- unify plan, execution, and verification into a conversational progress flow
- update focused component, integration, and Product E2E selectors

## Validation
- focused Vitest: 118 tests passed
- final focused Vitest: 10 tests passed
- npm run typecheck
- npm run lint
- npm run build